### PR TITLE
Run the Agda action without the `--safe` flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,4 @@ jobs:
       with:
         main-file: AllModulesIndex.lagda
         source-dir: source
+        unsafe: true


### PR DESCRIPTION
This should fix the failing run of the Agda action. The problem is that it defaults to running Agda with the `--safe` flag which doesn't work for `AllModulesIndex.lagda`. This PR disables the `--safe` flag.