### PR TITLE
typos in Univalence from Scratch

### DIFF
--- a/source/UnivalenceFromScratch.lagda
+++ b/source/UnivalenceFromScratch.lagda
@@ -244,7 +244,7 @@ points x:X that are mapped to (a point identified with) y:
 
     f⁻¹(y) := Σ(x:X),Id(f(x),y).
 
-The function f is called an equivalence if its is fibers are all
+The function f is called an equivalence if its fibers are all
 singletons:
 
     isEquiv(f) := Π(y:Y), isSingleton(f⁻¹(y)).
@@ -253,7 +253,7 @@ The type of equivalences from X:U to Y:U is
 
     Eq(X,Y) := Σ(f:X→Y), isEquiv(f).
 
-Given x:X, we have the singleton type consisting of the elements y:Y
+Given x:X, we have the singleton type consisting of the elements y:X
 identified with x:
 
    singletonType(x) := Σ(y:X), Id(y,x).


### PR DESCRIPTION
Hi, I'm pretty new to Univalence, and most of my experience of MLTT consists of using Idris as a theorem prover for various toy examples. 

Possibly the variable **y** of type **X** could have a different name, eg **x'** or **x_1**, to avoid confusion with **y** of type **Y** ?