### PR TITLE
Prove that clopens and compact opens coincide in Stone locales

### DIFF
--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -368,11 +368,11 @@ clopenness-equivalent-to-well-inside-itself F U =
 
 \begin{code}
 
-well-inside-upwards : (F : frame 𝓤 𝓥 𝓦) (U₁ U₂ V : ⟨ F ⟩)
+well-inside-upwards : (F : frame 𝓤 𝓥 𝓦) {U₁ U₂ V : ⟨ F ⟩}
                     → (U₁ ⋜[ F ] V) holds
                     → (U₂ ⋜[ F ] V) holds
                     → ((U₁ ∨[ F ] U₂) ⋜[ F ] V) holds
-well-inside-upwards F U₁ U₂ V =
+well-inside-upwards F {U₁} {U₂} {V} =
  ∥∥-rec₂ (holds-is-prop ((U₁ ∨[ F ] U₂) ⋜[ F ] V)) γ
   where
    open PosetReasoning (poset-of F)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -12,6 +12,7 @@ open import UF-PropTrunc
 open import UF-FunExt
 open import UF-Univalence
 open import UF-UA-FunExt
+open import List hiding ([_])
 
 module CompactRegular
         (pt : propositional-truncations-exist)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -595,3 +595,28 @@ clopens-are-compact-in-compact-frames F κ U =
  ⋜₀-implies-≪-in-compact-frames F κ  U U
 
 \end{code}
+
+\begin{code}
+
+≪-implies-⋜-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
+                              → is-regular F holds
+                              → (U V : ⟨ F ⟩)
+                              → (U ≪[ F ] V) holds
+                              → (U ⋜[ F ] V) holds
+≪-implies-⋜-in-regular-frames F ρ U V κ =
+ ∥∥-rec (holds-is-prop ((U ⋜[ F ] V))) {!!} (κ {!↓↓[ F ] V!} {!!} {!!})
+  where
+   -- Stone Spaces pg. 303 (PDF pg. 324)
+   W : ⟨ F ⟩
+   W = {!!}
+
+   p : (W ⋜[ F ] V) holds
+   p = {!T≤U⋜V≤W-implies-T⋜W!}
+
+   β : (U ≤[ poset-of F ] {!!}) holds
+   β = {!!}
+
+   γ : {!!}
+   γ = {!!}
+
+\end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -305,6 +305,18 @@ clopenness-equivalent-to-well-inside-itself F U =
 
 \end{code}
 
+\begin{code}
+
+𝟎-is-clopen : (F : frame 𝓤 𝓥 𝓦) → 𝟎[ F ] ⋜₀[ F ] 𝟎[ F ]
+𝟎-is-clopen F = 𝟏[ F ] , β , γ
+ where
+  β : 𝟎[ F ] ∧[ F ] 𝟏[ F ] ≡ 𝟎[ F ]
+  β = 𝟎-left-annihilator-for-∧ F 𝟏[ F ]
+
+  γ : 𝟎[ F ] ∨[ F ] 𝟏[ F ] ≡ 𝟏[ F ]
+  γ = 𝟏-right-annihilator-for-∨ F 𝟎[ F ]
+
+\end{code}
 \section{Definition of regularity}
 
 \begin{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -317,6 +317,20 @@ clopenness-equivalent-to-well-inside-itself F U =
   γ = 𝟏-right-annihilator-for-∨ F 𝟎[ F ]
 
 \end{code}
+
+\begin{code}
+
+𝟎-is-well-inside-anything : (F : frame 𝓤 𝓥 𝓦) (U : ⟨ F ⟩)
+                          → (𝟎[ F ] ⋜[ F ] U) holds
+𝟎-is-well-inside-anything F U = T≤U⋜V≤W-implies-T⋜W F β ∣ 𝟎-is-clopen F ∣ γ
+ where
+  β : (𝟎[ F ] ≤[ poset-of F ] 𝟎[ F ]) holds
+  β = ≤-is-reflexive (poset-of F) 𝟎[ F ]
+
+  γ : (𝟎[ F ] ≤[ poset-of F ] U) holds
+  γ = 𝟎-is-bottom F U
+
+\end{code}
 \section{Definition of regularity}
 
 \begin{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -769,3 +769,36 @@ zero-dimensional-locales-are-regular {𝓦 = 𝓦} F =
          η = ≤-is-reflexive (poset-of F) (ℬ [ 𝒥 [ i ] ])
 
 \end{code}
+
+\section{Stone Locales}
+
+A frame F is called Stone iff it is compact and zero-dimensional.
+
+\begin{code}
+
+is-stone : (F : frame 𝓤 𝓥 𝓦) → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-stone F = is-compact F ∧ is-zero-dimensional F
+
+\end{code}
+
+In a Stone locale, an open is a clopen iff it is compact.
+
+\begin{code}
+
+clopen-iff-compact-in-stone-frame : (F : frame 𝓤 𝓥 𝓦)
+                                  → is-stone F holds
+                                  → (U : ⟨ F ⟩)
+                                  → (is-clopen F U holds)
+                                  ⇔ (is-compact-open F U holds)
+clopen-iff-compact-in-stone-frame F (κ , ζ) U = β , γ
+ where
+  β : (is-clopen F U ⇒ is-compact-open F U) holds
+  β = clopens-are-compact-in-compact-frames F κ U
+
+  ρ : is-regular F holds
+  ρ = zero-dimensional-locales-are-regular F ζ
+
+  γ : (is-compact-open F U ⇒ is-clopen F U) holds
+  γ = compacts-are-clopen-in-regular-frames F ρ U
+
+\end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -239,6 +239,40 @@ well-inside-implies-below F U V = ∥∥-rec (holds-is-prop (U ≤[ poset-of F ]
 
 \end{code}
 
+\begin{code}
+
+T≤U⋜V≤W-implies-T⋜W : (F : frame 𝓤 𝓥 𝓦)
+                    → {T U V W : ⟨ F ⟩}
+                    → (T ≤[ poset-of F ] U) holds
+                    → (U ⋜[ F ] V) holds
+                    → (V ≤[ poset-of F ] W) holds
+                    → (T ⋜[ F ] W) holds
+T≤U⋜V≤W-implies-T⋜W F {T} {U} {V} {W} p q r =
+ ∥∥-rec (holds-is-prop (T ⋜[ F ] W)) γ q
+  where
+   γ : U ⋜₀[ F ] V → (T ⋜[ F ] W) holds
+   γ (S , c₁ , c₂) = ∣ S , δ , ε ∣
+    where
+     open PosetReasoning (poset-of F)
+
+     δ : T ∧[ F ] S ≡ 𝟎[ F ]
+     δ = only-𝟎-is-below-𝟎 F (T ∧[ F ] S) δ₁
+      where
+       δ₁ : ((T ∧[ F ] S) ≤[ poset-of F ] 𝟎[ F ]) holds
+       δ₁ = T ∧[ F ] S  ≤⟨ ∧[ F ]-left-monotone p ⟩
+            U ∧[ F ] S  ≡⟨ c₁                     ⟩ₚ
+            𝟎[ F ]      ■
+
+     ε : W ∨[ F ] S ≡ 𝟏[ F ]
+     ε = only-𝟏-is-above-𝟏 F (W ∨[ F ] S) ε₁
+      where
+       ε₁ : (𝟏[ F ] ≤[ poset-of F ] (W ∨[ F ] S)) holds
+       ε₁ = 𝟏[ F ]      ≡⟨ c₂ ⁻¹                  ⟩ₚ
+            V ∨[ F ] S  ≤⟨ ∨[ F ]-left-monotone r ⟩
+            W ∨[ F ] S  ■
+
+\end{code}
+
 An open _U_ in a frame _A_ is *clopen* iff it is well-inside itself.
 
 \begin{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -633,6 +633,7 @@ basis-of-regular-frame F r = ∥∥-rec (holds-is-prop (has-basis F)) γ r
   γ (ℬ , δ)= ∣ ℬ , (λ U → pr₁ (δ U) , pr₁ (pr₂ (δ U))) ∣
 
 \end{code}
+
 \section{Zero-dimensionality}
 
 A locale L is said to be zero-dimensional iff it has a basis consisting of
@@ -716,4 +717,5 @@ directification-preserves-regularity F ℬ β r U = γ
 
      ζ : Σ k ꞉ index S , (U ≤[ poset-of F ] (S [ k ])) holds → (U ⋜[ F ] V) holds
      ζ (k , q) = T≤U⋜V≤W-implies-T⋜W F q (ρ↑ V k) (≤-is-reflexive (poset-of F) V)
+
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -719,3 +719,14 @@ directification-preserves-regularity F ℬ β r U = γ
      ζ (k , q) = T≤U⋜V≤W-implies-T⋜W F q (ρ↑ V k) (≤-is-reflexive (poset-of F) V)
 
 \end{code}
+
+\begin{code}
+
+compacts-are-clopen-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
+                                      → is-regular F holds
+                                      → (Ɐ U ∶ ⟨ F ⟩ ,
+                                          is-compact-open F U ⇒ is-clopen F U) holds
+compacts-are-clopen-in-regular-frames F r U =
+ well-inside-itself-implies-clopen F U ∘ ≪-implies-⋜-in-regular-frames F r U U
+
+\end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -663,25 +663,65 @@ basis-of-zero-dimensional-frame : (F : frame 𝓤 𝓥 𝓦)
                                 → (is-zero-dimensional F ⇒ has-basis F) holds
 basis-of-zero-dimensional-frame F =
  ∥∥-rec (holds-is-prop (has-basis F)) λ { (ℬ , δ , _) → ∣ ℬ , δ ∣ }
+
+directification-preserves-regularity : (F : frame 𝓤 𝓥 𝓦)
+                                     → (ℬ : Fam 𝓦 ⟨ F ⟩)
+                                     → (β : is-basis-for F ℬ)
+                                     → is-regular-basis F ℬ β holds
+                                     → let
+                                        ℬ↑ = directify F ℬ
+                                        β↑ = directified-basis-is-basis F ℬ β
+                                       in
+                                        is-regular-basis F ℬ↑ β↑ holds
+directification-preserves-regularity F ℬ β r U = γ
+ where
+  ℬ↑ = directify F ℬ
+  β↑ = directified-basis-is-basis F ℬ β
+
+  𝒥  = pr₁ (β U)
+  𝒥↑ = pr₁ (β↑ U)
+
+  γ : (Ɐ js ∶ index 𝒥↑ , ℬ↑ [ 𝒥↑ [ js ] ] ⋜[ F ] U) holds
+  γ []       = 𝟎-is-well-inside-anything F U
+  γ (j ∷ js) = well-inside-upwards F (r U j) (γ js)
+
 ≪-implies-⋜-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
-                              → is-regular F holds
+                              → (is-regular F) holds
                               → (U V : ⟨ F ⟩)
-                              → (U ≪[ F ] V) holds
-                              → (U ⋜[ F ] V) holds
-≪-implies-⋜-in-regular-frames F ρ U V κ =
- ∥∥-rec (holds-is-prop ((U ⋜[ F ] V))) {!!} (κ {!↓↓[ F ] V!} {!!} {!!})
+                              → (U ≪[ F ] V ⇒ U ⋜[ F ] V) holds
+≪-implies-⋜-in-regular-frames {𝓦 = 𝓦} F r U V =
+ ∥∥-rec (holds-is-prop (U ≪[ F ] V ⇒ U ⋜[ F ] V)) γ r
   where
-   -- Stone Spaces pg. 303 (PDF pg. 324)
-   W : ⟨ F ⟩
-   W = {!!}
+   γ : is-regular₀ F → (U ≪[ F ] V ⇒ U ⋜[ F ] V) holds
+   γ (ℬ , δ) κ = ∥∥-rec (holds-is-prop (U ⋜[ F ] V)) ζ (κ S ε c)
+    where
+     ℬ↑ : Fam 𝓦 ⟨ F ⟩
+     ℬ↑ = directify F ℬ
 
-   p : (W ⋜[ F ] V) holds
-   p = {!T≤U⋜V≤W-implies-T⋜W!}
+     β : is-basis-for F ℬ
+     β U = pr₁ (δ U) , pr₁ (pr₂ (δ U))
 
-   β : (U ≤[ poset-of F ] {!!}) holds
-   β = {!!}
+     β↑ : is-basis-for F ℬ↑
+     β↑ = directified-basis-is-basis F ℬ β
 
-   γ : {!!}
-   γ = {!!}
+     ρ : is-regular-basis F ℬ β holds
+     ρ U = pr₂ (pr₂ (δ U))
 
+     ρ↑ : is-regular-basis F ℬ↑ β↑ holds
+     ρ↑ = directification-preserves-regularity F ℬ β ρ
+
+     𝒥 : Fam 𝓦 (index ℬ↑)
+     𝒥 = pr₁ (β↑ V)
+
+     S : Fam 𝓦 ⟨ F ⟩
+     S = ⁅ ℬ↑ [ i ] ∣ i ε 𝒥 ⁆
+
+     ε : is-directed (poset-of F) S holds
+     ε = covers-of-directified-basis-are-directed F ℬ β V
+
+     c : (V ≤[ poset-of F ] (⋁[ F ] S)) holds
+     c = reflexivity+ (poset-of F) (⋁[ F ]-unique S V (pr₂ (β↑ V)))
+
+     ζ : Σ k ꞉ index S , (U ≤[ poset-of F ] (S [ k ])) holds → (U ⋜[ F ] V) holds
+     ζ (k , q) = T≤U⋜V≤W-implies-T⋜W F q (ρ↑ V k) (≤-is-reflexive (poset-of F) V)
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -463,16 +463,7 @@ We now want to prove that this set is upwards-closed.
    ∣ ((V₁ ∨[ F ] V₂) , δ) , ∨[ F ]-upper₁ V₁ V₂ , ∨[ F ]-upper₂ V₁ V₂ ∣
     where
      δ : ((V₁ ∨[ F ] V₂) ⋜[ F ] U) holds
-     δ = well-inside-upwards F V₁ V₂ U p₁ p₂
-
-\end{code}
-
-\begin{code}
-
-is-regular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
-is-regular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
- where
-  open Joins (λ U V → U ≤[ poset-of F ] V)
+     δ = well-inside-upwards F p₁ p₂
 
 \end{code}
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -634,28 +634,7 @@ basis-of-regular-frame F r = ∥∥-rec (holds-is-prop (has-basis F)) γ r
 
 \end{code}
 
-\section{Zero-dimensionality}
-
-A locale L is said to be zero-dimensional iff it has a basis consisting of
-clopen elements.
-
 \begin{code}
-
-consists-of-clopens : (F : frame 𝓤 𝓥 𝓦) → (S : Fam 𝓦 ⟨ F ⟩) → Ω (𝓤 ⊔ 𝓦)
-consists-of-clopens F S = Ɐ i ∶ index S , is-clopen F (S [ i ])
-
-is-zero-dimensional₀ : frame 𝓤 𝓥 𝓦 → (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺) ̇
-is-zero-dimensional₀ {𝓦 = 𝓦} F =
- Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
-
-is-zero-dimensional : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-is-zero-dimensional {𝓦 = 𝓦} F =
- Ǝ ℬ ∶ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
-
-basis-of-zero-dimensional-frame : (F : frame 𝓤 𝓥 𝓦)
-                                → (is-zero-dimensional F ⇒ has-basis F) holds
-basis-of-zero-dimensional-frame F =
- ∥∥-rec (holds-is-prop (has-basis F)) λ { (ℬ , δ , _) → ∣ ℬ , δ ∣ }
 
 directification-preserves-regularity : (F : frame 𝓤 𝓥 𝓦)
                                      → (ℬ : Fam 𝓦 ⟨ F ⟩)
@@ -720,6 +699,7 @@ directification-preserves-regularity F ℬ β r U = γ
 
 \end{code}
 
+
 \begin{code}
 
 compacts-are-clopen-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
@@ -728,5 +708,30 @@ compacts-are-clopen-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
                                           is-compact-open F U ⇒ is-clopen F U) holds
 compacts-are-clopen-in-regular-frames F r U =
  well-inside-itself-implies-clopen F U ∘ ≪-implies-⋜-in-regular-frames F r U U
+
+\end{code}
+
+\section{Zero-dimensionality}
+
+A locale L is said to be zero-dimensional iff it has a basis consisting of
+clopen elements.
+
+\begin{code}
+
+consists-of-clopens : (F : frame 𝓤 𝓥 𝓦) → (S : Fam 𝓦 ⟨ F ⟩) → Ω (𝓤 ⊔ 𝓦)
+consists-of-clopens F S = Ɐ i ∶ index S , is-clopen F (S [ i ])
+
+is-zero-dimensional₀ : frame 𝓤 𝓥 𝓦 → (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺) ̇
+is-zero-dimensional₀ {𝓦 = 𝓦} F =
+ Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
+
+is-zero-dimensional : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-zero-dimensional {𝓦 = 𝓦} F =
+ Ǝ ℬ ∶ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
+
+basis-of-zero-dimensional-frame : (F : frame 𝓤 𝓥 𝓦)
+                                → (is-zero-dimensional F ⇒ has-basis F) holds
+basis-of-zero-dimensional-frame F =
+ ∥∥-rec (holds-is-prop (has-basis F)) λ { (ℬ , δ , _) → ∣ ℬ , δ ∣ }
 
 \end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -331,19 +331,111 @@ clopenness-equivalent-to-well-inside-itself F U =
   γ = 𝟎-is-bottom F U
 
 \end{code}
+
+\begin{code}
+
+well-inside-upwards : (F : frame 𝓤 𝓥 𝓦) (U₁ U₂ V : ⟨ F ⟩)
+                    → (U₁ ⋜[ F ] V) holds
+                    → (U₂ ⋜[ F ] V) holds
+                    → ((U₁ ∨[ F ] U₂) ⋜[ F ] V) holds
+well-inside-upwards F U₁ U₂ V =
+ ∥∥-rec₂ (holds-is-prop ((U₁ ∨[ F ] U₂) ⋜[ F ] V)) γ
+  where
+   open PosetReasoning (poset-of F)
+
+   γ : U₁ ⋜₀[ F ] V → U₂ ⋜₀[ F ] V → ((U₁ ∨[ F ] U₂) ⋜[ F ] V) holds
+   γ (W₁ , c₁ , d₁) (W₂ , c₂ , d₂) = ∣ (W₁ ∧[ F ] W₂) , c , d ∣
+    where
+     δ : (W₁ ∧[ F ] W₂) ∧[ F ] U₂ ≡ 𝟎[ F ]
+     δ = (W₁ ∧[ F ] W₂) ∧[ F ] U₂  ≡⟨ (∧[ F ]-is-associative W₁ W₂ U₂) ⁻¹ ⟩
+         W₁ ∧[ F ] (W₂ ∧[ F ] U₂)  ≡⟨ †                                   ⟩
+         W₁ ∧[ F ] (U₂ ∧[ F ] W₂)  ≡⟨ ap (λ - → meet-of F W₁ -) c₂        ⟩
+         W₁ ∧[ F ] 𝟎[ F ]          ≡⟨ 𝟎-right-annihilator-for-∧ F W₁      ⟩
+         𝟎[ F ]                    ∎
+          where
+           † = ap (λ - → W₁ ∧[ F ] -) (∧[ F ]-is-commutative W₂ U₂)
+
+     ε : ((W₁ ∧[ F ] W₂) ∧[ F ] U₁) ≡ 𝟎[ F ]
+     ε = (W₁ ∧[ F ] W₂) ∧[ F ] U₁  ≡⟨ †                                   ⟩
+         (W₂ ∧[ F ] W₁) ∧[ F ] U₁  ≡⟨ (∧[ F ]-is-associative W₂ W₁ U₁) ⁻¹ ⟩
+         W₂ ∧[ F ] (W₁ ∧[ F ] U₁)  ≡⟨ ‡                                   ⟩
+         W₂ ∧[ F ] (U₁ ∧[ F ] W₁)  ≡⟨ ap (λ - → W₂ ∧[ F ] -) c₁           ⟩
+         W₂ ∧[ F ] 𝟎[ F ]          ≡⟨ 𝟎-right-annihilator-for-∧ F W₂      ⟩
+         𝟎[ F ]                    ∎
+          where
+           † = ap (λ - → - ∧[ F ] U₁) (∧[ F ]-is-commutative W₁ W₂)
+           ‡ = ap (λ - → W₂ ∧[ F ] -) (∧[ F ]-is-commutative W₁ U₁)
+
+     c : ((U₁ ∨[ F ] U₂) ∧[ F ] (W₁ ∧[ F ] W₂)) ≡ 𝟎[ F ]
+     c = (U₁ ∨[ F ] U₂) ∧[ F ] (W₁ ∧[ F ] W₂)                          ≡⟨ i    ⟩
+         (W₁ ∧[ F ] W₂) ∧[ F ] (U₁ ∨[ F ] U₂)                          ≡⟨ ii   ⟩
+         ((W₁ ∧[ F ] W₂) ∧[ F ] U₁) ∨[ F ] ((W₁ ∧[ F ] W₂) ∧[ F ] U₂)  ≡⟨ iii  ⟩
+         ((W₁ ∧[ F ] W₂) ∧[ F ] U₁) ∨[ F ] 𝟎[ F ]                      ≡⟨ iv   ⟩
+         (W₁ ∧[ F ] W₂) ∧[ F ] U₁                                      ≡⟨ ε    ⟩
+         𝟎[ F ]                                                        ∎
+          where
+           i   = ∧[ F ]-is-commutative (U₁ ∨[ F ] U₂) (W₁ ∧[ F ] W₂)
+           ii  = binary-distributivity F (W₁ ∧[ F ] W₂) U₁ U₂
+           iii = ap (λ - → ((W₁ ∧[ F ] W₂) ∧[ F ] U₁) ∨[ F ] -) δ
+           iv  = 𝟎-left-unit-of-∨ F ((W₁ ∧[ F ] W₂) ∧[ F ] U₁)
+
+     d : V ∨[ F ] (W₁ ∧[ F ] W₂) ≡ 𝟏[ F ]
+     d = V ∨[ F ] (W₁ ∧[ F ] W₂)            ≡⟨ i   ⟩
+         (V ∨[ F ] W₁) ∧[ F ] (V ∨[ F ] W₂) ≡⟨ ii  ⟩
+         𝟏[ F ] ∧[ F ] (V ∨[ F ] W₂)        ≡⟨ iii ⟩
+         𝟏[ F ] ∧[ F ] 𝟏[ F ]               ≡⟨ iv  ⟩
+         𝟏[ F ] ∎
+          where
+           i   = binary-distributivity-op F V W₁ W₂
+           ii  = ap (λ - → - ∧[ F ] (V ∨[ F ] W₂)) d₁
+           iii = ap (λ - → 𝟏[ F ] ∧[ F ] -) d₂
+           iv  = 𝟏-right-unit-of-∧ F 𝟏[ F ]
+
+\end{code}
+
 \section{Definition of regularity}
 
 \begin{code}
 
-↓↓[_] : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Fam (𝓤 ⊔ 𝓥) ⟨ F ⟩
-↓↓[ F ] U = (Σ V ꞉ ⟨ F ⟩ , (V ≤[ poset-of F ] U) holds) , pr₁
+↓↓[_] : (F : frame 𝓤 𝓥 𝓦) → ⟨ F ⟩ → Fam 𝓤 ⟨ F ⟩
+↓↓[ F ] U = (Σ V ꞉ ⟨ F ⟩ , (V ⋜[ F ] U) holds) , pr₁
 
 \end{code}
 
 \begin{code}
 
-isRegular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
-isRegular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
+↓↓[_]-is-directed : (F : frame 𝓤 𝓥 𝓦)
+                  → (U : ⟨ F ⟩) → is-directed (poset-of F) (↓↓[ F ] U) holds
+↓↓[_]-is-directed F U = β , γ
+ where
+  β : ∥ index (↓↓[ F ] U) ∥
+  β = ∣ 𝟎[ F ] , 𝟎-is-well-inside-anything F U  ∣
+
+\end{code}
+
+We now want to prove that this set is upwards-closed.
+
+\begin{code}
+
+  Ψ = Ɐ i ∶ index (↓↓[ F ] U) ,
+       Ɐ j ∶ index (↓↓[ F ] U) ,
+        Ǝ k ∶ index (↓↓[ F ] U) ,
+           ((↓↓[ F ] U [ i ]) ≤[ poset-of F ] (↓↓[ F ] U [ k ])) holds
+         × ((↓↓[ F ] U [ j ]) ≤[ poset-of F ] (↓↓[ F ] U [ k ])) holds
+
+  γ : Ψ holds
+  γ i@(V₁ , p₁) j@(V₂ , p₂) =
+   ∣ ((V₁ ∨[ F ] V₂) , δ) , ∨[ F ]-upper₁ V₁ V₂ , ∨[ F ]-upper₂ V₁ V₂ ∣
+    where
+     δ : ((V₁ ∨[ F ] V₂) ⋜[ F ] U) holds
+     δ = well-inside-upwards F V₁ V₂ U p₁ p₂
+
+\end{code}
+
+\begin{code}
+
+is-regular : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥)
+is-regular F = Ɐ U ∶ ⟨ F ⟩ , U is-lub-of (↓↓[ F ] U)
  where
   open Joins (λ U V → U ≤[ poset-of F ] V)
 

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -641,6 +641,28 @@ basis-of-regular-frame F r = ∥∥-rec (holds-is-prop (has-basis F)) γ r
   γ (ℬ , δ)= ∣ ℬ , (λ U → pr₁ (δ U) , pr₁ (pr₂ (δ U))) ∣
 
 \end{code}
+\section{Zero-dimensionality}
+
+A locale L is said to be zero-dimensional iff it has a basis consisting of
+clopen elements.
+
+\begin{code}
+
+consists-of-clopens : (F : frame 𝓤 𝓥 𝓦) → (S : Fam 𝓦 ⟨ F ⟩) → Ω (𝓤 ⊔ 𝓦)
+consists-of-clopens F S = Ɐ i ∶ index S , is-clopen F (S [ i ])
+
+is-zero-dimensional₀ : frame 𝓤 𝓥 𝓦 → (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺) ̇
+is-zero-dimensional₀ {𝓦 = 𝓦} F =
+ Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
+
+is-zero-dimensional : frame 𝓤 𝓥 𝓦 → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-zero-dimensional {𝓦 = 𝓦} F =
+ Ǝ ℬ ∶ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ × consists-of-clopens F ℬ holds
+
+basis-of-zero-dimensional-frame : (F : frame 𝓤 𝓥 𝓦)
+                                → (is-zero-dimensional F ⇒ has-basis F) holds
+basis-of-zero-dimensional-frame F =
+ ∥∥-rec (holds-is-prop (has-basis F)) λ { (ℬ , δ , _) → ∣ ℬ , δ ∣ }
 ≪-implies-⋜-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
                               → is-regular F holds
                               → (U V : ⟨ F ⟩)

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -735,3 +735,37 @@ basis-of-zero-dimensional-frame F =
  ∥∥-rec (holds-is-prop (has-basis F)) λ { (ℬ , δ , _) → ∣ ℬ , δ ∣ }
 
 \end{code}
+
+Every zero-dimensional locale is regular.
+
+\begin{code}
+
+zero-dimensional-locales-are-regular : (F : frame 𝓤 𝓥 𝓦)
+                                     → is-zero-dimensional F holds
+                                     → is-regular F holds
+zero-dimensional-locales-are-regular {𝓦 = 𝓦} F =
+ ∥∥-rec (holds-is-prop (is-regular F)) γ
+  where
+   open Joins (λ x y → x ≤[ poset-of F ] y)
+
+   γ : is-zero-dimensional₀ F → is-regular F holds
+   γ (ℬ , β , ξ) = ∣ ℬ , δ ∣
+    where
+     δ : Π U ꞉ ⟨ F ⟩ ,
+          Σ J ꞉ Fam 𝓦 (index ℬ) ,
+             (U is-lub-of (fmap-syntax (_[_] ℬ) J)) holds
+           × (Π i ꞉ index J , (ℬ [ J [ i ] ] ⋜[ F ] U) holds)
+     δ U = 𝒥 , c , ε
+      where
+       𝒥 = pr₁ (β U)
+
+       c : (U is-lub-of ⁅ ℬ [ j ] ∣ j ε 𝒥 ⁆) holds
+       c = pr₂ (β U)
+
+       ε : Π i ꞉ index 𝒥 , (ℬ [ 𝒥 [ i ] ] ⋜[ F ] U) holds
+       ε i = T≤U⋜V≤W-implies-T⋜W F η ∣ ξ (𝒥 [ i ]) ∣ (pr₁ c i)
+        where
+         η : ((ℬ [ 𝒥 [ i ] ]) ≤[ poset-of F ] (ℬ [ 𝒥 [ i ] ])) holds
+         η = ≤-is-reflexive (poset-of F) (ℬ [ 𝒥 [ i ] ])
+
+\end{code}

--- a/source/CompactRegular.lagda
+++ b/source/CompactRegular.lagda
@@ -596,8 +596,51 @@ clopens-are-compact-in-compact-frames F κ U =
 
 \end{code}
 
+\section{Regularity}
+
 \begin{code}
 
+is-regular : (F : frame 𝓤 𝓥 𝓦) → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
+is-regular {𝓤 = 𝓤} {𝓥} {𝓦} F =
+ let
+  open Joins (λ x y → x ≤[ poset-of F ] y)
+
+  P : Fam 𝓦 ⟨ F ⟩ → 𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ̇ 
+  P ℬ = Π x ꞉ ⟨ F ⟩ ,
+         Σ J ꞉ Fam 𝓦 (index ℬ) ,
+            (x is-lub-of ⁅ ℬ [ j ] ∣ j ε J ⁆) holds
+          × (Π i ꞉ index J , (ℬ [ J [ i ] ] ⋜[ F ] x) holds)
+ in
+  Ǝ ℬ ∶ Fam 𝓦 ⟨ F ⟩ , P ℬ
+
+is-regular-basis : (F : frame 𝓤 𝓥 𝓦)
+                 → (ℬ : Fam 𝓦 ⟨ F ⟩) → (β : is-basis-for F ℬ) → Ω (𝓤 ⊔ 𝓦)
+is-regular-basis F ℬ β =
+ Ɐ U ∶ ⟨ F ⟩ ,
+  let 𝒥 = pr₁ (β U) in
+   Ɐ j ∶ (index 𝒥) , ℬ [ 𝒥 [ j ] ] ⋜[ F ] U
+
+is-regular₀ : (F : frame 𝓤 𝓥 𝓦) → (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺) ̇ 
+is-regular₀ {𝓤 = 𝓤} {𝓥} {𝓦} F =
+ let
+  open Joins (λ x y → x ≤[ poset-of F ] y)
+
+  P : Fam 𝓦 ⟨ F ⟩ → 𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺ ̇ 
+  P ℬ = Π x ꞉ ⟨ F ⟩ ,
+         Σ J ꞉ Fam 𝓦 (index ℬ) ,
+            (x is-lub-of ⁅ ℬ [ j ] ∣ j ε J ⁆) holds
+          × (Π i ꞉ index J , (ℬ [ J [ i ] ] ⋜[ F ] x) holds)
+ in
+  Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ , P ℬ
+
+basis-of-regular-frame : (F : frame 𝓤 𝓥 𝓦)
+                       → (is-regular F ⇒ has-basis F) holds
+basis-of-regular-frame F r = ∥∥-rec (holds-is-prop (has-basis F)) γ r
+ where
+  γ : is-regular₀ F → has-basis F holds
+  γ (ℬ , δ)= ∣ ℬ , (λ U → pr₁ (δ U) , pr₁ (pr₂ (δ U))) ∣
+
+\end{code}
 ≪-implies-⋜-in-regular-frames : (F : frame 𝓤 𝓥 𝓦)
                               → is-regular F holds
                               → (U V : ⟨ F ⟩)

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -791,6 +791,41 @@ distributivity′ F x S =
    ‡ = ∧[ F ]-is-commutative x ∘ (_[_] S)
    † = ap (λ - → join-of F (index S , -)) (dfunext fe ‡)
 
+absorption-right : (F : frame 𝓤 𝓥 𝓦) (x y : ⟨ F ⟩)
+                 → x ∨[ F ] (x ∧[ F ] y) ≡ x
+absorption-right F x y = ≤-is-antisymmetric (poset-of F) β γ
+ where
+  β : ((x ∨[ F ] (x ∧[ F ] y)) ≤[ poset-of F ] x) holds
+  β = ∨[ F ]-least (≤-is-reflexive (poset-of F) x) (∧[ F ]-lower₁ x y)
+
+  γ : (x ≤[ poset-of F ] (x ∨[ F ] (x ∧[ F ] y))) holds
+  γ = ∨[ F ]-upper₁ x (x ∧[ F ] y)
+
+absorption-left : (F : frame 𝓤 𝓥 𝓦) (x y : ⟨ F ⟩)
+                → x ∨[ F ] (y ∧[ F ] x) ≡ x
+absorption-left F x y =
+ x ∨[ F ] (y ∧[ F ] x) ≡⟨ ap (λ - → x ∨[ F ] -) (∧[ F ]-is-commutative y x) ⟩
+ x ∨[ F ] (x ∧[ F ] y) ≡⟨ absorption-right F x y                            ⟩
+ x                     ∎
+
+absorptionᵒᵖ-right : (F : frame 𝓤 𝓥 𝓦) → (x y : ⟨ F ⟩) → x ∧[ F ] (x ∨[ F ] y) ≡ x
+absorptionᵒᵖ-right F x y = ≤-is-antisymmetric (poset-of F) β γ
+ where
+  β : ((x ∧[ F ] (x ∨[ F ] y)) ≤[ poset-of F ] x) holds
+  β = ∧[ F ]-lower₁ x (x ∨[ F ] y)
+
+  γ : (x ≤[ poset-of F ] (x ∧[ F ] (x ∨[ F ] y))) holds
+  γ = ∧[ F ]-greatest x (x ∨[ F ] y) x
+       (≤-is-reflexive (poset-of F) x)
+       (∨[ F ]-upper₁ x y)
+
+absorptionᵒᵖ-left : (F : frame 𝓤 𝓥 𝓦) (x y : ⟨ F ⟩)
+                  → x ∧[ F ] (y ∨[ F ] x) ≡ x
+absorptionᵒᵖ-left F x y =
+ x ∧[ F ] (y ∨[ F ] x)  ≡⟨ ap (λ - → x ∧[ F ] -) (∨[ F ]-is-commutative y x) ⟩
+ x ∧[ F ] (x ∨[ F ] y)  ≡⟨ absorptionᵒᵖ-right F x y                          ⟩
+ x                      ∎
+
 binary-distributivity : (F : frame 𝓤 𝓥 𝓦)
                       → (x y z : ⟨ F ⟩)
                       → x ∧[ F ] (y ∨[ F ] z) ≡ (x ∧[ F ] y) ∨[ F ] (x ∧[ F ] z)

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -1054,12 +1054,14 @@ is-directed F (I , β) =
  ∧ (Ɐ i ∶ I , Ɐ j ∶ I , (Ǝ k ∶ I , ((β i ≤ β k) ∧ (β j ≤ β k)) holds))
   where open PosetNotation (poset-of F)
 
+has-directed-basis₀ : (F : frame 𝓤 𝓥 𝓦) → (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺) ̇ 
+has-directed-basis₀ {𝓦 = 𝓦} F =
+ Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ ,
+  Σ b ꞉ is-basis-for F ℬ ,
+   Π x ꞉ ⟨ F ⟩ , is-directed F (⁅ ℬ [ i ] ∣ i ε pr₁ (b x) ⁆) holds
+
 has-directed-basis : (F : frame 𝓤 𝓥 𝓦) → Ω (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⁺)
-has-directed-basis {𝓦 = 𝓦} F =
- ∥ Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩
- , Σ b ꞉ is-basis-for F ℬ ,
-    Π x ꞉ ⟨ F ⟩ ,
-     is-directed F (⁅ ℬ [ i ] ∣ i ε pr₁ (b x) ⁆) holds ∥Ω
+has-directed-basis {𝓦 = 𝓦} F = ∥ has-directed-basis₀ F ∥Ω
 
 \end{code}
 

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -1198,6 +1198,79 @@ directify-preserves-joins₀ F S x p =
 
 \begin{code}
 
+directified-basis-is-basis : (F : frame 𝓤 𝓥 𝓦)
+                           → (ℬ : Fam 𝓦 ⟨ F ⟩)
+                           → is-basis-for F ℬ
+                           → is-basis-for F (directify F ℬ)
+directified-basis-is-basis {𝓦 = 𝓦} F ℬ β = β↑
+ where
+  open PosetNotation (poset-of F)
+  open Joins (λ x y → x ≤ y)
+
+  ℬ↑ = directify F ℬ
+
+  𝒥 : ⟨ F ⟩ → Fam 𝓦 (index ℬ)
+  𝒥 x = pr₁ (β x)
+
+  𝒦 : ⟨ F ⟩ → Fam 𝓦 (List (index ℬ))
+  𝒦 x = List (index (𝒥 x)) , (λ - → 𝒥 x [ - ]) <$>_
+
+  φ : (x : ⟨ F ⟩)
+    → (is : List (index (𝒥 x)))
+    → directify F ℬ [ (λ - → 𝒥 x [ - ]) <$> is ]
+    ≡ directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆ [ is ]
+  φ x []       = refl
+  φ x (i ∷ is) = ap (λ - → (_ ∨[ F ] -)) (φ x is)
+
+  ψ : (x : ⟨ F ⟩)
+    → ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ ≡ directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
+  ψ x = to-Σ-≡ (refl , dfunext fe (φ x))
+
+  β↑ : (x : ⟨ F ⟩)
+     → Σ J ꞉ Fam 𝓦 (index ℬ↑) , (x is-lub-of ⁅ ℬ↑ [ j ] ∣ j ε J ⁆) holds
+  β↑ x = 𝒦 x , transport (λ - → (x is-lub-of -) holds) (ψ x ⁻¹) δ
+    where
+    p : (x is-lub-of ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆) holds
+    p = pr₂ (β x)
+
+    δ : (x is-lub-of directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆) holds
+    δ = directify-preserves-joins₀ F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆ x p
+
+  δ : (x : ⟨ F ⟩)
+    → is-directed F ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ holds
+  δ x = transport (λ - → is-directed F - holds) (ψ x ⁻¹) ε
+    where
+    ε = directify-is-directed F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
+
+covers-of-directified-basis-are-directed : (F : frame 𝓤 𝓥 𝓦)
+                                         → (ℬ : Fam 𝓦 ⟨ F ⟩)
+                                         → (β : is-basis-for F ℬ)
+                                         → (x : ⟨ F ⟩)
+                                         → let
+                                            ℬ↑ = directify F ℬ
+                                            β↑ = directified-basis-is-basis F ℬ β
+                                            𝒥↑ = pr₁ (β↑ x)
+                                           in
+                                            is-directed F (⁅ ℬ↑ [ i ] ∣ i ε 𝒥↑ ⁆) holds
+covers-of-directified-basis-are-directed {𝓦 = 𝓦} F ℬ β x =
+ transport (λ - → is-directed F - holds) (ψ ⁻¹) ε
+  where
+   𝒥 = pr₁ (β x)
+
+   𝒦 : Fam 𝓦 (List (index ℬ))
+   𝒦 = ⁅ (λ - → 𝒥 [ - ]) <$> is ∣ is ∶ List (index 𝒥) ⁆
+
+   φ : (is : List (index 𝒥))
+     → directify F ℬ [ (λ - → 𝒥 [ - ]) <$> is ]
+     ≡ directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 ⁆ [ is ]
+   φ []       = refl
+   φ (i ∷ is) = ap (λ - → (_ ∨[ F ] -)) (φ is)
+
+   ψ : ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 ⁆ ≡ directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 ⁆
+   ψ = to-Σ-≡ (refl , dfunext fe φ)
+
+   ε = directify-is-directed F ⁅ ℬ [ j ] ∣ j ε 𝒥 ⁆
+
 directify-basis : (F : frame 𝓤 𝓥 𝓦)
                 → (has-basis F ⇒ has-directed-basis F) holds
 directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis F)) γ
@@ -1207,12 +1280,12 @@ directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis 
   open Joins (λ x y → x ≤ y)
 
   γ : Σ ℬ ꞉ Fam 𝓦 ⟨ F ⟩ , is-basis-for F ℬ → has-directed-basis F holds
-  γ (ℬ@(I , _) , b) = ∣ directify F ℬ , β , δ ∣
+  γ (ℬ , β) = ∣ directify F ℬ , (directified-basis-is-basis F ℬ β) , δ ∣
    where
-    𝒥 : ⟨ F ⟩ → Fam 𝓦 I
-    𝒥 x = pr₁ (b x)
+    𝒥 : ⟨ F ⟩ → Fam 𝓦 (index ℬ)
+    𝒥 x = pr₁ (β x)
 
-    𝒦 : ⟨ F ⟩ → Fam 𝓦 (List I)
+    𝒦 : ⟨ F ⟩ → Fam 𝓦 (List (index ℬ))
     𝒦 x = List (index (𝒥 x)) , (λ - → 𝒥 x [ - ]) <$>_
 
     φ : (x : ⟨ F ⟩)
@@ -1225,17 +1298,6 @@ directify-basis {𝓦 = 𝓦} F = ∥∥-rec (holds-is-prop (has-directed-basis 
     ψ : (x : ⟨ F ⟩)
       → ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ ≡ directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆
     ψ x = to-Σ-≡ (refl , dfunext fe (φ x))
-
-    β : (x : ⟨ F ⟩)
-      → Σ J ꞉ Fam 𝓦 (List I)
-        , (x is-lub-of ⁅ directify F ℬ [ j ] ∣ j ε J ⁆) holds
-    β x = 𝒦 x , transport (λ - → (x is-lub-of -) holds) (ψ x ⁻¹) δ
-     where
-      p : (x is-lub-of ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆) holds
-      p = pr₂ (b x)
-
-      δ : (x is-lub-of directify F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆) holds
-      δ = directify-preserves-joins₀ F ⁅ ℬ [ j ] ∣ j ε 𝒥 x ⁆ x p
 
     δ : (x : ⟨ F ⟩)
       → is-directed F ⁅ directify F ℬ [ is ] ∣ is ε 𝒦 x ⁆ holds

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -742,6 +742,52 @@ frame-morphisms-are-monotonic F G f (_ , ψ , _) (x , y) p =
   γ : (Ɐ (l , _) ∶ lower-bound (y , x) , l ≤ (x ∧[ F ] y)) holds
   γ (l , p , q) = ∧[ F ]-greatest x y l q p
 
+∧[_]-is-associative : (F : frame 𝓤 𝓥 𝓦) (x y z : ⟨ F ⟩)
+                    → x ∧[ F ] (y ∧[ F ] z) ≡ (x ∧[ F ] y) ∧[ F ] z
+∧[ F ]-is-associative x y z = ≤-is-antisymmetric (poset-of F) β γ
+ where
+  open PosetReasoning (poset-of F)
+
+  abstract
+   β : ((x ∧[ F ] (y ∧[ F ] z)) ≤[ poset-of F ] ((x ∧[ F ] y) ∧[ F ] z)) holds
+   β = ∧[ F ]-greatest (x ∧[ F ] y) z (x ∧[ F ] (y ∧[ F ] z)) δ ε
+    where
+     δ : ((x ∧[ F ] (y ∧[ F ] z)) ≤[ poset-of F ] (x ∧[ F ] y)) holds
+     δ = ∧[ F ]-greatest x y (x ∧[ F ] (y ∧[ F ] z)) δ₁ δ₂
+      where
+       δ₁ : ((x ∧[ F ] (y ∧[ F ] z)) ≤[ poset-of F ] x) holds
+       δ₁ = ∧[ F ]-lower₁ x (y ∧[ F ] z)
+
+       δ₂ : ((x ∧[ F ] (y ∧[ F ] z)) ≤[ poset-of F ] y) holds
+       δ₂ = x ∧[ F ] (y ∧[ F ] z) ≤⟨ ∧[ F ]-lower₂ x (y ∧[ F ] z) ⟩
+            y ∧[ F ] z            ≤⟨ ∧[ F ]-lower₁ y z            ⟩
+            y                     ■
+
+     ε : ((x ∧[ F ] (y ∧[ F ] z)) ≤[ poset-of F ] z) holds
+     ε = x ∧[ F ] (y ∧[ F ] z)  ≤⟨ ∧[ F ]-lower₂ x (y ∧[ F ] z) ⟩
+         y ∧[ F ] z             ≤⟨ ∧[ F ]-lower₂ y z            ⟩
+         z                      ■
+
+   γ : (((x ∧[ F ] y) ∧[ F ] z) ≤[ poset-of F ] (x ∧[ F ] (y ∧[ F ] z))) holds
+   γ = ∧[ F ]-greatest x (y ∧[ F ] z) ((x ∧[ F ] y) ∧[ F ] z) ζ η
+    where
+     ζ : (((x ∧[ F ] y) ∧[ F ] z) ≤[ poset-of F ] x) holds
+     ζ = (x ∧[ F ] y) ∧[ F ] z     ≤⟨ ∧[ F ]-lower₁ (x ∧[ F ] y) z ⟩
+         x ∧[ F ] y                ≤⟨ ∧[ F ]-lower₁ x y            ⟩
+         x                         ■
+
+     η : (((x ∧[ F ] y) ∧[ F ] z) ≤[ poset-of F ] (y ∧[ F ] z)) holds
+     η = ∧[ F ]-greatest y z ((x ∧[ F ] y) ∧[ F ] z) η₀ η₁
+      where
+       η₀ : (((x ∧[ F ] y) ∧[ F ] z) ≤[ poset-of F ] y) holds
+       η₀ = (x ∧[ F ] y) ∧[ F ] z  ≤⟨ ∧[ F ]-lower₁ (x ∧[ F ] y) z ⟩
+            x ∧[ F ] y             ≤⟨ ∧[ F ]-lower₂ x y            ⟩
+            y                      ■
+
+       η₁ : (((x ∧[ F ] y) ∧[ F ] z) ≤[ poset-of F ] z) holds
+       η₁ = ∧[ F ]-lower₂ (x ∧[ F ] y) z
+
+\end{code}
 \end{code}
 
 \begin{code}

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -837,6 +837,35 @@ binary-distributivity {𝓦 = 𝓦} F x y z =
    † = distributivity F x (binary-family 𝓦 y z)
    ‡ = ap (λ - → join-of F -) (fmap-binary-family 𝓦 (λ - → x ∧[ F ] -) y z)
 
+binary-distributivity-op : (F : frame 𝓤 𝓥 𝓦) (x y z : ⟨ F ⟩)
+                         → x ∨[ F ] (y ∧[ F ] z) ≡ (x ∨[ F ] y) ∧[ F ] (x ∨[ F ] z)
+binary-distributivity-op F x y z =
+ x ∨[ F ] (y ∧[ F ] z)                                   ≡⟨ †    ⟩
+ x ∨[ F ] ((z ∧[ F ] x) ∨[ F ] (z ∧[ F ] y))             ≡⟨ I    ⟩
+ x ∨[ F ] (z ∧[ F ] (x ∨[ F ] y))                        ≡⟨ II   ⟩
+ x ∨[ F ] ((x ∨[ F ] y) ∧[ F ] z)                        ≡⟨ III  ⟩
+ (x ∧[ F ] (x ∨[ F ] y)) ∨[ F ] ((x ∨[ F ] y) ∧[ F ] z)  ≡⟨ IV   ⟩
+ ((x ∨[ F ] y) ∧[ F ] x) ∨[ F ] ((x ∨[ F ] y) ∧[ F ] z)  ≡⟨ V    ⟩
+ (x ∨[ F ] y) ∧[ F ] (x ∨[ F ] z)                        ∎
+  where
+   w   = (x ∨[ F ] y) ∧[ F ] z
+
+   I   = ap (λ - → x ∨[ F ] -) ((binary-distributivity F z x y) ⁻¹)
+   II  = ap (λ - → x ∨[ F ] -) (∧[ F ]-is-commutative z (x ∨[ F ] y))
+   III = ap (λ - → - ∨[ F ] w) (absorptionᵒᵖ-right F x y) ⁻¹
+   IV  = ap (λ - → - ∨[ F ] w) (∧[ F ]-is-commutative x (x ∨[ F ] y))
+   V   = (binary-distributivity F (x ∨[ F ] y) x z) ⁻¹
+
+   † : x ∨[ F ] (y ∧[ F ] z) ≡ x ∨[ F ] ((z ∧[ F ] x) ∨[ F ] (z ∧[ F ] y))
+   † = x ∨[ F ] (y ∧[ F ] z)                        ≡⟨ i    ⟩
+       (x ∨[ F ] (z ∧[ F ] x)) ∨[ F ] (y ∧[ F ] z)  ≡⟨ ii   ⟩
+       (x ∨[ F ] (z ∧[ F ] x)) ∨[ F ] (z ∧[ F ] y)  ≡⟨ iii  ⟩
+       x ∨[ F ] ((z ∧[ F ] x) ∨[ F ] (z ∧[ F ] y))  ∎
+        where
+         i   = ap (λ - → - ∨[ F ] (y ∧[ F ] z)) (absorption-left F x z) ⁻¹
+         ii  = ap (λ - → (x ∨[ F ] (z ∧[ F ] x)) ∨[ F ] -) (∧[ F ]-is-commutative y z)
+         iii = ∨[ F ]-assoc x (z ∧[ F ] x) (z ∧[ F ] y)
+
 \end{code}
 
 \begin{code}

--- a/source/Frame.lagda
+++ b/source/Frame.lagda
@@ -788,6 +788,35 @@ frame-morphisms-are-monotonic F G f (_ , ψ , _) (x , y) p =
        η₁ = ∧[ F ]-lower₂ (x ∧[ F ] y) z
 
 \end{code}
+
+\begin{code}
+
+∧[_]-left-monotone : (F : frame 𝓤 𝓥 𝓦)
+                   → {x y z : ⟨ F ⟩}
+                   → (x ≤[ poset-of F ] y) holds
+                   → ((x ∧[ F ] z) ≤[ poset-of F ] (y ∧[ F ] z)) holds
+∧[ F ]-left-monotone {x} {y} {z} p = ∧[ F ]-greatest y z (x ∧[ F ] z) β γ
+ where
+  open PosetReasoning (poset-of F)
+
+  β : ((x ∧[ F ] z) ≤[ poset-of F ] y) holds
+  β = x ∧[ F ] z ≤⟨ ∧[ F ]-lower₁ x z ⟩ x ≤⟨ p ⟩ y ■
+
+  γ : ((x ∧[ F ] z) ≤[ poset-of F ] z) holds
+  γ = ∧[ F ]-lower₂ x z
+
+∧[_]-right-monotone : (F : frame 𝓤 𝓥 𝓦)
+                    → {x y z : ⟨ F ⟩}
+                    → (x ≤[ poset-of F ] y) holds
+                    → ((z ∧[ F ] x) ≤[ poset-of F ] (z ∧[ F ] y)) holds
+∧[ F ]-right-monotone {x} {y} {z} p =
+ z ∧[ F ] x  ≡⟨ ∧[ F ]-is-commutative z x ⟩ₚ
+ x ∧[ F ] z  ≤⟨ ∧[ F ]-left-monotone p    ⟩
+ y ∧[ F ] z  ≡⟨ ∧[ F ]-is-commutative y z ⟩ₚ
+ z ∧[ F ] y  ■
+  where
+   open PosetReasoning (poset-of F)
+
 \end{code}
 
 \begin{code}


### PR DESCRIPTION
In PR #67, I added a proof of the fact that the well inside relation implies the way below relation in compact frames. This PR adds a proof of the converse statement for regular locales. I actually did not have a predicatively satisfactory definition of regularity in the previous PR so I had to re-define it here.

Here is a more specific list of things added in this PR:

1. Definition of regularity.
2. Definition of zero-dimensionality.
3. Proof of the fact that zero-dimensionality implies regularity.
4. Definition of Stone locale as compact and zero-dimensional.
5. Proof of the fact that, in any regular locale, `U ≪ V` implies `U ⋜ V`.
    1. Compact opens are therefore clopen in regular locales.
6. By (3) and (5.i), clopens and the compact opens coincide in any Stone frame.