### PR TITLE
Some developments related to well inside and way below

### DIFF
--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -337,7 +337,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
   open Joins _≤_
 
   β : ((U ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
-  β i = ∨[ F ]-right-mono (⋁[ F ]-upper S i)
+  β i = ∨[ F ]-right-monotone (⋁[ F ]-upper S i)
 
   γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
         ((U ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
@@ -386,7 +386,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
 
    δ : (𝟏[ F ] ≤ (⋁[ F ] T)) holds
    δ = 𝟏[ F ]                           ≡⟨ c₂ ⁻¹                              ⟩ₚ
-       V ∨[ F ] W                       ≤⟨ ∨[ F ]-left-mono q                 ⟩
+       V ∨[ F ] W                       ≤⟨ ∨[ F ]-left-monotone q             ⟩
        (⋁[ F ] S) ∨[ F ] W              ≡⟨ ∨[ F ]-is-commutative (⋁[ F ] S) W ⟩ₚ
        W ∨[ F ] (⋁[ F ] S)              ≡⟨ ∨-is-scott-continuous-eq F W S d   ⟩ₚ
        ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆  ■
@@ -406,7 +406,7 @@ The family `T` we defined is also directed by the directedness of `S`.
            Ǝ k , (T [ i ] ≤ T [ k ]) holds × (T [ j ] ≤ T [ k ]) holds) holds
    up i j = ∥∥-rec ∃-is-prop r (pr₂ d i j)
     where
-     r  = λ (k , p , q) → ∣ k , ∨[ F ]-right-mono p , ∨[ F ]-right-mono q ∣
+     r  = λ (k , p , q) → ∣ k , ∨[ F ]-right-monotone p , ∨[ F ]-right-monotone q ∣
 
 \end{code}
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -133,12 +133,12 @@ well-inside-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
   _⊓_ = λ x y → x ∧[ F ] y
 
   γ : U ≡ U ∧[ F ] V
-  γ = U                       ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
-      U ⊓ 𝟏[ F ]              ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
-      U ⊓ (V ∨[ F ] W)        ≡⟨ binary-distributivity F               ⟩
-      (U ⊓ V) ∨[ F ] (U ⊓ W)  ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
-      (U ⊓ V) ∨[ F ] 𝟎[ F ]   ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
-      U ⊓ V                   ∎
+  γ = U                        ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
+      U ⊓ 𝟏[ F ]               ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
+      U ⊓ (V ∨[ F ] W)         ≡⟨ binary-distributivity F               ⟩
+      (U ⊓ V) ∨[ F ] (U ⊓ W)   ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
+      (U ⊓ V) ∨[ F ] 𝟎[ F ]    ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
+      U ⊓ V                    ∎
 
 \end{code}
 
@@ -215,50 +215,60 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
    γ = pr₁ ((∨-is-scott-continuous F U) S dir)
    δ = pr₂ ((∨-is-scott-continuous F U) S dir)
 
-
-
 ⋜-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
                               → isCompact F holds
                               → (U V : ⟨ F ⟩)
                               → U ⋜[ F ] V
                               → (U ≪[ F ] V) holds
-⋜-implies-≪-in-compact-frames F κ U V (W , c₁ , c₂) S d q =
+⋜-implies-≪-in-compact-frames {𝓦 = 𝓦} F κ U V (W , c₁ , c₂) S d q =
  ∥∥-rec ∃-is-prop θ ζ
   where
    open PosetNotation  (poset-of F)
    open PosetReasoning (poset-of F)
 
-   ε : ((W ∨[ F ] (⋁[ F ] S)) ≤ (⋁[ F ] ⁅ W ∧[ F ] Sᵢ ∣ Sᵢ ε S ⁆)) holds
-   ε = W ∨[ F ] (⋁[ F ] S) ≤⟨ {!!} ⟩ {!!} ≤⟨ {!!} ⟩ {!!} ■
+   T : Fam 𝓦 ⟨ F ⟩
+   T = ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆
 
-   δ : (𝟏[ F ] ≤ (⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆)) holds
+   δ : (𝟏[ F ] ≤ (⋁[ F ] T)) holds
    δ = 𝟏[ F ]                          ≡⟨ c₂ ⁻¹                              ⟩ₚ
        V ∨[ F ] W                      ≤⟨ ∨[ F ]-left-mono q                 ⟩
        (⋁[ F ] S) ∨[ F ] W             ≡⟨ ∨[ F ]-is-commutative (⋁[ F ] S) W ⟩ₚ
        W ∨[ F ] (⋁[ F ] S)             ≡⟨ ∨-is-scott-continuous-eq F W S d   ⟩ₚ
        ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ■
 
-   up : _
+   ε : ((W ∨[ F ] (⋁[ F ] S)) ≤ (⋁[ F ] T)) holds
+   ε = W ∨[ F ] (⋁[ F ] S)              ≤⟨ 𝟏-is-top F (W ∨[ F ] (⋁[ F ] S)) ⟩
+       𝟏[ F ]                           ≤⟨ δ                                ⟩
+       ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆  ■
+
+   -- T is closed under binary upper bounds.
+   up : (Ɐ i , Ɐ j ,
+           Ǝ k , (T [ i ] ≤ T [ k ]) holds × (T [ j ] ≤ T [ k ]) holds) holds
    up i j = ∥∥-rec ∃-is-prop r (pr₂ d i j)
     where
      r  = λ (k , p , q) → ∣ k , ∨[ F ]-right-mono p , ∨[ F ]-right-mono q ∣
 
-   d′ : (is-directed (poset-of F) ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
-   d′ = pr₁ d , up
+   T-is-directed : (is-directed (poset-of F) ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
+   T-is-directed = pr₁ d , up
 
-   ζ : ∥ Σ i ꞉ index S , (S [ i ]) ∨[ F ] W ≡ 𝟏[ F ] ∥
-   ζ = {!!}
+   ζ : ∥ Σ i ꞉ index S , (𝟏[ F ] ≤ (W ∨[ F ] (S [ i ]))) holds ∥
+   ζ = κ ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ T-is-directed δ
 
-   θ : Σ i ꞉ index S , (S [ i ]) ∨[ F ] W ≡ 𝟏[ F ]
+   θ : Σ i ꞉ index S , (𝟏[ F ] ≤ (W ∨[ F ] S [ i ])) holds
      → ∃ i ꞉ index S , (U ≤ S [ i ]) holds
-   θ (i , p) = ∣ {!!} , {!!} ∣
+   θ (i , p) = ∣ i , well-inside-implies-below F U (S [ i ]) (W , (c₁ , ι)) ∣
+    where
+     η = 𝟏[ F ]              ≤⟨ p                                 ⟩
+         W ∨[ F ] (S [ i ])  ≡⟨ ∨[ F ]-is-commutative W (S [ i ]) ⟩ₚ
+         (S [ i ]) ∨[ F ] W  ■
 
+     ι = only-𝟏-is-above-𝟏 F ((S [ i ]) ∨[ F ] W) η
 
 clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
+                                      → isCompact F holds
                                       → (x : ⟨ F ⟩)
                                       → isClopen F x
                                       → isCompactOpen F x holds
-clopens-are-compact-in-compact-frames F x x⋜x S S-dir =
-  {!!}
+clopens-are-compact-in-compact-frames F κ x = ⋜-implies-≪-in-compact-frames F κ x x
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -175,7 +175,7 @@ well-inside-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
   γ : U ≡ U ∧[ F ] V
   γ = U                        ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
       U ⊓ 𝟏[ F ]               ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
-      U ⊓ (V ∨[ F ] W)         ≡⟨ binary-distributivity F               ⟩
+      U ⊓ (V ∨[ F ] W)         ≡⟨ binary-distributivity F U V W         ⟩
       (U ⊓ V) ∨[ F ] (U ⊓ W)   ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
       (U ⊓ V) ∨[ F ] 𝟎[ F ]    ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
       U ⊓ V                    ∎

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -396,12 +396,21 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
        𝟏[ F ]                           ≤⟨ δ                                ⟩
        ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆  ■
 
-   -- T is closed under binary upper bounds.
+\end{code}
+
+The family `T` we defined is also directed by the directedness of `S`.
+
+\begin{code}
+
    up : (Ɐ i , Ɐ j ,
            Ǝ k , (T [ i ] ≤ T [ k ]) holds × (T [ j ] ≤ T [ k ]) holds) holds
    up i j = ∥∥-rec ∃-is-prop r (pr₂ d i j)
     where
      r  = λ (k , p , q) → ∣ k , ∨[ F ]-right-mono p , ∨[ F ]-right-mono q ∣
+
+\end{code}
+
+\begin{code}
 
    T-is-directed : (is-directed (poset-of F) ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
    T-is-directed = pr₁ d , up

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -1,0 +1,264 @@
+Ayberk Tosun, 9 December 2021
+
+Based on `ayberkt/formal-topology-in-UF`.
+
+\begin{code}[hide]
+open import SpartanMLTT
+open import UF-Base
+open import UF-PropTrunc
+open import UF-FunExt
+open import UF-Univalence
+open import UF-UA-FunExt
+
+module CompactRegular
+        (pt : propositional-truncations-exist)
+        (fe : Fun-Ext)
+       where
+
+open import UF-Subsingletons
+open import UF-Subsingleton-Combinators
+open import Frame pt fe hiding (is-directed)
+
+open AllCombinators pt fe
+open PropositionalTruncation pt
+\end{code}
+
+\section{The way below relation}
+
+We first define the notion of a directed family. This is actually
+defined in the `Dcpo` module but I am redefining it here to avoid
+importing the `Dcpo` module. There are also some things about that
+definition that make it a bit inconvenient to work with. It might be
+good idea to address this duplication at some point.
+
+\begin{code}
+is-directed : (P : poset 𝓤 𝓥) → (S : Fam 𝓦 ∣ P ∣ₚ) → Ω (𝓥 ⊔ 𝓦)
+is-directed P (I , s) =
+   ∥ I ∥Ω
+ ∧ (Ɐ i ∶ I , Ɐ j ∶ I , Ǝ k ∶ I , ((s i ≤ s k) ∧ (s j ≤ s k)) holds)
+  where open PosetNotation P using (_≤_)
+\end{code}
+
+\begin{code}
+way-below : (F : frame 𝓤 𝓥 𝓦) → (x y : ⟨ F ⟩) → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+way-below {𝓤 = 𝓤} {𝓦 = 𝓦} F x y =
+ Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ , is-directed (poset-of F) S ⇒
+  y ≤ (⋁[ F ] S) ⇒ (Ǝ i ∶ index S , (x ≤ S [ i ]) holds)
+   where
+    open PosetNotation (poset-of F) using (_≤_)
+
+infix 5 way-below
+
+syntax way-below F x y = x ≪[ F ] y
+\end{code}
+
+\begin{code}
+
+isCompactOpen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+isCompactOpen F x = x ≪[ F ] x
+
+\end{code}
+
+A compact frame is simply a frame whose top element is finite.
+
+\begin{code}
+
+isCompact : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+isCompact F = isCompactOpen F 𝟏[ F ]
+
+\end{code}
+
+\begin{code}
+
+compacts-are-closed-under-joins : (F : frame 𝓤 𝓥 𝓦)
+                                → (U V : ⟨ F ⟩)
+                                → isCompactOpen F U holds
+                                → isCompactOpen F V holds
+                                → isCompactOpen F (U ∨[ F ] V) holds
+compacts-are-closed-under-joins F U V κ₁ κ₂ S dir@(_ , up) p =
+ ∥∥-rec₂ ∃-is-prop γ s₁′ s₂′
+  where
+   open PosetNotation  (poset-of F) using (_≤_)
+   open PosetReasoning (poset-of F)
+
+   -- S covers U.
+   q₁ : (U ≤ (⋁[ F ] S)) holds
+   q₁ = U ≤⟨ ∨[ F ]-upper₁ U V ⟩ U ∨[ F ] V ≤⟨ p ⟩ ⋁[ F ] S ■
+
+   -- S covers V.
+   q₂ : (V ≤ (⋁[ F ] S)) holds
+   q₂ = V ≤⟨ ∨[ F ]-upper₂ U V ⟩ U ∨[ F ] V ≤⟨ p ⟩ ⋁[ F ] S ■
+
+   s₁′ : ∥ Σ i₁ ꞉ index S , (U ≤ S [ i₁ ]) holds ∥
+   s₁′ = κ₁ S dir q₁
+
+   s₂′ : ∥ Σ i₂ ꞉ index S , (V ≤ S [ i₂ ]) holds ∥
+   s₂′ = κ₂ S dir q₂
+
+   γ : (Σ i₁ ꞉ index S , (U ≤ S [ i₁ ]) holds)
+     → (Σ i₂ ꞉ index S , (V ≤ S [ i₂ ]) holds)
+     → ∃ i ꞉ index S , ((U ∨[ F ] V) ≤ S [ i ]) holds
+   γ (i₁ , s₁) (i₂ , s₂) = ∥∥-rec ∃-is-prop δ (up i₁ i₂)
+    where
+     δ : Σ i ꞉ index S , ((S [ i₁ ] ≤ S [ i ]) ∧ (S [ i₂ ] ≤ S [ i ])) holds
+       → ∃ i ꞉ index S , ((U ∨[ F ] V) ≤ S [ i ]) holds
+     δ (i , r₁ , r₂) = ∣ i , ∨[ F ]-least ε ζ ∣
+      where
+       ε : (U ≤ S [ i ]) holds
+       ε = U ≤⟨ s₁ ⟩ S [ i₁ ] ≤⟨ r₁ ⟩ S [ i ] ■
+
+       ζ : (V ≤ S [ i ]) holds
+       ζ = V ≤⟨ s₂ ⟩ S [ i₂ ] ≤⟨ r₂ ⟩ S [ i ] ■
+
+\end{code}
+
+\section{Well Inside}
+
+\begin{code}
+
+well-inside : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → 𝓤 ̇ 
+well-inside F U V =
+ Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (V ∨[ F ] W ≡ 𝟏[ F ])
+
+infix 4 well-inside
+
+syntax well-inside F U V = U ⋜[ F ] V
+
+well-inside-implies-below : (F : frame 𝓤 𝓥 𝓦)
+                          → (U V : ⟨ F ⟩)
+                          → U ⋜[ F ] V
+                          → (U ≤[ poset-of F ] V) holds
+well-inside-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
+ where
+  _⊓_ = λ x y → x ∧[ F ] y
+
+  γ : U ≡ U ∧[ F ] V
+  γ = U                       ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹ ⟩
+      U ⊓ 𝟏[ F ]              ≡⟨ ap (U ⊓_) (c₂ ⁻¹)        ⟩
+      U ⊓ (V ∨[ F ] W)        ≡⟨ {!bin-distr!} ⟩
+      (U ⊓ V) ∨[ F ] (U ⊓ W)  ≡⟨ {!!} ⟩
+      (U ⊓ V) ∨[ F ] 𝟎[ F ]   ≡⟨ {!!} ⟩
+      U ⊓ V                   ∎
+
+\end{code}
+
+An open x in a frame F is *clopen* iff it is well-inside itself.
+
+\begin{code}
+
+isClopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → 𝓤 ̇ 
+isClopen F U = U ⋜[ F ] U
+
+\end{code}
+
+\section{Definition of regularity}
+
+\begin{code}
+
+↓↓[_] : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Fam (𝓤 ⊔ 𝓥) ⟨ F ⟩
+↓↓[ F ] x = (Σ y ꞉ ⟨ F ⟩ , (y ≤[ poset-of F ] x) holds) , pr₁
+
+\end{code}
+
+\begin{code}
+
+isRegular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
+isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
+  where
+  open Joins (λ x y → x ≤[ poset-of F ] y)
+
+\end{code}
+
+\section{Some properties}
+
+\begin{code}
+∨-is-scott-continuous : (F : frame 𝓤 𝓥 𝓦)
+                      → (x : ⟨ F ⟩)
+                      → is-scott-continuous F F (λ - → x ∨[ F ] -) holds
+∨-is-scott-continuous F x S dir = β , γ
+ where
+ open PosetNotation  (poset-of F) using (_≤_)
+ open PosetReasoning (poset-of F)
+ open Joins _≤_
+
+ β : ((x ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ x ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
+ β i = ∨[ F ]-right-mono (⋁[ F ]-upper S i)
+
+ γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ x ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
+       ((x ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
+ γ (u′ , p) = ∨[ F ]-least γ₁ γ₂
+  where
+   δ₁ : index S → (x ≤ u′) holds
+   δ₁ i = x                  ≤⟨ ∨[ F ]-upper₁ x (S [ i ]) ⟩
+          x ∨[ F ] (S [ i ]) ≤⟨ p i                       ⟩
+          u′                 ■
+
+   γ₁ : (x ≤[ poset-of F ] u′) holds
+   γ₁ = ∥∥-rec (holds-is-prop (x ≤[ poset-of F ] u′)) δ₁ (pr₁ dir)
+
+   γ₂ : ((⋁[ F ] S) ≤[ poset-of F ] u′) holds
+   γ₂ = ⋁[ F ]-least S (u′ , δ₂)
+    where
+     δ₂ : (u′ is-an-upper-bound-of S) holds
+     δ₂ i = S [ i ]                         ≤⟨ ∨[ F ]-upper₂ x (S [ i ]) ⟩
+            x ∨[ F ] (S [ i ])              ≤⟨ p i                       ⟩
+            u′                              ■
+
+∨-is-scott-continuous-eq : (F : frame 𝓤 𝓥 𝓦)
+                         → (U : ⟨ F ⟩)
+                         → (S : Fam 𝓦 ⟨ F ⟩)
+                         → (is-directed (poset-of F) S) holds
+                         → U ∨[ F ] (⋁[ F ] S) ≡ ⋁[ F ] ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆
+∨-is-scott-continuous-eq F U S dir =
+ ⋁[ F ]-unique ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ (U ∨[ F ] (⋁[ F ] S)) (γ , δ)
+  where
+   γ = pr₁ ((∨-is-scott-continuous F U) S dir)
+   δ = pr₂ ((∨-is-scott-continuous F U) S dir)
+
+
+
+⋜-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
+                              → isCompact F holds
+                              → (U V : ⟨ F ⟩)
+                              → U ⋜[ F ] V
+                              → (U ≪[ F ] V) holds
+⋜-implies-≪-in-compact-frames F κ U V (W , c₁ , c₂) S d q =
+ ∥∥-rec ∃-is-prop θ ζ
+  where
+   open PosetNotation  (poset-of F)
+   open PosetReasoning (poset-of F)
+
+   ε : ((W ∨[ F ] (⋁[ F ] S)) ≤ (⋁[ F ] ⁅ W ∧[ F ] Sᵢ ∣ Sᵢ ε S ⁆)) holds
+   ε = W ∨[ F ] (⋁[ F ] S) ≤⟨ {!!} ⟩ {!!} ≤⟨ {!!} ⟩ {!!} ■
+
+   δ : (𝟏[ F ] ≤ (⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆)) holds
+   δ = 𝟏[ F ]                          ≡⟨ c₂ ⁻¹                              ⟩ₚ
+       V ∨[ F ] W                      ≤⟨ ∨[ F ]-left-mono q                 ⟩
+       (⋁[ F ] S) ∨[ F ] W             ≡⟨ ∨[ F ]-is-commutative (⋁[ F ] S) W ⟩ₚ
+       W ∨[ F ] (⋁[ F ] S)             ≡⟨ ∨-is-scott-continuous-eq F W S d   ⟩ₚ
+       ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ■
+
+   up : _
+   up i j = ∥∥-rec ∃-is-prop r (pr₂ d i j)
+    where
+     r  = λ (k , p , q) → ∣ k , ∨[ F ]-right-mono p , ∨[ F ]-right-mono q ∣
+
+   d′ : (is-directed (poset-of F) ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
+   d′ = pr₁ d , up
+
+   ζ : ∥ Σ i ꞉ index S , (S [ i ]) ∨[ F ] W ≡ 𝟏[ F ] ∥
+   ζ = {!!}
+
+   θ : Σ i ꞉ index S , (S [ i ]) ∨[ F ] W ≡ 𝟏[ F ]
+     → ∃ i ꞉ index S , (U ≤ S [ i ]) holds
+   θ (i , p) = ∣ {!!} , {!!} ∣
+
+
+clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
+                                      → (x : ⟨ F ⟩)
+                                      → isClopen F x
+                                      → isCompactOpen F x holds
+clopens-are-compact-in-compact-frames F x x⋜x S S-dir =
+  {!!}
+
+\end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -284,7 +284,7 @@ clopenness-equivalent-to-well-inside-oneself F U =
 
 isRegular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
 isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
-  where
+ where
   open Joins (λ U V → U ≤[ poset-of F ] V)
 
 \end{code}
@@ -298,32 +298,32 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
                       → is-scott-continuous F F (λ - → U ∨[ F ] -) holds
 ∨-is-scott-continuous F U S dir = β , γ
  where
- open PosetNotation  (poset-of F) using (_≤_)
- open PosetReasoning (poset-of F)
- open Joins _≤_
+  open PosetNotation  (poset-of F) using (_≤_)
+  open PosetReasoning (poset-of F)
+  open Joins _≤_
 
- β : ((U ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
- β i = ∨[ F ]-right-mono (⋁[ F ]-upper S i)
+  β : ((U ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
+  β i = ∨[ F ]-right-mono (⋁[ F ]-upper S i)
 
- γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
-       ((U ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
- γ (u′ , p) = ∨[ F ]-least γ₁ γ₂
-  where
-   δ₁ : index S → (U ≤ u′) holds
-   δ₁ i = U                  ≤⟨ ∨[ F ]-upper₁ U (S [ i ]) ⟩
-          U ∨[ F ] (S [ i ]) ≤⟨ p i                       ⟩
-          u′                 ■
+  γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
+        ((U ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
+  γ (u′ , p) = ∨[ F ]-least γ₁ γ₂
+   where
+    δ₁ : index S → (U ≤ u′) holds
+    δ₁ i = U                  ≤⟨ ∨[ F ]-upper₁ U (S [ i ]) ⟩
+           U ∨[ F ] (S [ i ]) ≤⟨ p i                       ⟩
+           u′                 ■
 
-   γ₁ : (U ≤[ poset-of F ] u′) holds
-   γ₁ = ∥∥-rec (holds-is-prop (U ≤[ poset-of F ] u′)) δ₁ (pr₁ dir)
+    γ₁ : (U ≤[ poset-of F ] u′) holds
+    γ₁ = ∥∥-rec (holds-is-prop (U ≤[ poset-of F ] u′)) δ₁ (pr₁ dir)
 
-   γ₂ : ((⋁[ F ] S) ≤[ poset-of F ] u′) holds
-   γ₂ = ⋁[ F ]-least S (u′ , δ₂)
-    where
-     δ₂ : (u′ is-an-upper-bound-of S) holds
-     δ₂ i = S [ i ]                         ≤⟨ ∨[ F ]-upper₂ U (S [ i ]) ⟩
-            U ∨[ F ] (S [ i ])              ≤⟨ p i                       ⟩
-            u′                              ■
+    γ₂ : ((⋁[ F ] S) ≤[ poset-of F ] u′) holds
+    γ₂ = ⋁[ F ]-least S (u′ , δ₂)
+     where
+      δ₂ : (u′ is-an-upper-bound-of S) holds
+      δ₂ i = S [ i ]                         ≤⟨ ∨[ F ]-upper₂ U (S [ i ]) ⟩
+             U ∨[ F ] (S [ i ])              ≤⟨ p i                       ⟩
+             u′                              ■
 
 ∨-is-scott-continuous-eq : (F : frame 𝓤 𝓥 𝓦)
                          → (U : ⟨ F ⟩)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -21,6 +21,8 @@ open import Frame pt fe hiding (is-directed)
 
 open AllCombinators pt fe
 open PropositionalTruncation pt
+
+open import InitialFrame pt fe
 \end{code}
 
 \section{The way below relation}
@@ -123,6 +125,44 @@ well-inside F U V =
 infix 4 well-inside
 
 syntax well-inside F U V = U ⋜[ F ] V
+
+-- The well inside relation is not propositional in general, even though the
+-- “has complement” (i.e. is well inside itself) is propositional.
+well-inside-is-not-prop : (ua : is-univalent 𝓤₀)
+                        → ¬ ((F : frame 𝓤₁ 𝓤₀ 𝓤₀) → (x y : ⟨ F ⟩) → is-prop (x ⋜[ F ] y))
+well-inside-is-not-prop ua ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
+ where
+  IF : frame 𝓤₁ 𝓤₀ 𝓤₀ -- “IF” standing for “initial frame”.
+  IF = 𝟎-𝔽𝕣𝕞 ua
+
+  γ₂ : 𝟎[ IF ] ⋜[ IF ] 𝟏[ IF ]
+  γ₂ = 𝟏[ IF ] , (β , γ)
+        where
+         abstract
+          β : 𝟎[ IF ] ∧[ IF ] 𝟏[ IF ] ≡ 𝟎[ IF ]
+          β = 𝟎-left-annihilator-for-∧ IF 𝟏[ IF ]
+
+          γ : 𝟏[ IF ] ∨[ IF ] 𝟏[ IF ] ≡ 𝟏[ IF ]
+          γ = 𝟏-right-annihilator-for-∨ IF 𝟏[ IF ]
+
+  γ₁ : 𝟎[ IF ] ⋜[ IF ] 𝟏[ IF ]
+  γ₁ = 𝟎[ IF ] , (β , γ)
+        where
+         abstract
+          β : 𝟎[ IF ] ∧[ IF ] 𝟎[ IF ] ≡ 𝟎[ IF ]
+          β = 𝟎-right-annihilator-for-∧ IF 𝟎[ IF ]
+
+          γ : 𝟏[ IF ] ∨[ IF ] 𝟎[ IF ] ≡ 𝟏[ IF ]
+          γ = 𝟏-left-annihilator-for-∨ IF 𝟎[ IF ]
+
+  𝟎-is-not-𝟏 : ¬ (𝟎[ IF ] ≡ 𝟏[ IF ])
+  𝟎-is-not-𝟏 p = γ
+   where
+    γ : ⊥Ω holds
+    γ = transport _holds (𝟏[ IF ] ≡⟨ p ⁻¹ ⟩ 𝟎[ IF ] ≡⟨ 𝟎-of-IF-is-⊥ ua ⟩ ⊥Ω ∎) *
+
+  δ : γ₁ ≡ γ₂
+  δ = ψ IF 𝟎[ IF ] 𝟏[ IF ] γ₁ γ₂
 
 well-inside-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U V : ⟨ F ⟩)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -133,11 +133,11 @@ well-inside-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
   _⊓_ = λ x y → x ∧[ F ] y
 
   γ : U ≡ U ∧[ F ] V
-  γ = U                       ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹ ⟩
-      U ⊓ 𝟏[ F ]              ≡⟨ ap (U ⊓_) (c₂ ⁻¹)        ⟩
-      U ⊓ (V ∨[ F ] W)        ≡⟨ {!bin-distr!} ⟩
-      (U ⊓ V) ∨[ F ] (U ⊓ W)  ≡⟨ {!!} ⟩
-      (U ⊓ V) ∨[ F ] 𝟎[ F ]   ≡⟨ {!!} ⟩
+  γ = U                       ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
+      U ⊓ 𝟏[ F ]              ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
+      U ⊓ (V ∨[ F ] W)        ≡⟨ binary-distributivity F               ⟩
+      (U ⊓ V) ∨[ F ] (U ⊓ W)  ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
+      (U ⊓ V) ∨[ F ] 𝟎[ F ]   ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
       U ⊓ V                   ∎
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -161,10 +161,10 @@ complement” predicate (i.e. is well inside itself) is propositional.
 
 \begin{code}
 
-well-inside-is-not-prop : is-univalent 𝓤₀
+well-inside₀-is-not-prop : is-univalent 𝓤₀
                         → Σ F ꞉ frame 𝓤₁ 𝓤₀ 𝓤₀ ,
                            (¬ ((U V : ⟨ F ⟩) → is-prop (U ⋜₀[ F ] V)))
-well-inside-is-not-prop ua = IF , ε
+well-inside₀-is-not-prop ua = IF , ε
  where
   IF : frame 𝓤₁ 𝓤₀ 𝓤₀ -- “IF” standing for “initial frame”.
   IF = 𝟎-𝔽𝕣𝕞 ua

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -339,8 +339,8 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
   β : ((U ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
   β i = ∨[ F ]-right-monotone (⋁[ F ]-upper S i)
 
-  γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
-        ((U ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
+  γ : (Ɐ (U′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
+        ((U ∨[ F ] (⋁[ F ] S)) ≤ U′)) holds
   γ (u′ , p) = ∨[ F ]-least γ₁ γ₂
    where
     δ₁ : index S → (U ≤ u′) holds

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -268,13 +268,13 @@ is-clopen₀-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-
       W₂ ∧[ F ] 𝟏[ F ]                    ≡⟨ viii                              ⟩
       W₂                                  ∎
        where
-        i   = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative W₁ U)
-        ii  = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) p₁
-        iii = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (p₂ ⁻¹)
-        iv  = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative U W₂)
-        v   = ap (λ - → (W₂ ∧[ F ] U) ∨[ F ] -) (∧[ F ]-is-commutative W₁ W₂)
-        vi  = binary-distributivity F W₂ U W₁ ⁻¹
-        vii = ap (λ - → W₂ ∧[ F ] -) q₁
+        i    = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative W₁ U)
+        ii   = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) p₁
+        iii  = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (p₂ ⁻¹)
+        iv   = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative U W₂)
+        v    = ap (λ - → (W₂ ∧[ F ] U) ∨[ F ] -) (∧[ F ]-is-commutative W₁ W₂)
+        vi   = binary-distributivity F W₂ U W₁ ⁻¹
+        vii  = ap (λ - → W₂ ∧[ F ] -) q₁
         viii = 𝟏-right-unit-of-∧ F W₂
 
 is-clopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω 𝓤

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -56,8 +56,8 @@ syntax way-below F x y = x ≪[ F ] y
 
 \begin{code}
 
-isCompactOpen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-isCompactOpen F x = x ≪[ F ] x
+is-compact-open : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-compact-open F x = x ≪[ F ] x
 
 \end{code}
 
@@ -66,7 +66,7 @@ A compact frame is simply a frame whose top element is finite.
 \begin{code}
 
 isCompact : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-isCompact F = isCompactOpen F 𝟏[ F ]
+isCompact F = is-compact-open F 𝟏[ F ]
 
 \end{code}
 
@@ -74,9 +74,9 @@ isCompact F = isCompactOpen F 𝟏[ F ]
 
 compacts-are-closed-under-joins : (F : frame 𝓤 𝓥 𝓦)
                                 → (U V : ⟨ F ⟩)
-                                → isCompactOpen F U holds
-                                → isCompactOpen F V holds
-                                → isCompactOpen F (U ∨[ F ] V) holds
+                                → is-compact-open F U holds
+                                → is-compact-open F V holds
+                                → is-compact-open F (U ∨[ F ] V) holds
 compacts-are-closed-under-joins F U V κ₁ κ₂ S dir@(_ , up) p =
  ∥∥-rec₂ ∃-is-prop γ s₁′ s₂′
   where
@@ -346,7 +346,7 @@ clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
                                       → isCompact F holds
                                       → (x : ⟨ F ⟩)
                                       → is-clopen F x holds
-                                      → isCompactOpen F x holds
+                                      → is-compact-open F x holds
 clopens-are-compact-in-compact-frames F κ x = ⋜-implies-≪-in-compact-frames F κ x x
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -190,8 +190,42 @@ An open x in a frame F is *clopen* iff it is well-inside itself.
 
 \begin{code}
 
-isClopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → 𝓤 ̇ 
-isClopen F U = U ⋜[ F ] U
+is-clopen′ : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → 𝓤 ̇ 
+is-clopen′ F U = Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (U ∨[ F ] W ≡ 𝟏[ F ])
+
+is-clopen′-is-prop : (F : frame 𝓤 𝓥 𝓦) → (U : ⟨ F ⟩) → is-prop (is-clopen′ F U)
+is-clopen′-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-≡ β γ
+ where
+  P = poset-of F -- we refer to the underlying poset of F as P.
+
+  β : (W : ⟨ F ⟩) → is-prop ((U ∧[ F ] W ≡ 𝟎[ F ]) × (U ∨[ F ] W ≡ 𝟏[ F ]))
+  β W = ×-is-prop carrier-of-[ P ]-is-set carrier-of-[ P ]-is-set
+
+  γ : W₁ ≡ W₂
+  γ = W₁                                  ≡⟨ (𝟏-right-unit-of-∧ F W₁) ⁻¹       ⟩
+      W₁ ∧[ F ] 𝟏[ F ]                    ≡⟨ ap (λ - → meet-of F W₁ -) (q₂ ⁻¹) ⟩
+      W₁ ∧[ F ] (U ∨[ F ] W₂)             ≡⟨ binary-distributivity F W₁ U W₂   ⟩
+      (W₁ ∧[ F ] U) ∨[ F ] (W₁ ∧[ F ] W₂) ≡⟨ i                                 ⟩
+      (U ∧[ F ] W₁) ∨[ F ] (W₁ ∧[ F ] W₂) ≡⟨ ii                                ⟩
+      𝟎[ F ] ∨[ F ] (W₁ ∧[ F ] W₂)        ≡⟨ iii                               ⟩
+      (U ∧[ F ] W₂) ∨[ F ] (W₁ ∧[ F ] W₂) ≡⟨ iv                                ⟩
+      (W₂ ∧[ F ] U) ∨[ F ] (W₁ ∧[ F ] W₂) ≡⟨ v                                 ⟩
+      (W₂ ∧[ F ] U) ∨[ F ] (W₂ ∧[ F ] W₁) ≡⟨ vi                                ⟩
+      W₂ ∧[ F ] (U ∨[ F ] W₁)             ≡⟨ vii                               ⟩
+      W₂ ∧[ F ] 𝟏[ F ]                    ≡⟨ viii                              ⟩
+      W₂                                  ∎
+       where
+        i   = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative W₁ U)
+        ii  = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) p₁
+        iii = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (p₂ ⁻¹)
+        iv  = ap (λ - → - ∨[ F ] (W₁ ∧[ F ] W₂)) (∧[ F ]-is-commutative U W₂)
+        v   = ap (λ - → (W₂ ∧[ F ] U) ∨[ F ] -) (∧[ F ]-is-commutative W₁ W₂)
+        vi  = binary-distributivity F W₂ U W₁ ⁻¹
+        vii = ap (λ - → W₂ ∧[ F ] -) q₁
+        viii = 𝟏-right-unit-of-∧ F W₂
+
+is-clopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω 𝓤
+is-clopen F U = is-clopen′ F U , is-clopen′-is-prop F U
 
 \end{code}
 
@@ -311,7 +345,7 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
 clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
                                       → isCompact F holds
                                       → (x : ⟨ F ⟩)
-                                      → isClopen F x
+                                      → is-clopen F x holds
                                       → isCompactOpen F x holds
 clopens-are-compact-in-compact-frames F κ x = ⋜-implies-≪-in-compact-frames F κ x x
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -96,13 +96,25 @@ compacts-are-closed-under-joins F U V κ₁ κ₂ S dir@(_ , up) p =
    open PosetNotation  (poset-of F) using (_≤_)
    open PosetReasoning (poset-of F)
 
-   -- S covers U.
+\end{code}
+
+We know that both `U` and `V` are covered by `S` by the assumption that `U ∨ V`
+is covered by `S`
+
+\begin{code}
+
    q₁ : (U ≤ (⋁[ F ] S)) holds
    q₁ = U ≤⟨ ∨[ F ]-upper₁ U V ⟩ U ∨[ F ] V ≤⟨ p ⟩ ⋁[ F ] S ■
 
-   -- S covers V.
    q₂ : (V ≤ (⋁[ F ] S)) holds
    q₂ = V ≤⟨ ∨[ F ]-upper₂ U V ⟩ U ∨[ F ] V ≤⟨ p ⟩ ⋁[ F ] S ■
+
+\end{code}
+
+Therefore there must exist indices `i₁` and `i₂` such that `U ≤ Sᵢ₁` and `V ≤
+Sᵢ₂`.
+
+\begin{code}
 
    s₁′ : ∥ Σ i₁ ꞉ index S , (U ≤ S [ i₁ ]) holds ∥
    s₁′ = κ₁ S dir q₁
@@ -129,9 +141,11 @@ compacts-are-closed-under-joins F U V κ₁ κ₂ S dir@(_ , up) p =
 
 \section{Well Inside}
 
+`well-inside₀` is the type family expressing that a given open of a frame is
+clopen.
+
 \begin{code}
 
--- The type family expressing that a given open of a frame is clopen.
 well-inside₀ : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → 𝓤 ̇ 
 well-inside₀ F U V =
  Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (V ∨[ F ] W ≡ 𝟏[ F ])
@@ -140,8 +154,13 @@ infix 4 well-inside₀
 
 syntax well-inside₀ F U V = U ⋜₀[ F ] V
 
--- The well inside relation is not propositional in general, even though the
--- “has complement” (i.e. is well inside itself) is propositional.
+\end{code}
+
+The well inside relation is not propositional in general, even though the “has
+complement” predicate (i.e. is well inside itself) is propositional.
+
+\begin{code}
+
 well-inside-is-not-prop : is-univalent 𝓤₀
                         → Σ F ꞉ frame 𝓤₁ 𝓤₀ 𝓤₀ ,
                            (¬ ((U V : ⟨ F ⟩) → is-prop (U ⋜₀[ F ] V)))
@@ -182,8 +201,13 @@ well-inside-is-not-prop ua = IF , ε
     δ : γ₁ ≡ γ₂
     δ = ψ 𝟎[ IF ] 𝟏[ IF ] γ₁ γ₂
 
--- Because well inside is not propositional, we have to truncate it to get a
--- relation.
+\end{code}
+
+Because well inside is not propositional, we have to truncate it to get a
+relation.
+
+\begin{code}
+
 well-inside : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → Ω 𝓤
 well-inside F U V = ∥ U ⋜₀[ F ] V ∥Ω
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -280,28 +280,28 @@ is-clopen₀-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-
 is-clopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω 𝓤
 is-clopen F U = is-clopen₀ F U , is-clopen₀-is-prop F U
 
-clopen-implies-well-inside-oneself : (F : frame 𝓤 𝓥 𝓦)
+clopen-implies-well-inside-itself : (F : frame 𝓤 𝓥 𝓦)
                                    → (U : ⟨ F ⟩)
                                    → (is-clopen F U ⇒ U ⋜[ F ] U) holds
-clopen-implies-well-inside-oneself F U = ∣_∣
+clopen-implies-well-inside-itself F U = ∣_∣
 
-well-inside-oneself-implies-clopen : (F : frame 𝓤 𝓥 𝓦)
+well-inside-itself-implies-clopen : (F : frame 𝓤 𝓥 𝓦)
                                           → (U : ⟨ F ⟩)
                                           → (U ⋜[ F ] U ⇒ is-clopen F U) holds
-well-inside-oneself-implies-clopen F U =
+well-inside-itself-implies-clopen F U =
  ∥∥-rec (holds-is-prop (is-clopen F U)) id
 
-clopenness-equivalent-to-well-inside-oneself : (F : frame 𝓤 𝓥 𝓦)
+clopenness-equivalent-to-well-inside-itself : (F : frame 𝓤 𝓥 𝓦)
                                              → (U : ⟨ F ⟩)
                                              → (U ⋜[ F ] U) holds
                                              ≃ is-clopen F U holds
-clopenness-equivalent-to-well-inside-oneself F U =
-   well-inside-oneself-implies-clopen F U
+clopenness-equivalent-to-well-inside-itself F U =
+   well-inside-itself-implies-clopen F U
  , logically-equivalent-props-give-is-equiv
     (holds-is-prop (U ⋜[ F ] U))
     (holds-is-prop (is-clopen F U))
-    (well-inside-oneself-implies-clopen F U)
-    (clopen-implies-well-inside-oneself F U)
+    (well-inside-itself-implies-clopen F U)
+    (clopen-implies-well-inside-itself F U)
 
 \end{code}
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -3,6 +3,9 @@ Ayberk Tosun, 9 December 2021
 Based on `ayberkt/formal-topology-in-UF`.
 
 \begin{code}[hide]
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
 open import SpartanMLTT
 open import UF-Base
 open import UF-PropTrunc

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -219,25 +219,27 @@ syntax well-inside F U V = U ⋜[ F ] V
 
 \begin{code}
 
-well-inside₀-implies-below : (F : frame 𝓤 𝓥 𝓦)
+well-inside-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U V : ⟨ F ⟩)
-                          → U ⋜₀[ F ] V
-                          → (U ≤[ poset-of F ] V) holds
-well-inside₀-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
+                          → (U ⋜[ F ] V ⇒ (U ≤[ poset-of F ] V)) holds
+well-inside-implies-below F U V = ∥∥-rec (holds-is-prop (U ≤[ poset-of F ] V)) γ
  where
   _⊓_ = λ U V → U ∧[ F ] V
 
-  γ : U ≡ U ∧[ F ] V
-  γ = U                        ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
-      U ⊓ 𝟏[ F ]               ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
-      U ⊓ (V ∨[ F ] W)         ≡⟨ binary-distributivity F U V W         ⟩
-      (U ⊓ V) ∨[ F ] (U ⊓ W)   ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
-      (U ⊓ V) ∨[ F ] 𝟎[ F ]    ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
-      U ⊓ V                    ∎
+  γ : U ⋜₀[ F ] V → (U ≤[ poset-of F ] V) holds
+  γ (W , c₁ , c₂) = connecting-lemma₂ F δ
+   where
+    δ : U ≡ U ∧[ F ] V
+    δ = U                        ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
+        U ⊓ 𝟏[ F ]               ≡⟨ ap (U ⊓_) (c₂ ⁻¹)                     ⟩
+        U ⊓ (V ∨[ F ] W)         ≡⟨ binary-distributivity F U V W         ⟩
+        (U ⊓ V) ∨[ F ] (U ⊓ W)   ≡⟨ ap (λ - → binary-join F (U ⊓ V) -) c₁ ⟩
+        (U ⊓ V) ∨[ F ] 𝟎[ F ]    ≡⟨ 𝟎-left-unit-of-∨ F (U ⊓ V)            ⟩
+        U ⊓ V                    ∎
 
 \end{code}
 
-An open U in a frame F is *clopen* iff it is well-inside itself.
+An open _U_ in a frame _A_ is *clopen* iff it is well-inside itself.
 
 \begin{code}
 
@@ -383,11 +385,11 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
    T = ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆
 
    δ : (𝟏[ F ] ≤ (⋁[ F ] T)) holds
-   δ = 𝟏[ F ]                          ≡⟨ c₂ ⁻¹                              ⟩ₚ
-       V ∨[ F ] W                      ≤⟨ ∨[ F ]-left-mono q                 ⟩
-       (⋁[ F ] S) ∨[ F ] W             ≡⟨ ∨[ F ]-is-commutative (⋁[ F ] S) W ⟩ₚ
-       W ∨[ F ] (⋁[ F ] S)             ≡⟨ ∨-is-scott-continuous-eq F W S d   ⟩ₚ
-       ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ■
+   δ = 𝟏[ F ]                           ≡⟨ c₂ ⁻¹                              ⟩ₚ
+       V ∨[ F ] W                       ≤⟨ ∨[ F ]-left-mono q                 ⟩
+       (⋁[ F ] S) ∨[ F ] W              ≡⟨ ∨[ F ]-is-commutative (⋁[ F ] S) W ⟩ₚ
+       W ∨[ F ] (⋁[ F ] S)              ≡⟨ ∨-is-scott-continuous-eq F W S d   ⟩ₚ
+       ⋁[ F ] ⁅ W ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆  ■
 
    ε : ((W ∨[ F ] (⋁[ F ] S)) ≤ (⋁[ F ] T)) holds
    ε = W ∨[ F ] (⋁[ F ] S)              ≤⟨ 𝟏-is-top F (W ∨[ F ] (⋁[ F ] S)) ⟩
@@ -409,7 +411,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
 
    θ : Σ i ꞉ index S , (𝟏[ F ] ≤ (W ∨[ F ] S [ i ])) holds
      → ∃ i ꞉ index S , (U ≤ S [ i ]) holds
-   θ (i , p) = ∣ i , well-inside₀-implies-below F U (S [ i ]) (W , c₁ , ι) ∣
+   θ (i , p) = ∣ i , well-inside-implies-below F U (S [ i ]) ∣ W , c₁ , ι ∣ ∣
     where
      η = 𝟏[ F ]              ≤⟨ p                                 ⟩
          W ∨[ F ] (S [ i ])  ≡⟨ ∨[ F ]-is-commutative W (S [ i ]) ⟩ₚ

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -368,7 +368,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
 
    θ : Σ i ꞉ index S , (𝟏[ F ] ≤ (W ∨[ F ] S [ i ])) holds
      → ∃ i ꞉ index S , (U ≤ S [ i ]) holds
-   θ (i , p) = ∣ i , well-inside₀-implies-below F U (S [ i ]) (W , (c₁ , ι)) ∣
+   θ (i , p) = ∣ i , well-inside₀-implies-below F U (S [ i ]) (W , c₁ , ι) ∣
     where
      η = 𝟏[ F ]              ≤⟨ p                                 ⟩
          W ∨[ F ] (S [ i ])  ≡⟨ ∨[ F ]-is-commutative W (S [ i ]) ⟩ₚ

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -215,6 +215,10 @@ infix 4 well-inside
 
 syntax well-inside F U V = U ⋜[ F ] V
 
+\end{code}
+
+\begin{code}
+
 well-inside₀-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U V : ⟨ F ⟩)
                           → U ⋜₀[ F ] V

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -66,8 +66,8 @@ A compact frame is simply a frame whose top element is finite.
 
 \begin{code}
 
-isCompact : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-isCompact F = is-compact-open F 𝟏[ F ]
+is-compact : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-compact F = is-compact-open F 𝟏[ F ]
 
 \end{code}
 
@@ -328,7 +328,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
    δ = pr₂ ((∨-is-scott-continuous F U) S dir)
 
 ⋜₀-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
-                               → isCompact F holds
+                               → is-compact F holds
                                → (U V : ⟨ F ⟩)
                                → U ⋜₀[ F ] V
                                → (U ≪[ F ] V) holds
@@ -377,13 +377,13 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
      ι = only-𝟏-is-above-𝟏 F ((S [ i ]) ∨[ F ] W) η
 
 ⋜-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
-                              → isCompact F holds
+                              → is-compact F holds
                               → (U V : ⟨ F ⟩) → (U ⋜[ F ] V ⇒ U ≪[ F ] V) holds
 ⋜-implies-≪-in-compact-frames F κ U V =
  ∥∥-rec (holds-is-prop (U ≪[ F ] V)) (⋜₀-implies-≪-in-compact-frames F κ U V)
 
 clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
-                                      → isCompact F holds
+                                      → is-compact F holds
                                       → (U : ⟨ F ⟩)
                                       → is-clopen F U holds
                                       → is-compact-open F U holds

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -128,9 +128,10 @@ syntax well-inside F U V = U ⋜[ F ] V
 
 -- The well inside relation is not propositional in general, even though the
 -- “has complement” (i.e. is well inside itself) is propositional.
-well-inside-is-not-prop : (ua : is-univalent 𝓤₀)
-                        → ¬ ((F : frame 𝓤₁ 𝓤₀ 𝓤₀) → (x y : ⟨ F ⟩) → is-prop (x ⋜[ F ] y))
-well-inside-is-not-prop ua ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
+well-inside-is-not-prop : is-univalent 𝓤₀
+                        → Σ F ꞉ frame 𝓤₁ 𝓤₀ 𝓤₀ ,
+                           (¬ ((x y : ⟨ F ⟩) → is-prop (x ⋜[ F ] y)))
+well-inside-is-not-prop ua = IF , ε
  where
   IF : frame 𝓤₁ 𝓤₀ 𝓤₀ -- “IF” standing for “initial frame”.
   IF = 𝟎-𝔽𝕣𝕞 ua
@@ -161,8 +162,11 @@ well-inside-is-not-prop ua ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
     γ : ⊥Ω holds
     γ = transport _holds (𝟏[ IF ] ≡⟨ p ⁻¹ ⟩ 𝟎[ IF ] ≡⟨ 𝟎-of-IF-is-⊥ ua ⟩ ⊥Ω ∎) *
 
-  δ : γ₁ ≡ γ₂
-  δ = ψ IF 𝟎[ IF ] 𝟏[ IF ] γ₁ γ₂
+  ε : ¬ ((x y : ⟨ IF ⟩) → is-prop (well-inside IF x y))
+  ε ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
+   where
+    δ : γ₁ ≡ γ₂
+    δ = ψ 𝟎[ IF ] 𝟏[ IF ] γ₁ γ₂
 
 well-inside-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U V : ⟨ F ⟩)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -17,6 +17,7 @@ module CompactRegular
 
 open import UF-Subsingletons
 open import UF-Subsingleton-Combinators
+open import UF-Equiv using (_≃_; logically-equivalent-props-give-is-equiv)
 open import Frame pt fe hiding (is-directed)
 
 open AllCombinators pt fe
@@ -118,25 +119,26 @@ compacts-are-closed-under-joins F U V κ₁ κ₂ S dir@(_ , up) p =
 
 \begin{code}
 
-well-inside : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → 𝓤 ̇ 
-well-inside F U V =
+-- The type family expressing that a given open of a frame is clopen.
+well-inside₀ : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → 𝓤 ̇ 
+well-inside₀ F U V =
  Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (V ∨[ F ] W ≡ 𝟏[ F ])
 
-infix 4 well-inside
+infix 4 well-inside₀
 
-syntax well-inside F U V = U ⋜[ F ] V
+syntax well-inside₀ F U V = U ⋜₀[ F ] V
 
 -- The well inside relation is not propositional in general, even though the
 -- “has complement” (i.e. is well inside itself) is propositional.
 well-inside-is-not-prop : is-univalent 𝓤₀
                         → Σ F ꞉ frame 𝓤₁ 𝓤₀ 𝓤₀ ,
-                           (¬ ((x y : ⟨ F ⟩) → is-prop (x ⋜[ F ] y)))
+                           (¬ ((x y : ⟨ F ⟩) → is-prop (x ⋜₀[ F ] y)))
 well-inside-is-not-prop ua = IF , ε
  where
   IF : frame 𝓤₁ 𝓤₀ 𝓤₀ -- “IF” standing for “initial frame”.
   IF = 𝟎-𝔽𝕣𝕞 ua
 
-  γ₂ : 𝟎[ IF ] ⋜[ IF ] 𝟏[ IF ]
+  γ₂ : 𝟎[ IF ] ⋜₀[ IF ] 𝟏[ IF ]
   γ₂ = 𝟏[ IF ] , (β , γ)
         where
          abstract
@@ -146,7 +148,7 @@ well-inside-is-not-prop ua = IF , ε
           γ : 𝟏[ IF ] ∨[ IF ] 𝟏[ IF ] ≡ 𝟏[ IF ]
           γ = 𝟏-right-annihilator-for-∨ IF 𝟏[ IF ]
 
-  γ₁ : 𝟎[ IF ] ⋜[ IF ] 𝟏[ IF ]
+  γ₁ : 𝟎[ IF ] ⋜₀[ IF ] 𝟏[ IF ]
   γ₁ = 𝟎[ IF ] , (β , γ)
         where
          abstract
@@ -162,17 +164,26 @@ well-inside-is-not-prop ua = IF , ε
     γ : ⊥Ω holds
     γ = transport _holds (𝟏[ IF ] ≡⟨ p ⁻¹ ⟩ 𝟎[ IF ] ≡⟨ 𝟎-of-IF-is-⊥ ua ⟩ ⊥Ω ∎) *
 
-  ε : ¬ ((x y : ⟨ IF ⟩) → is-prop (well-inside IF x y))
+  ε : ¬ ((x y : ⟨ IF ⟩) → is-prop (well-inside₀ IF x y))
   ε ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
    where
     δ : γ₁ ≡ γ₂
     δ = ψ 𝟎[ IF ] 𝟏[ IF ] γ₁ γ₂
 
-well-inside-implies-below : (F : frame 𝓤 𝓥 𝓦)
+-- Because well inside is not propositional, we have to truncate it to get a
+-- relation.
+well-inside : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → Ω 𝓤
+well-inside F U V = ∥ U ⋜₀[ F ] V ∥Ω
+
+infix 4 well-inside
+
+syntax well-inside F U V = U ⋜[ F ] V
+
+well-inside₀-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U V : ⟨ F ⟩)
-                          → U ⋜[ F ] V
+                          → U ⋜₀[ F ] V
                           → (U ≤[ poset-of F ] V) holds
-well-inside-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
+well-inside₀-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
  where
   _⊓_ = λ x y → x ∧[ F ] y
 
@@ -190,11 +201,11 @@ An open x in a frame F is *clopen* iff it is well-inside itself.
 
 \begin{code}
 
-is-clopen′ : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → 𝓤 ̇ 
-is-clopen′ F U = Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (U ∨[ F ] W ≡ 𝟏[ F ])
+is-clopen₀ : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → 𝓤 ̇ 
+is-clopen₀ F U = Σ W ꞉ ⟨ F ⟩ , (U ∧[ F ] W ≡ 𝟎[ F ]) × (U ∨[ F ] W ≡ 𝟏[ F ])
 
-is-clopen′-is-prop : (F : frame 𝓤 𝓥 𝓦) → (U : ⟨ F ⟩) → is-prop (is-clopen′ F U)
-is-clopen′-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-≡ β γ
+is-clopen₀-is-prop : (F : frame 𝓤 𝓥 𝓦) → (U : ⟨ F ⟩) → is-prop (is-clopen₀ F U)
+is-clopen₀-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-≡ β γ
  where
   P = poset-of F -- we refer to the underlying poset of F as P.
 
@@ -225,7 +236,30 @@ is-clopen′-is-prop F U (W₁ , p₁ , q₁) (W₂ , p₂ , q₂) = to-subtype-
         viii = 𝟏-right-unit-of-∧ F W₂
 
 is-clopen : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω 𝓤
-is-clopen F U = is-clopen′ F U , is-clopen′-is-prop F U
+is-clopen F U = is-clopen₀ F U , is-clopen₀-is-prop F U
+
+clopen-implies-well-inside-oneself : (F : frame 𝓤 𝓥 𝓦)
+                                   → (U : ⟨ F ⟩)
+                                   → (is-clopen F U ⇒ U ⋜[ F ] U) holds
+clopen-implies-well-inside-oneself F U = ∣_∣
+
+well-inside-oneself-implies-clopen : (F : frame 𝓤 𝓥 𝓦)
+                                          → (U : ⟨ F ⟩)
+                                          → (U ⋜[ F ] U ⇒ is-clopen F U) holds
+well-inside-oneself-implies-clopen F U =
+ ∥∥-rec (holds-is-prop (is-clopen F U)) id
+
+clopenness-equivalent-to-well-inside-oneself : (F : frame 𝓤 𝓥 𝓦)
+                                             → (U : ⟨ F ⟩)
+                                             → (U ⋜[ F ] U) holds
+                                             ≃ is-clopen F U holds
+clopenness-equivalent-to-well-inside-oneself F U =
+   well-inside-oneself-implies-clopen F U
+ , logically-equivalent-props-give-is-equiv
+    (holds-is-prop (U ⋜[ F ] U))
+    (holds-is-prop (is-clopen F U))
+    (well-inside-oneself-implies-clopen F U)
+    (clopen-implies-well-inside-oneself F U)
 
 \end{code}
 
@@ -293,12 +327,12 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
    γ = pr₁ ((∨-is-scott-continuous F U) S dir)
    δ = pr₂ ((∨-is-scott-continuous F U) S dir)
 
-⋜-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
-                              → isCompact F holds
-                              → (U V : ⟨ F ⟩)
-                              → U ⋜[ F ] V
-                              → (U ≪[ F ] V) holds
-⋜-implies-≪-in-compact-frames {𝓦 = 𝓦} F κ U V (W , c₁ , c₂) S d q =
+⋜₀-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
+                               → isCompact F holds
+                               → (U V : ⟨ F ⟩)
+                               → U ⋜₀[ F ] V
+                               → (U ≪[ F ] V) holds
+⋜₀-implies-≪-in-compact-frames {𝓦 = 𝓦} F κ U V (W , c₁ , c₂) S d q =
  ∥∥-rec ∃-is-prop θ ζ
   where
    open PosetNotation  (poset-of F)
@@ -334,7 +368,7 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
 
    θ : Σ i ꞉ index S , (𝟏[ F ] ≤ (W ∨[ F ] S [ i ])) holds
      → ∃ i ꞉ index S , (U ≤ S [ i ]) holds
-   θ (i , p) = ∣ i , well-inside-implies-below F U (S [ i ]) (W , (c₁ , ι)) ∣
+   θ (i , p) = ∣ i , well-inside₀-implies-below F U (S [ i ]) (W , (c₁ , ι)) ∣
     where
      η = 𝟏[ F ]              ≤⟨ p                                 ⟩
          W ∨[ F ] (S [ i ])  ≡⟨ ∨[ F ]-is-commutative W (S [ i ]) ⟩ₚ
@@ -342,11 +376,17 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
 
      ι = only-𝟏-is-above-𝟏 F ((S [ i ]) ∨[ F ] W) η
 
+⋜-implies-≪-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
+                              → isCompact F holds
+                              → (U V : ⟨ F ⟩) → (U ⋜[ F ] V ⇒ U ≪[ F ] V) holds
+⋜-implies-≪-in-compact-frames F κ U V =
+ ∥∥-rec (holds-is-prop (U ≪[ F ] V)) (⋜₀-implies-≪-in-compact-frames F κ U V)
+
 clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
                                       → isCompact F holds
                                       → (x : ⟨ F ⟩)
                                       → is-clopen F x holds
                                       → is-compact-open F x holds
-clopens-are-compact-in-compact-frames F κ x = ⋜-implies-≪-in-compact-frames F κ x x
+clopens-are-compact-in-compact-frames F κ x = ⋜₀-implies-≪-in-compact-frames F κ x x
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -43,22 +43,22 @@ is-directed P (I , s) =
 \end{code}
 
 \begin{code}
-way-below : (F : frame 𝓤 𝓥 𝓦) → (x y : ⟨ F ⟩) → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-way-below {𝓤 = 𝓤} {𝓦 = 𝓦} F x y =
+way-below : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+way-below {𝓤 = 𝓤} {𝓦 = 𝓦} F U V =
  Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ , is-directed (poset-of F) S ⇒
-  y ≤ (⋁[ F ] S) ⇒ (Ǝ i ∶ index S , (x ≤ S [ i ]) holds)
+  V ≤ (⋁[ F ] S) ⇒ (Ǝ i ∶ index S , (U ≤ S [ i ]) holds)
    where
     open PosetNotation (poset-of F) using (_≤_)
 
 infix 5 way-below
 
-syntax way-below F x y = x ≪[ F ] y
+syntax way-below F U V = U ≪[ F ] V
 \end{code}
 
 \begin{code}
 
 is-compact-open : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-is-compact-open F x = x ≪[ F ] x
+is-compact-open F U = U ≪[ F ] U
 
 \end{code}
 
@@ -132,7 +132,7 @@ syntax well-inside₀ F U V = U ⋜₀[ F ] V
 -- “has complement” (i.e. is well inside itself) is propositional.
 well-inside-is-not-prop : is-univalent 𝓤₀
                         → Σ F ꞉ frame 𝓤₁ 𝓤₀ 𝓤₀ ,
-                           (¬ ((x y : ⟨ F ⟩) → is-prop (x ⋜₀[ F ] y)))
+                           (¬ ((U V : ⟨ F ⟩) → is-prop (U ⋜₀[ F ] V)))
 well-inside-is-not-prop ua = IF , ε
  where
   IF : frame 𝓤₁ 𝓤₀ 𝓤₀ -- “IF” standing for “initial frame”.
@@ -164,7 +164,7 @@ well-inside-is-not-prop ua = IF , ε
     γ : ⊥Ω holds
     γ = transport _holds (𝟏[ IF ] ≡⟨ p ⁻¹ ⟩ 𝟎[ IF ] ≡⟨ 𝟎-of-IF-is-⊥ ua ⟩ ⊥Ω ∎) *
 
-  ε : ¬ ((x y : ⟨ IF ⟩) → is-prop (well-inside₀ IF x y))
+  ε : ¬ ((U V : ⟨ IF ⟩) → is-prop (well-inside₀ IF U V))
   ε ψ = 𝟎-is-not-𝟏 (pr₁ (from-Σ-≡ δ))
    where
     δ : γ₁ ≡ γ₂
@@ -185,7 +185,7 @@ well-inside₀-implies-below : (F : frame 𝓤 𝓥 𝓦)
                           → (U ≤[ poset-of F ] V) holds
 well-inside₀-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
  where
-  _⊓_ = λ x y → x ∧[ F ] y
+  _⊓_ = λ U V → U ∧[ F ] V
 
   γ : U ≡ U ∧[ F ] V
   γ = U                        ≡⟨ 𝟏-right-unit-of-∧ F U ⁻¹              ⟩
@@ -197,7 +197,7 @@ well-inside₀-implies-below F U V (W , c₁ , c₂) = connecting-lemma₂ F γ
 
 \end{code}
 
-An open x in a frame F is *clopen* iff it is well-inside itself.
+An open U in a frame F is *clopen* iff it is well-inside itself.
 
 \begin{code}
 
@@ -268,16 +268,16 @@ clopenness-equivalent-to-well-inside-oneself F U =
 \begin{code}
 
 ↓↓[_] : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Fam (𝓤 ⊔ 𝓥) ⟨ F ⟩
-↓↓[ F ] x = (Σ y ꞉ ⟨ F ⟩ , (y ≤[ poset-of F ] x) holds) , pr₁
+↓↓[ F ] U = (Σ V ꞉ ⟨ F ⟩ , (V ≤[ poset-of F ] U) holds) , pr₁
 
 \end{code}
 
 \begin{code}
 
 isRegular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
-isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
+isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
   where
-  open Joins (λ x y → x ≤[ poset-of F ] y)
+  open Joins (λ U V → U ≤[ poset-of F ] V)
 
 \end{code}
 
@@ -285,35 +285,35 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
 
 \begin{code}
 ∨-is-scott-continuous : (F : frame 𝓤 𝓥 𝓦)
-                      → (x : ⟨ F ⟩)
-                      → is-scott-continuous F F (λ - → x ∨[ F ] -) holds
-∨-is-scott-continuous F x S dir = β , γ
+                      → (U : ⟨ F ⟩)
+                      → is-scott-continuous F F (λ - → U ∨[ F ] -) holds
+∨-is-scott-continuous F U S dir = β , γ
  where
  open PosetNotation  (poset-of F) using (_≤_)
  open PosetReasoning (poset-of F)
  open Joins _≤_
 
- β : ((x ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ x ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
+ β : ((U ∨[ F ] (⋁[ F ] S)) is-an-upper-bound-of ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆) holds
  β i = ∨[ F ]-right-mono (⋁[ F ]-upper S i)
 
- γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ x ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
-       ((x ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
+ γ : (Ɐ (u′ , _) ∶ upper-bound ⁅ U ∨[ F ] Sᵢ ∣ Sᵢ ε S ⁆ ,
+       ((U ∨[ F ] (⋁[ F ] S)) ≤ u′)) holds
  γ (u′ , p) = ∨[ F ]-least γ₁ γ₂
   where
-   δ₁ : index S → (x ≤ u′) holds
-   δ₁ i = x                  ≤⟨ ∨[ F ]-upper₁ x (S [ i ]) ⟩
-          x ∨[ F ] (S [ i ]) ≤⟨ p i                       ⟩
+   δ₁ : index S → (U ≤ u′) holds
+   δ₁ i = U                  ≤⟨ ∨[ F ]-upper₁ U (S [ i ]) ⟩
+          U ∨[ F ] (S [ i ]) ≤⟨ p i                       ⟩
           u′                 ■
 
-   γ₁ : (x ≤[ poset-of F ] u′) holds
-   γ₁ = ∥∥-rec (holds-is-prop (x ≤[ poset-of F ] u′)) δ₁ (pr₁ dir)
+   γ₁ : (U ≤[ poset-of F ] u′) holds
+   γ₁ = ∥∥-rec (holds-is-prop (U ≤[ poset-of F ] u′)) δ₁ (pr₁ dir)
 
    γ₂ : ((⋁[ F ] S) ≤[ poset-of F ] u′) holds
    γ₂ = ⋁[ F ]-least S (u′ , δ₂)
     where
      δ₂ : (u′ is-an-upper-bound-of S) holds
-     δ₂ i = S [ i ]                         ≤⟨ ∨[ F ]-upper₂ x (S [ i ]) ⟩
-            x ∨[ F ] (S [ i ])              ≤⟨ p i                       ⟩
+     δ₂ i = S [ i ]                         ≤⟨ ∨[ F ]-upper₂ U (S [ i ]) ⟩
+            U ∨[ F ] (S [ i ])              ≤⟨ p i                       ⟩
             u′                              ■
 
 ∨-is-scott-continuous-eq : (F : frame 𝓤 𝓥 𝓦)
@@ -384,9 +384,10 @@ isRegular F = Ɐ x ∶ ⟨ F ⟩ , x is-lub-of (↓↓[ F ] x)
 
 clopens-are-compact-in-compact-frames : (F : frame 𝓤 𝓥 𝓦)
                                       → isCompact F holds
-                                      → (x : ⟨ F ⟩)
-                                      → is-clopen F x holds
-                                      → is-compact-open F x holds
-clopens-are-compact-in-compact-frames F κ x = ⋜₀-implies-≪-in-compact-frames F κ x x
+                                      → (U : ⟨ F ⟩)
+                                      → is-clopen F U holds
+                                      → is-compact-open F U holds
+clopens-are-compact-in-compact-frames F κ U =
+ ⋜₀-implies-≪-in-compact-frames F κ  U U
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -27,6 +27,7 @@ open AllCombinators pt fe
 open PropositionalTruncation pt
 
 open import InitialFrame pt fe
+
 \end{code}
 
 \section{The way below relation}
@@ -38,14 +39,17 @@ definition that make it a bit inconvenient to work with. It might be
 good idea to address this duplication at some point.
 
 \begin{code}
+
 is-directed : (P : poset 𝓤 𝓥) → (S : Fam 𝓦 ∣ P ∣ₚ) → Ω (𝓥 ⊔ 𝓦)
 is-directed P (I , s) =
    ∥ I ∥Ω
  ∧ (Ɐ i ∶ I , Ɐ j ∶ I , Ǝ k ∶ I , ((s i ≤ s k) ∧ (s j ≤ s k)) holds)
   where open PosetNotation P using (_≤_)
+
 \end{code}
 
 \begin{code}
+
 way-below : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
 way-below {𝓤 = 𝓤} {𝓦 = 𝓦} F U V =
  Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ , is-directed (poset-of F) S ⇒
@@ -56,6 +60,7 @@ way-below {𝓤 = 𝓤} {𝓦 = 𝓦} F U V =
 infix 5 way-below
 
 syntax way-below F U V = U ≪[ F ] V
+
 \end{code}
 
 \begin{code}
@@ -287,6 +292,7 @@ isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
 \section{Some properties}
 
 \begin{code}
+
 ∨-is-scott-continuous : (F : frame 𝓤 𝓥 𝓦)
                       → (U : ⟨ F ⟩)
                       → is-scott-continuous F F (λ - → U ∨[ F ] -) holds

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -63,6 +63,8 @@ syntax way-below F U V = U ≪[ F ] V
 
 \end{code}
 
+A compact open is one that is way below itself.
+
 \begin{code}
 
 is-compact-open : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
@@ -78,6 +80,8 @@ is-compact : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
 is-compact F = is-compact-open F 𝟏[ F ]
 
 \end{code}
+
+Compacts opens are always closed undery binary joins.
 
 \begin{code}
 

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -431,6 +431,19 @@ binary-family {A = A} 𝓦 x y = 𝟚 𝓦  , α
   α (inl *) = x
   α (inr *) = y
 
+fmap-binary-family : {A : 𝓤 ̇ } {B : 𝓥 ̇ }
+                   → (𝓦 : Universe)
+                   → (f : A → B)
+                   → (x y : A)
+                   → ⁅ f z ∣ z ε (binary-family 𝓦 x y) ⁆
+                   ≡ binary-family 𝓦 (f x) (f y)
+fmap-binary-family 𝓦 f x y = ap (λ - → 𝟚 𝓦 , -) (dfunext fe γ)
+ where
+  γ : ⁅ f z ∣ z ε binary-family 𝓦 x y ⁆ [_] ∼ binary-family 𝓦 (f x) (f y) [_]
+  γ (inl *) = refl
+  γ (inr *) = refl
+
+
 binary-join : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → ⟨ F ⟩
 binary-join {𝓦 = 𝓦} F x y = ⋁[ F ] binary-family 𝓦 x y
 
@@ -713,12 +726,13 @@ distributivity′ F x S =
 binary-distributivity : (F : frame 𝓤 𝓥 𝓦)
                       → {x y z : ⟨ F ⟩}
                       → x ∧[ F ] (y ∨[ F ] z) ≡ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)
-binary-distributivity F {x} {y} {z} =
- x ∧[ F ] (y ∨[ F ] z)                           ≡⟨ distributivity F x _ ⟩
- ⋁⟨ i ⟩ (x ∧[ F ] ((binary-family _ y z) [ i ])) ≡⟨ {!!} ⟩
- (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)                ∎
+binary-distributivity {𝓦 = 𝓦} F {x} {y} {z} =
+ x ∧[ F ] (y ∨[ F ] z)                            ≡⟨ † ⟩
+ ⋁[ F ] ⁅ x ∧[ F ] w ∣ w ε binary-family 𝓦 y z ⁆  ≡⟨ ‡ ⟩
+ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)                 ∎
   where
-   open JoinNotation (λ - → ⋁[ F ] -)
+   † = distributivity F x (binary-family 𝓦 y z)
+   ‡ = ap (λ - → join-of F -) (fmap-binary-family 𝓦 (λ - → x ∧[ F ] -) y z)
 
 \end{code}
 

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -964,9 +964,9 @@ directed one.
 
 \begin{code}
 
-directify-is-directed : (F : frame 𝓤 𝓥 𝓦) (S : Fam 𝓦 ⟨ F ⟩)
-                      → is-directed F (directify F S) holds
-directify-is-directed F S@(I , α) = ∣ [] ∣ , υ
+directify-works : (F : frame 𝓤 𝓥 𝓦) (S : Fam 𝓦 ⟨ F ⟩)
+                → is-directed F (directify F S) holds
+directify-works F S@(I , α) = ∣ [] ∣ , υ
  where
   open PropositionalTruncation pt
   open PosetNotation (poset-of F)
@@ -1052,7 +1052,8 @@ directify-preserves-joins₀ F S x p =
 
 directify-basis : (F : frame 𝓤 𝓥 𝓦)
                 → (has-basis F ⇒ has-directed-basis F) holds
-directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis F)) γ
+directify-basis {𝓦 = 𝓦} F =
+ ∥∥-rec (holds-is-prop (has-directed-basis F)) γ
  where
   open PropositionalTruncation pt
   open PosetNotation (poset-of F)
@@ -1093,7 +1094,7 @@ directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis 
       → is-directed F ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ holds
     δ x = transport (λ - → is-directed F - holds) (ψ x ⁻¹) ε
      where
-      ε = directify-is-directed F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
+      ε = directify-works F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
 
 \end{code}
 
@@ -1107,7 +1108,7 @@ is-scott-continuous : (F : frame 𝓤  𝓥  𝓦)
                     → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ⊔ 𝓤′ ⊔ 𝓥′)
 is-scott-continuous {𝓦 = 𝓦} F G f =
  let
-  open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
+   open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
  in
    Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ ,
     is-directed F S ⇒ f (⋁[ F ] S) is-lub-of ⁅ f s ∣ s ε S ⁆

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -1052,8 +1052,7 @@ directify-preserves-joins₀ F S x p =
 
 directify-basis : (F : frame 𝓤 𝓥 𝓦)
                 → (has-basis F ⇒ has-directed-basis F) holds
-directify-basis {𝓦 = 𝓦} F =
- ∥∥-rec (holds-is-prop (has-directed-basis F)) γ
+directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis F)) γ
  where
   open PropositionalTruncation pt
   open PosetNotation (poset-of F)

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -739,6 +739,34 @@ frame-morphisms-are-monotonic F G f (_ , ψ , _) (x , y) p =
 
 \begin{code}
 
+𝟎-right-annihilator-for-∧ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                          → x ∧[ F ] 𝟎[ F ] ≡ 𝟎[ F ]
+𝟎-right-annihilator-for-∧ F x =
+ only-𝟎-is-below-𝟎 F (x ∧[ F ] 𝟎[ F ]) (∧[ F ]-lower₂ x 𝟎[ F ])
+
+𝟎-left-annihilator-for-∧ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                         → 𝟎[ F ] ∧[ F ] x ≡ 𝟎[ F ]
+𝟎-left-annihilator-for-∧ F x =
+ 𝟎[ F ] ∧[ F ] x  ≡⟨ ∧[ F ]-is-commutative 𝟎[ F ] x ⟩
+ x ∧[ F ] 𝟎[ F ]  ≡⟨ 𝟎-right-annihilator-for-∧ F x  ⟩
+ 𝟎[ F ]           ∎
+
+𝟏-right-annihilator-for-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                          → x ∨[ F ] 𝟏[ F ] ≡ 𝟏[ F ]
+𝟏-right-annihilator-for-∨ F x =
+ only-𝟏-is-above-𝟏 F (x ∨[ F ] 𝟏[ F ]) (∨[ F ]-upper₂ x 𝟏[ F ])
+
+𝟏-left-annihilator-for-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                         → 𝟏[ F ] ∨[ F ] x ≡ 𝟏[ F ]
+𝟏-left-annihilator-for-∨ F x =
+ 𝟏[ F ] ∨[ F ] x  ≡⟨ ∨[ F ]-is-commutative 𝟏[ F ] x ⟩
+ x ∨[ F ] 𝟏[ F ]  ≡⟨ 𝟏-right-annihilator-for-∨ F x  ⟩
+ 𝟏[ F ] ∎
+
+\end{code}
+
+\begin{code}
+
 distributivity′ : (F : frame 𝓤 𝓥 𝓦)
                 → (x : ⟨ F ⟩)
                 → (S : Fam 𝓦 ⟨ F ⟩)

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -542,11 +542,18 @@ syntax binary-join F x y = x ∨[ F ] y
       y ∨[ F ] z             ≤⟨ ∨[ F ]-upper₂ x (y ∨[ F ] z) ⟩
       x ∨[ F ] (y ∨[ F ] z)  ■
 
-∨[_]-left-mono : (F : frame 𝓤 𝓥 𝓦)
+\end{code}
+
+By fixing the left or right argument of `_∨_` to anything, we get a monotonic
+map.
+
+\begin{code}
+
+∨[_]-left-monotone : (F : frame 𝓤 𝓥 𝓦)
                → {x y z : ⟨ F ⟩}
                → (x ≤[ poset-of F ] y) holds
                → ((x ∨[ F ] z) ≤[ poset-of F ] (y ∨[ F ] z)) holds
-∨[_]-left-mono F {x = x} {y} {z} p = ∨[ F ]-least γ (∨[ F ]-upper₂ y z)
+∨[_]-left-monotone F {x = x} {y} {z} p = ∨[ F ]-least γ (∨[ F ]-upper₂ y z)
  where
   open PosetNotation  (poset-of F) using (_≤_)
   open PosetReasoning (poset-of F)
@@ -554,13 +561,13 @@ syntax binary-join F x y = x ∨[ F ] y
   γ : (x ≤ (y ∨[ F ] z)) holds
   γ = x ≤⟨ p ⟩ y ≤⟨ ∨[ F ]-upper₁ y z ⟩ y ∨[ F ] z ■
 
-∨[_]-right-mono : (F : frame 𝓤 𝓥 𝓦)
+∨[_]-right-monotone : (F : frame 𝓤 𝓥 𝓦)
                 → {x y z : ⟨ F ⟩}
                 → (x ≤[ poset-of F ] y) holds
                 → ((z ∨[ F ] x) ≤[ poset-of F ] (z ∨[ F ] y)) holds
-∨[_]-right-mono F {x} {y} {z} p =
+∨[_]-right-monotone F {x} {y} {z} p =
  z ∨[ F ] x  ≡⟨ ∨[ F ]-is-commutative z x ⟩ₚ
- x ∨[ F ] z  ≤⟨ ∨[ F ]-left-mono p        ⟩
+ x ∨[ F ] z  ≤⟨ ∨[ F ]-left-monotone p    ⟩
  y ∨[ F ] z  ≡⟨ ∨[ F ]-is-commutative y z ⟩ₚ
  z ∨[ F ] y  ■
   where

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -353,8 +353,27 @@ Some projections.
 𝟏[_] : (F : frame 𝓤 𝓥 𝓦) →  ⟨ F ⟩
 𝟏[ (A , (_ , 𝟏 , _ , _) , p , _) ] = 𝟏
 
-𝟏-is-top : (F : frame 𝓤 𝓥 𝓦) → (x : ⟨ F ⟩) → (x ≤[ poset-of F ] 𝟏[ F ]) holds
+is-top : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Ω (𝓤 ⊔ 𝓥)
+is-top F t = Ɐ x ∶ ⟨ F ⟩ , x ≤[ poset-of F ] t
+
+𝟏-is-top : (F : frame 𝓤 𝓥 𝓦) → (is-top F 𝟏[ F ]) holds
 𝟏-is-top (A , _ , _ , p , _) = p
+
+𝟏-is-unique : (F : frame 𝓤 𝓥 𝓦) → (t : ⟨ F ⟩) → is-top F t holds → t ≡ 𝟏[ F ]
+𝟏-is-unique F t t-top = ≤-is-antisymmetric (poset-of F) β γ
+ where
+  β : (t ≤[ poset-of F ] 𝟏[ F ]) holds
+  β = 𝟏-is-top F t
+
+  γ : (𝟏[ F ] ≤[ poset-of F ] t) holds
+  γ = t-top 𝟏[ F ]
+
+only-𝟏-is-above-𝟏 : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                  → (𝟏[ F ] ≤[ poset-of F ] x) holds → x ≡ 𝟏[ F ]
+only-𝟏-is-above-𝟏 F x p =
+ 𝟏-is-unique F x λ y → y ≤⟨ 𝟏-is-top F y ⟩ 𝟏[ F ] ≤⟨ p ⟩ x ■
+  where
+   open PosetReasoning (poset-of F)
 
 meet-of : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → ⟨ F ⟩ → ⟨ F ⟩
 meet-of (_ , (_ , _ , _∧_ , _) , _ , _) x y = x ∧ y
@@ -558,8 +577,8 @@ syntax binary-join F x y = x ∨[ F ] y
             → (x : ⟨ F ⟩) → (𝟎[ F ] ≤[ poset-of F ] x) holds
 𝟎-is-bottom F x = ⋁[ F ]-least (𝟘 , λ ()) (x , λ ())
 
-𝟎-unit-of-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩) → 𝟎[ F ] ∨[ F ] x ≡ x
-𝟎-unit-of-∨ {𝓦 = 𝓦} F x = ≤-is-antisymmetric (poset-of F) β γ
+𝟎-right-unit-of-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩) → 𝟎[ F ] ∨[ F ] x ≡ x
+𝟎-right-unit-of-∨ {𝓦 = 𝓦} F x = ≤-is-antisymmetric (poset-of F) β γ
  where
   open PosetNotation (poset-of F)
 
@@ -569,6 +588,11 @@ syntax binary-join F x y = x ∨[ F ] y
   γ : (x ≤ (𝟎[ F ] ∨[ F ] x)) holds
   γ = ⋁[ F ]-upper (binary-family 𝓦 𝟎[ F ] x) (inr *)
 
+𝟎-left-unit-of-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩) → x ∨[ F ] 𝟎[ F ] ≡ x
+𝟎-left-unit-of-∨ {𝓦 = 𝓦} F x =
+ x ∨[ F ] 𝟎[ F ]  ≡⟨ ∨[ F ]-is-commutative x 𝟎[ F ] ⟩
+ 𝟎[ F ] ∨[ F ] x  ≡⟨ 𝟎-right-unit-of-∨ F x          ⟩
+ x                ∎
 
 \end{code}
 
@@ -885,7 +909,7 @@ directify-functorial F S@(I , α) = γ
                   directify F S [ js ]                ≡⟨ †    ⟩
                   𝟎[ F ]  ∨[ F ] directify F S [ js ] ∎
                    where
-                    † = 𝟎-unit-of-∨ F (directify F S [ js ]) ⁻¹
+                    † = 𝟎-right-unit-of-∨ F (directify F S [ js ]) ⁻¹
   γ (i ∷ is) js =
    directify F S [ (i ∷ is) ++ js ]                              ≡⟨ refl ⟩
    α i ∨[ F ] directify F S [ is ++ js ]                         ≡⟨ †    ⟩
@@ -954,7 +978,7 @@ directify-preserves-joins F S = ≤-is-antisymmetric (poset-of F) β γ
    where
     ν : (i : index S) → (S [ i ] ≤ (⋁[ F ] directify F S)) holds
     ν i =
-     S [ i ]                   ≡⟨ 𝟎-unit-of-∨ F (S [ i ]) ⁻¹             ⟩ₚ
+     S [ i ]                   ≡⟨ 𝟎-right-unit-of-∨ F (S [ i ]) ⁻¹       ⟩ₚ
      𝟎[ F ] ∨[ F ] S [ i ]     ≡⟨ ∨[ F ]-is-commutative 𝟎[ F ] (S [ i ]) ⟩ₚ
      S [ i ] ∨[ F ] 𝟎[ F ]     ≡⟨ refl                                   ⟩ₚ
      directify F S [ i ∷ [] ]  ≤⟨ ⋁[ F ]-upper (directify F S) (i ∷ [])  ⟩

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -748,9 +748,9 @@ distributivity′ F x S =
    † = ap (λ - → join-of F (index S , -)) (dfunext fe ‡)
 
 binary-distributivity : (F : frame 𝓤 𝓥 𝓦)
-                      → {x y z : ⟨ F ⟩}
+                      → (x y z : ⟨ F ⟩)
                       → x ∧[ F ] (y ∨[ F ] z) ≡ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)
-binary-distributivity {𝓦 = 𝓦} F {x} {y} {z} =
+binary-distributivity {𝓦 = 𝓦} F x y z =
  x ∧[ F ] (y ∨[ F ] z)                            ≡⟨ † ⟩
  ⋁[ F ] ⁅ x ∧[ F ] w ∣ w ε binary-family 𝓦 y z ⁆  ≡⟨ ‡ ⟩
  (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)                 ∎

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -964,9 +964,9 @@ directed one.
 
 \begin{code}
 
-directify-works : (F : frame 𝓤 𝓥 𝓦) (S : Fam 𝓦 ⟨ F ⟩)
-                → is-directed F (directify F S) holds
-directify-works F S@(I , α) = ∣ [] ∣ , υ
+directify-is-directed : (F : frame 𝓤 𝓥 𝓦) (S : Fam 𝓦 ⟨ F ⟩)
+                      → is-directed F (directify F S) holds
+directify-is-directed F S@(I , α) = ∣ [] ∣ , υ
  where
   open PropositionalTruncation pt
   open PosetNotation (poset-of F)
@@ -1094,7 +1094,7 @@ directify-basis {𝓦 = 𝓦} F =
       → is-directed F ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ holds
     δ x = transport (λ - → is-directed F - holds) (ψ x ⁻¹) ε
      where
-      ε = directify-works F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
+      ε = directify-is-directed F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
 
 \end{code}
 

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -366,7 +366,7 @@ syntax meet-of F x y = x ∧[ F ] y
 join-of : (F : frame 𝓤 𝓥 𝓦) → Fam 𝓦 ⟨ F ⟩ → ⟨ F ⟩
 join-of (_ , (_ , _ , _ , ⋁_) , _ , _) = ⋁_
 
-infix 3 join-of
+infix 4 join-of
 
 syntax join-of F U = ⋁[ F ] U
 
@@ -389,6 +389,20 @@ syntax join-of F U = ⋁[ F ] U
               → (z ≤[ poset-of A ] (x ∧[ A ] y)) holds
 ∧[_]-greatest (A , _ , _ , (_ , γ , _ , _)) x y z p q =
   pr₂ (γ (x , y)) (z , p , q)
+
+\end{code}
+
+\begin{code}
+
+𝟏-right-unit-of-∧ : (F : frame 𝓤 𝓥 𝓦)
+                  → (x : ⟨ F ⟩) → x ∧[ F ] 𝟏[ F ] ≡ x
+𝟏-right-unit-of-∧ F x = ≤-is-antisymmetric (poset-of F) β γ
+ where
+  β : ((x ∧[ F ] 𝟏[ F ]) ≤[ poset-of F ] x) holds
+  β = ∧[ F ]-lower₁ x 𝟏[ F ]
+
+  γ : (x ≤[ poset-of F ] (x ∧[ F ] 𝟏[ F ])) holds
+  γ = ∧[ F ]-greatest x 𝟏[ F ] x (≤-is-reflexive (poset-of F) x) (𝟏-is-top F x)
 
 \end{code}
 
@@ -446,10 +460,10 @@ syntax binary-join F x y = x ∨[ F ] y
               (x y : ⟨ F ⟩) → (y ≤[ poset-of F ] (x ∨[ F ] y)) holds
 ∨[_]-upper₂ {𝓦 = 𝓦} F x y = ⋁[ F ]-upper (binary-family 𝓦 x y) (inr *)
 
-∨[_]-comm : (F : frame 𝓤 𝓥 𝓦)
-          → (x y : ⟨ F ⟩)
-          → (x ∨[ F ] y) ≡ (y ∨[ F ] x)
-∨[_]-comm F x y =
+∨[_]-is-commutative : (F : frame 𝓤 𝓥 𝓦)
+                    → (x y : ⟨ F ⟩)
+                    → (x ∨[ F ] y) ≡ (y ∨[ F ] x)
+∨[_]-is-commutative F x y =
  ≤-is-antisymmetric (poset-of F) β γ
   where
    open PosetNotation  (poset-of F)
@@ -495,6 +509,31 @@ syntax binary-join F x y = x ∨[ F ] y
   γ = z                      ≤⟨ ∨[ F ]-upper₂ y z            ⟩
       y ∨[ F ] z             ≤⟨ ∨[ F ]-upper₂ x (y ∨[ F ] z) ⟩
       x ∨[ F ] (y ∨[ F ] z)  ■
+
+∨[_]-left-mono : (F : frame 𝓤 𝓥 𝓦)
+               → {x y z : ⟨ F ⟩}
+               → (x ≤[ poset-of F ] y) holds
+               → ((x ∨[ F ] z) ≤[ poset-of F ] (y ∨[ F ] z)) holds
+∨[_]-left-mono F {x = x} {y} {z} p = ∨[ F ]-least γ (∨[ F ]-upper₂ y z)
+ where
+  open PosetNotation  (poset-of F) using (_≤_)
+  open PosetReasoning (poset-of F)
+
+  γ : (x ≤ (y ∨[ F ] z)) holds
+  γ = x ≤⟨ p ⟩ y ≤⟨ ∨[ F ]-upper₁ y z ⟩ y ∨[ F ] z ■
+
+∨[_]-right-mono : (F : frame 𝓤 𝓥 𝓦)
+                → {x y z : ⟨ F ⟩}
+                → (x ≤[ poset-of F ] y) holds
+                → ((z ∨[ F ] x) ≤[ poset-of F ] (z ∨[ F ] y)) holds
+∨[_]-right-mono F {x} {y} {z} p =
+ z ∨[ F ] x  ≡⟨ ∨[ F ]-is-commutative z x ⟩ₚ
+ x ∨[ F ] z  ≤⟨ ∨[ F ]-left-mono p        ⟩
+ y ∨[ F ] z  ≡⟨ ∨[ F ]-is-commutative y z ⟩ₚ
+ z ∨[ F ] y  ■
+  where
+   open PosetReasoning (poset-of F)
+
 \end{code}
 
 \begin{code}
@@ -609,6 +648,13 @@ connecting-lemma₁ F x y p = ∧[ F ]-unique (β , γ)
   γ : (Ɐ (z , _) ∶ lower-bound (x , y) , z ≤[ poset-of F ] x) holds
   γ (z , q , _) = q
 
+connecting-lemma₂ : (F : frame 𝓤 𝓥 𝓦) {x y : ⟨ F ⟩}
+                  → x ≡ x ∧[ F ] y
+                  → (x ≤[ poset-of F ] y) holds
+connecting-lemma₂ F {x} {y} p = x ≡⟨ p ⟩ₚ x ∧[ F ] y ≤⟨ ∧[ F ]-lower₂ x y ⟩ y ■
+ where
+  open PosetReasoning (poset-of F)
+
 frame-morphisms-are-monotonic : (F : frame 𝓤  𝓥  𝓦)
                                 (G : frame 𝓤′ 𝓥′ 𝓦′)
                               → (f : ⟨ F ⟩ → ⟨ G ⟩)
@@ -642,6 +688,37 @@ frame-morphisms-are-monotonic F G f (_ , ψ , _) (x , y) p =
 
   γ : (Ɐ (l , _) ∶ lower-bound (y , x) , l ≤ (x ∧[ F ] y)) holds
   γ (l , p , q) = ∧[ F ]-greatest x y l q p
+
+\end{code}
+
+\begin{code}
+
+distributivity′ : (F : frame 𝓤 𝓥 𝓦)
+                → (x : ⟨ F ⟩)
+                → (S : Fam 𝓦 ⟨ F ⟩)
+                → let open JoinNotation (λ - → ⋁[ F ] -) in
+                  x ∧[ F ] (⋁⟨ i ⟩ (S [ i ]))
+                ≡ ⋁⟨ i ⟩ ((S [ i ]) ∧[ F ] x)
+distributivity′ F x S =
+ x ∧[ F ] (⋁⟨ i ⟩ S [ i ])    ≡⟨ distributivity F x S ⟩
+ ⋁⟨ i ⟩ (x ∧[ F ] (S [ i ]))  ≡⟨ †                    ⟩
+ ⋁⟨ i ⟩ (S [ i ]) ∧[ F ] x    ∎
+  where
+   open PosetReasoning (poset-of F)
+   open JoinNotation (λ - → ⋁[ F ] -)
+
+   ‡ = ∧[ F ]-is-commutative x ∘ (_[_] S)
+   † = ap (λ - → join-of F (index S , -)) (dfunext fe ‡)
+
+binary-distributivity : (F : frame 𝓤 𝓥 𝓦)
+                      → {x y z : ⟨ F ⟩}
+                      → x ∧[ F ] (y ∨[ F ] z) ≡ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)
+binary-distributivity F {x} {y} {z} =
+ x ∧[ F ] (y ∨[ F ] z)                           ≡⟨ distributivity F x _ ⟩
+ ⋁⟨ i ⟩ (x ∧[ F ] ((binary-family _ y z) [ i ])) ≡⟨ {!!} ⟩
+ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)                ∎
+  where
+   open JoinNotation (λ - → ⋁[ F ] -)
 
 \end{code}
 
@@ -863,10 +940,10 @@ directify-preserves-joins F S = ≤-is-antisymmetric (poset-of F) β γ
    where
     ν : (i : index S) → (S [ i ] ≤ (⋁[ F ] directify F S)) holds
     ν i =
-     S [ i ]                   ≡⟨ 𝟎-unit-of-∨ F (S [ i ]) ⁻¹            ⟩ₚ
-     𝟎[ F ] ∨[ F ] S [ i ]     ≡⟨ ∨[ F ]-comm 𝟎[ F ] (S [ i ])          ⟩ₚ
-     S [ i ] ∨[ F ] 𝟎[ F ]     ≡⟨ refl                                  ⟩ₚ
-     directify F S [ i ∷ [] ]  ≤⟨ ⋁[ F ]-upper (directify F S) (i ∷ []) ⟩
+     S [ i ]                   ≡⟨ 𝟎-unit-of-∨ F (S [ i ]) ⁻¹             ⟩ₚ
+     𝟎[ F ] ∨[ F ] S [ i ]     ≡⟨ ∨[ F ]-is-commutative 𝟎[ F ] (S [ i ]) ⟩ₚ
+     S [ i ] ∨[ F ] 𝟎[ F ]     ≡⟨ refl                                   ⟩ₚ
+     directify F S [ i ∷ [] ]  ≤⟨ ⋁[ F ]-upper (directify F S) (i ∷ [])  ⟩
      ⋁[ F ] directify F S      ■
 
   γ : ((⋁[ F ] directify F S) ≤[ poset-of F ] (⋁[ F ] S)) holds
@@ -943,5 +1020,22 @@ directify-basis {𝓦 = 𝓦} F =
     δ x = transport (λ - → is-directed F - holds) (ψ x ⁻¹) ε
      where
       ε = directify-works F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
+
+\end{code}
+
+\section{Scott-continuity}
+
+\begin{code}
+
+is-scott-continuous : (F : frame 𝓤  𝓥  𝓦)
+                    → (G : frame 𝓤′ 𝓥′ 𝓦)
+                    → (f : ⟨ F ⟩ → ⟨ G ⟩)
+                    → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ⊔ 𝓤′ ⊔ 𝓥′)
+is-scott-continuous {𝓦 = 𝓦} F G f =
+ let
+   open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
+ in
+   Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ ,
+    is-directed F S ⇒ f (⋁[ F ] S) is-lub-of ⁅ f s ∣ s ε S ⁆
 
 \end{code}

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -1107,7 +1107,7 @@ is-scott-continuous : (F : frame 𝓤  𝓥  𝓦)
                     → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ⊔ 𝓤′ ⊔ 𝓥′)
 is-scott-continuous {𝓦 = 𝓦} F G f =
  let
-   open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
+  open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
  in
    Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ ,
     is-directed F S ⇒ f (⋁[ F ] S) is-lub-of ⁅ f s ∣ s ε S ⁆

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -1114,10 +1114,8 @@ is-scott-continuous : (F : frame 𝓤  𝓥  𝓦)
                     → (f : ⟨ F ⟩ → ⟨ G ⟩)
                     → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ⊔ 𝓤′ ⊔ 𝓥′)
 is-scott-continuous {𝓦 = 𝓦} F G f =
- let
+ Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ , is-directed F S ⇒ f (⋁[ F ] S) is-lub-of ⁅ f s ∣ s ε S ⁆
+  where
    open Joins (λ x y → x ≤[ poset-of G ] y) using (_is-lub-of_)
- in
-   Ɐ S ∶ Fam 𝓦 ⟨ F ⟩ ,
-    is-directed F S ⇒ f (⋁[ F ] S) is-lub-of ⁅ f s ∣ s ε S ⁆
 
 \end{code}

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -577,6 +577,15 @@ syntax binary-join F x y = x ∨[ F ] y
             → (x : ⟨ F ⟩) → (𝟎[ F ] ≤[ poset-of F ] x) holds
 𝟎-is-bottom F x = ⋁[ F ]-least (𝟘 , λ ()) (x , λ ())
 
+only-𝟎-is-below-𝟎 : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩)
+                  → (x ≤[ poset-of F ] 𝟎[ F ]) holds → x ≡ 𝟎[ F ]
+only-𝟎-is-below-𝟎 F x p =
+ ≤-is-antisymmetric (poset-of F) p (𝟎-is-bottom F x)
+
+𝟎-is-unique : (F : frame 𝓤 𝓥 𝓦) (b : ⟨ F ⟩)
+            → ((x : ⟨ F ⟩) → (b ≤[ poset-of F ] x) holds) → b ≡ 𝟎[ F ]
+𝟎-is-unique F b φ = only-𝟎-is-below-𝟎 F b (φ 𝟎[ F ])
+
 𝟎-right-unit-of-∨ : (F : frame 𝓤 𝓥 𝓦) (x : ⟨ F ⟩) → 𝟎[ F ] ∨[ F ] x ≡ x
 𝟎-right-unit-of-∨ {𝓦 = 𝓦} F x = ≤-is-antisymmetric (poset-of F) β γ
  where

--- a/source/InitialFrame.lagda
+++ b/source/InitialFrame.lagda
@@ -77,9 +77,9 @@ open propositional-truncations-exist pt
   ⋁_ : Fam 𝓤 (Ω 𝓤) → Ω 𝓤
   ⋁ U = Ǝ i ∶ index U , ((U [ i ]) holds)
 
-  open Meets _⊑_
+  open Meets _⊑_ renaming (is-top to is-the-top)
 
-  top : is-top (⊤Ω {𝓤}) holds
+  top : is-the-top (⊤Ω {𝓤}) holds
   top _ _ = *
 
   meet : (Ɐ (P , Q) , (P ∧ Q) is-glb-of (P , Q)) holds
@@ -100,26 +100,29 @@ open propositional-truncations-exist pt
     γ : (Ɐ (P , _) ∶ upper-bound U , (⋁ U) ⊑ P) holds
     γ ((A , A-prop) , q) r = ∥∥-rec A-prop (uncurry q) r
 
-  iss : is-set (Ω 𝓤)
-  iss = carrier-of-[ 𝟎F-poset ua ]-is-set
+  abstract
+   iss : is-set (Ω 𝓤)
+   iss = carrier-of-[ 𝟎F-poset ua ]-is-set
 
-  dist : (Ɐ(P , U) ∶ Ω 𝓤 × Fam 𝓤 (Ω 𝓤) ,
-          (P ∧ (⋁ U) ≡[ iss ]≡  ⋁⟨ i ⟩ P ∧ U [ i ])) holds
-  dist (P , U) = Ω-ext-from-univalence ua β γ
-   where
-    β : (P ∧ ⋁ U ⇒ (⋁⟨ i ⟩ (P ∧ U [ i ]))) holds
-    β (p , u) = ∥∥-rec (holds-is-prop (⋁⟨ i ⟩ (P ∧ U [ i ]))) α u
-     where
-      α : Σ i ꞉ index U , (U [ i ]) holds → (⋁⟨ i ⟩ P ∧ U [ i ]) holds
-      α (i , uᵢ) = ∣ i , p , uᵢ ∣
+   dist : (Ɐ(P , U) ∶ Ω 𝓤 × Fam 𝓤 (Ω 𝓤) ,
+           (P ∧ (⋁ U) ≡[ iss ]≡  ⋁⟨ i ⟩ P ∧ U [ i ])) holds
+   dist (P , U) = Ω-ext-from-univalence ua β γ
+    where
+     β : (P ∧ ⋁ U ⇒ (⋁⟨ i ⟩ (P ∧ U [ i ]))) holds
+     β (p , u) = ∥∥-rec (holds-is-prop (⋁⟨ i ⟩ (P ∧ U [ i ]))) α u
+      where
+       α : Σ i ꞉ index U , (U [ i ]) holds → (⋁⟨ i ⟩ P ∧ U [ i ]) holds
+       α (i , uᵢ) = ∣ i , p , uᵢ ∣
 
-    γ : ((⋁⟨ i ⟩ P ∧ U [ i ]) ⇒ P ∧ ⋁ U) holds
-    γ p = ∥∥-rec (holds-is-prop (P ∧ (⋁ U))) δ p
-     where
-      δ : Sigma (index (index U , (λ i → P ∧ U [ i ])))
-            (λ i → ((index U , (λ i₁ → P ∧ U [ i₁ ])) [ i ]) holds) →
-            (P ∧ (⋁ U)) holds
-      δ (i , q , uᵢ) = q , ∣ i , uᵢ ∣
+     γ : ((⋁⟨ i ⟩ P ∧ U [ i ]) ⇒ P ∧ ⋁ U) holds
+     γ p = ∥∥-rec (holds-is-prop (P ∧ (⋁ U))) δ p
+      where
+       δ : Sigma (index (index U , (λ i → P ∧ U [ i ])))
+             (λ i → ((index U , (λ i₁ → P ∧ U [ i₁ ])) [ i ]) holds) →
+             (P ∧ (⋁ U)) holds
+       δ (i , q , uᵢ) = q , ∣ i , uᵢ ∣
+
+\end{code}
 
 \end{code}
 

--- a/source/InitialFrame.lagda
+++ b/source/InitialFrame.lagda
@@ -124,6 +124,13 @@ open propositional-truncations-exist pt
 
 \end{code}
 
+\begin{code}
+𝟎-of-IF-is-⊥ : {𝓦 : Universe} → (ua : is-univalent 𝓦) → 𝟎[ 𝟎-𝔽𝕣𝕞 ua ] ≡ ⊥Ω
+𝟎-of-IF-is-⊥ ua =
+ ≤-is-antisymmetric (poset-of (𝟎-𝔽𝕣𝕞 ua)) γ λ ()
+ where
+  γ : (𝟎[ 𝟎-𝔽𝕣𝕞 ua ] ≤[ poset-of (𝟎-𝔽𝕣𝕞 ua) ]  ⊥Ω) holds
+  γ x = ∥∥-rec 𝟘-is-prop (λ ()) x
 \end{code}
 
 \section{Proof of initiality}

--- a/source/UF-Subsingleton-Combinators.lagda
+++ b/source/UF-Subsingleton-Combinators.lagda
@@ -48,8 +48,8 @@ module Universal (fe : Fun-Ext) where
  ∀[]-syntax : {I : 𝓤 ̇} → (I → Ω 𝓥) → Ω (𝓤 ⊔ 𝓥)
  ∀[]-syntax {I = I} P = ∀[∶]-syntax I P
 
- infix 3 ∀[∶]-syntax
- infix 3 ∀[]-syntax
+ infixr -1 ∀[∶]-syntax
+ infixr -1 ∀[]-syntax
 
  syntax ∀[∶]-syntax I (λ i → e) = Ɐ i ∶ I , e
  syntax ∀[]-syntax    (λ i → e) = Ɐ i , e
@@ -114,8 +114,8 @@ module Existential (pt : propositional-truncations-exist) where
  ∃[]-syntax : {I : 𝓤 ̇} → (I → 𝓥 ̇) → Ω (𝓤 ⊔ 𝓥)
  ∃[]-syntax {I = I} P = ∃[∶]-syntax I P
 
- infix 2 ∃[∶]-syntax
- infix 2 ∃[]-syntax
+ infixr -1 ∃[∶]-syntax
+ infixr -1 ∃[]-syntax
 
  syntax ∃[∶]-syntax I (λ i → e) = Ǝ i ∶ I , e
  syntax ∃[]-syntax    (λ i → e) = Ǝ i , e

--- a/source/index.lagda
+++ b/source/index.lagda
@@ -146,6 +146,7 @@ import FailureOfTotalSeparatedness
 import Frame-version1
 import Frame                           -- By Ayberk Tosun
 import InitialFrame                    -- By Ayberk Tosun
+import CompactRegular                  -- By Ayberk Tosun
 import FreeGroup                       -- By Marc Bezem, Thierry Coquand, Dybjer, and Martin Escardo.
 import FreeGroupOfLargeLocallySmallSet -- By Marc Bezem, Thierry Coquand, Dybjer, and Martin Escardo.
 import FreeJoinSemiLattice             -- By Tom de Jong


### PR DESCRIPTION
This PR contains some basic proofs that will be useful once I start porting the patch frame to `TypeTopology`. Here is a short summary of the developments added in this PR:

1. Definitions of the well inside and way below relations.
1. Well inside implies below.
1. The fact that being a clopen is a proposition, even though the well inside relation in general is not a proposition (I added a counterexample using the initial frame).
1. Compact opens are closed under binary joins in any frame.
1. Scott-continuity of the closed nucleus.
1. The fact that well inside implies way below in any compact frame, and
   - as a corollary of this: clopens are compact in any compact frame.