### PR TITLE
Add combinators for Ω (addresses #43)

### DIFF
--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -21,7 +21,10 @@ module Frame
        where
 
 open import UF-Subsingletons
+open import UF-Subsingleton-Combinators
 open import UF-Subsingletons-FunExt
+
+open AllCombinators pt fe
 
 \end{code}
 
@@ -47,23 +50,6 @@ infix 2 fmap-syntax
 
 syntax fmap-syntax (λ x → e) U = ⁅ e ∣ x ε U ⁆
 
-infixr 4 _∧_
-
-_∧_ : Ω 𝓤 → Ω 𝓥 → Ω (𝓤 ⊔ 𝓥)
-P ∧ Q = (P holds × Q holds) , γ
- where
-  γ = ×-is-prop (holds-is-prop P) (holds-is-prop Q)
-
-infix 3 forall-syntax
-
-forall-syntax : (I : 𝓤 ̇) → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
-forall-syntax I P = ((i : I) → P i holds) , γ
- where
-  γ : is-prop ((i : I) → P i holds)
-  γ = Π-is-prop fe (holds-is-prop ∘ P)
-
-syntax forall-syntax I (λ i → e) = ∀[ i ∶ I ] e
-
 \end{code}
 
 We define two projections for families: (1) for the index type,
@@ -88,22 +74,11 @@ module to be imported by both this module and the `Dcpo` module.
 \begin{code}
 
 is-reflexive : {A : 𝓤 ̇} → (A → A → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
-is-reflexive {A = A} _≤_ = ((x : A) → (x ≤ x) holds) , γ
- where
-  γ : is-prop ((x : A) → (x ≤ x) holds)
-  γ = Π-is-prop fe λ x → holds-is-prop (x ≤ x)
+is-reflexive {A = A} _≤_ = ∀[ x ∶ A ] x ≤ x
 
 is-transitive : {A : 𝓤 ̇} → (A → A → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
-is-transitive {A = A} _≤_ = P , γ
- where
-  P = (x y z : A) → (x ≤ y) holds → (y ≤ z) holds → (x ≤ z) holds
-
-  γ : is-prop P
-  γ = Π-is-prop fe λ x →
-       Π-is-prop fe λ _ →
-        Π-is-prop fe λ z →
-         Π-is-prop fe λ _ →
-          Π-is-prop fe λ _ → holds-is-prop (x ≤ z)
+is-transitive {A = A} _≤_ =
+ ∀[ x ∶ A ] ∀[ y ∶ A ] ∀[ z ∶ A ] x ≤ y ⇒ y ≤ z ⇒ x ≤ z
 
 is-preorder : {A : 𝓤 ̇} → (A → A → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
 is-preorder {A = A} _≤_ = is-reflexive _≤_ ∧ is-transitive _≤_
@@ -218,10 +193,7 @@ x ≡[ iss ]≡ y = (x ≡ y) , iss
 module Meets {A : 𝓤 ̇} (_≤_ : A → A → Ω 𝓥) where
 
  is-top : A → Ω (𝓤 ⊔ 𝓥)
- is-top t = ((x : A) → (x ≤ t) holds) , γ
-   where
-   γ : is-prop ((x : A) → (x ≤ t) holds)
-   γ = Π-is-prop fe λ x → holds-is-prop (x ≤ t)
+ is-top t = ∀[ x ∶ A ] (x ≤ t)
 
  _is-a-lower-bound-of_ : A → A × A → Ω 𝓥
  l is-a-lower-bound-of (x , y) = (l ≤ x) ∧ (l ≤ y)
@@ -243,10 +215,7 @@ module Meets {A : 𝓤 ̇} (_≤_ : A → A → Ω 𝓥) where
 module Joins {A : 𝓤 ̇} (_≤_ : A → A → Ω 𝓥) where
 
  _is-an-upper-bound-of_ : A → Fam 𝓦 A → Ω (𝓥 ⊔ 𝓦)
- u is-an-upper-bound-of U = Q , γ
-  where
-   Q = (i : index U) → ((U [ i ]) ≤ u) holds
-   γ = Π-is-prop fe λ i → holds-is-prop ((U [ i ]) ≤ u)
+ u is-an-upper-bound-of U = ∀[ i ∶ index U ] (U [ i ]) ≤ u
 
  upper-bound : Fam 𝓦 A → 𝓤 ⊔ 𝓥 ⊔ 𝓦 ̇
  upper-bound U = Σ u ꞉ A , (u is-an-upper-bound-of U) holds

--- a/source/UF-Subsingleton-Combinators.lagda
+++ b/source/UF-Subsingleton-Combinators.lagda
@@ -1,0 +1,131 @@
+Ayberk Tosun, 10 March 2021.
+
+Based in part by the `Cubical.Functions.Logic` module of
+`agda/cubical`.
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+module UF-Subsingleton-Combinators where
+
+open import SpartanMLTT
+open import UF-Subsingletons
+open import UF-PropTrunc
+open import UF-FunExt
+open import UF-Subsingletons-FunExt
+
+\end{code}
+
+\section{Conjunction}
+
+\begin{code}
+
+module Conjunction where
+
+ _∧_ : Ω 𝓤 → Ω 𝓥 → Ω (𝓤 ⊔ 𝓥)
+ P ∧ Q = (P holds × Q holds) , γ
+  where
+   γ = ×-is-prop (holds-is-prop P) (holds-is-prop Q)
+ 
+ infixr 4 _∧_
+
+\end{code}
+
+\section{Universal quantification}
+
+\begin{code}
+
+module Universal (fe : Fun-Ext) where
+
+ ∀[∶]-syntax : (I : 𝓤 ̇) → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
+ ∀[∶]-syntax I P = ((i : I) → P i holds) , γ
+  where
+   γ : is-prop ((i : I) → P i holds)
+   γ = Π-is-prop fe (holds-is-prop ∘ P)
+
+
+ ∀[]-syntax : {I : 𝓤 ̇} → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
+ ∀[]-syntax {I = I} P = ∀[∶]-syntax I P
+
+ infix 3 ∀[∶]-syntax
+ infix 3 ∀[]-syntax
+ 
+ syntax ∀[∶]-syntax I (λ i → e) = ∀[ i ∶ I ] e
+ syntax ∀[]-syntax    (λ i → e) = ∀[ i ] e
+
+\end{code}
+
+\section{Implication}
+
+\begin{code}
+
+module Implication (fe : Fun-Ext) where
+
+ open Universal fe
+
+ infixr 3 _⇒_
+
+ _⇒_ : Ω 𝓤 → Ω 𝓥 → Ω (𝓤 ⊔ 𝓥)
+ P ⇒ Q = (P holds → Q holds) , γ
+  where
+   γ : is-prop (P holds → Q holds)
+   γ = Π-is-prop fe λ _ → holds-is-prop Q
+
+\end{code}
+
+\section{Disjunction}
+
+\begin{code}
+
+module Disjunction (pt : propositional-truncations-exist) where
+
+ open propositional-truncations-exist pt
+
+ _∨_ : Ω 𝓤 → Ω 𝓥 → Ω (𝓤 ⊔ 𝓥)
+ P ∨ Q = ∥ P holds + Q holds ∥ , ∥∥-is-prop
+
+ infix 3 _∨_
+
+\end{code}
+
+\section{Existential quantification}
+
+\begin{code}
+
+module Existential (pt : propositional-truncations-exist) where
+
+ open propositional-truncations-exist pt
+
+ ∃[∶]-syntax : (I : 𝓤 ̇) → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
+ ∃[∶]-syntax I P = ∥ Σ i ꞉ I , P i holds ∥ , ∥∥-is-prop
+
+ ∃[]-syntax : {I : 𝓤 ̇} → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
+ ∃[]-syntax {I = I} P = ∃[∶]-syntax I P
+
+ infix 2 ∃[∶]-syntax
+ infix 2 ∃[]-syntax
+
+ syntax ∃[∶]-syntax I (λ i → e) = ∃[ i ∶ I ] e
+ syntax ∃[]-syntax    (λ i → e) = ∃[ i ] e
+
+\end{code}
+
+\section{A module for importing all combinators}
+
+\begin{code}
+
+module AllCombinators
+        (pt : propositional-truncations-exist)
+        (fe : Fun-Ext)
+       where
+
+ open Conjunction    public
+ open Universal   fe public
+ open Implication fe public
+ open Disjunction pt public
+ open Existential pt public
+
+\end{code}
+
+\end{code}

--- a/source/UF-Subsingleton-Combinators.lagda
+++ b/source/UF-Subsingleton-Combinators.lagda
@@ -27,7 +27,7 @@ module Conjunction where
  P ∧ Q = (P holds × Q holds) , γ
   where
    γ = ×-is-prop (holds-is-prop P) (holds-is-prop Q)
- 
+
  infixr 4 _∧_
 
 \end{code}
@@ -50,7 +50,7 @@ module Universal (fe : Fun-Ext) where
 
  infix 3 ∀[∶]-syntax
  infix 3 ∀[]-syntax
- 
+
  syntax ∀[∶]-syntax I (λ i → e) = ∀[ i ∶ I ] e
  syntax ∀[]-syntax    (λ i → e) = ∀[ i ] e
 

--- a/source/UF-Subsingleton-Combinators.lagda
+++ b/source/UF-Subsingleton-Combinators.lagda
@@ -97,10 +97,10 @@ module Existential (pt : propositional-truncations-exist) where
 
  open propositional-truncations-exist pt
 
- ∃[∶]-syntax : (I : 𝓤 ̇) → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
- ∃[∶]-syntax I P = ∥ Σ i ꞉ I , P i holds ∥ , ∥∥-is-prop
+ ∃[∶]-syntax : (I : 𝓤 ̇) → (I → 𝓥 ̇) → Ω (𝓤 ⊔ 𝓥)
+ ∃[∶]-syntax I A = ∥ Σ i ꞉ I , A i ∥ , ∥∥-is-prop
 
- ∃[]-syntax : {I : 𝓤 ̇} → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
+ ∃[]-syntax : {I : 𝓤 ̇} → (I → 𝓥 ̇) → Ω (𝓤 ⊔ 𝓥)
  ∃[]-syntax {I = I} P = ∃[∶]-syntax I P
 
  infix 2 ∃[∶]-syntax

--- a/source/index.lagda
+++ b/source/index.lagda
@@ -267,6 +267,7 @@ import UF-SIP-Examples
 import UF-SIP-IntervalObject
 import UF-Subsingletons-FunExt
 import UF-Subsingletons
+import UF-Subsingleton-Combinators
 import UF-UA-FunExt
 import UF-Univalence
 import UF-UniverseEmbedding


### PR DESCRIPTION
_This PR fixes #43._

I have added subsingleton combinators as discussed in #43. Because different combinators require different assumptions, I have separated these into their own submodules. To give an example:

```agda
module Universal (fe : Fun-Ext) where

 ∀[∶]-syntax : (I : 𝓤 ̇) → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
 ∀[∶]-syntax I P = ((i : I) → P i holds) , γ
  where
   γ : is-prop ((i : I) → P i holds)
   γ = Π-is-prop fe (holds-is-prop ∘ P)


 ∀[]-syntax : {I : 𝓤 ̇} → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
 ∀[]-syntax {I = I} P = ∀[∶]-syntax I P

 infix 3 ∀[∶]-syntax
 infix 3 ∀[]-syntax
 
 syntax ∀[∶]-syntax I (λ i → e) = ∀[ i ∶ I ] e
 syntax ∀[]-syntax    (λ i → e) = ∀[ i ] e
```

It will usually be the case that _all_ of these will be imported, so I also added a submodule called `AllCombinators` (that dependends on both propositional truncation and function extensionality) and imports all of these submodules.