### PR TITLE
New file on Kuratowski finite subsets

### DIFF
--- a/source/FreeJoinSemiLattice.lagda
+++ b/source/FreeJoinSemiLattice.lagda
@@ -64,6 +64,8 @@ then there is a *unique* mediating map f♭ : 𝓚 X → L such that:
           𝓚 X
      commutes.
 
+The map η : X → 𝓚 X is given by mapping x to the singleton subset ❴ x ❵.
+
 The idea in defining f♭ is to map a Kuratowski finite subset A to the finite
 join ∨ⁿ (f ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e) in L, where e is some eumeration
 (i.e. surjection) e : Fin n ↠ 𝕋 ⟨ A ⟩.
@@ -96,6 +98,9 @@ module _
 
   open singleton-subsets X-is-set
   open singleton-Kuratowski-finite-subsets X-is-set
+
+  η : X → 𝓚 X
+  η x = ❴ x ❵[𝓚]
 
 \end{code}
 
@@ -179,18 +184,16 @@ We show (ii) and then (i) now.
 
 \begin{code}
 
-  f♭-after-η-is-f : f♭ ∘ ❴_❵[𝓚] ∼ f
-  f♭-after-η-is-f x = f♭ ❴ x ❵[𝓚]     ≡⟨ I  ⟩
-                      fₛ A (1 , e , σ) ≡⟨ II ⟩
-                      f x              ∎
+  f♭-after-η-is-f : f♭ ∘ η ∼ f
+  f♭-after-η-is-f x = f♭ (η x)             ≡⟨ I  ⟩
+                      fₛ ❴ x ❵ (1 , e , σ) ≡⟨ II ⟩
+                      f x                  ∎
    where
-    A : 𝓟 X
-    A = ❴ x ❵
-    e : Fin 1 → 𝕋 A
+    e : Fin 1 → 𝕋 ❴ x ❵
     e 𝟎 = x , refl
     σ : is-surjection e
     σ (x , refl) = ∣ 𝟎 , refl ∣
-    I = f♭-in-terms-of-fₛ A σ ⟨ ❴ x ❵[𝓚] ⟩₂
+    I = f♭-in-terms-of-fₛ ❴ x ❵ σ ⟨ η x ⟩₂
     II = ⊑-is-antisymmetric _ _
           (∨-is-lowerbound-of-upperbounds _ _ _
            (⊥-is-least (f x)) (⊑-is-reflexive (f x)))
@@ -340,7 +343,7 @@ is proved in UF-Powerset-Fin.lagda.
    f♭-is-unique : (h : 𝓚 X → L)
                 → h ∅[𝓚] ≡ ⊥
                 → ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
-                → (h ∘ ❴_❵[𝓚] ∼ f)
+                → (h ∘ η ∼ f)
                 → h ∼ f♭
    f♭-is-unique h p₁ p₂ p₃ = Kuratowski-finite-subset-induction pe fe
                              X X-is-set
@@ -352,10 +355,10 @@ is proved in UF-Powerset-Fin.lagda.
      q₁ = h ∅[𝓚]  ≡⟨ p₁                ⟩
           ⊥       ≡⟨ f♭-preserves-⊥ ⁻¹ ⟩
           f♭ ∅[𝓚] ∎
-     q₂ : (x : X) → h ❴ x ❵[𝓚] ≡ f♭ ❴ x ❵[𝓚]
-     q₂ x = h ❴ x ❵[𝓚]  ≡⟨ p₃ x                   ⟩
-            f x         ≡⟨ (f♭-after-η-is-f x) ⁻¹ ⟩
-            f♭ ❴ x ❵[𝓚] ∎
+     q₂ : (x : X) → h (η x) ≡ f♭ (η x)
+     q₂ x = h (η x)  ≡⟨ p₃ x                   ⟩
+            f x      ≡⟨ (f♭-after-η-is-f x) ⁻¹ ⟩
+            f♭ (η x) ∎
      q₃ : (A B : 𝓚 X)
         → h A ≡ f♭ A
         → h B ≡ f♭ B
@@ -382,13 +385,13 @@ subsingletons (as L is a set).
    homotopy-uniqueness-of-f♭ :
     ∃! h ꞉ (𝓚 X → L) , (h ∅[𝓚] ≡ ⊥)
                      × ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
-                     × h ∘ ❴_❵[𝓚] ∼ f
+                     × h ∘ η ∼ f
    homotopy-uniqueness-of-f♭ =
     (f♭ , f♭-preserves-⊥ , f♭-preserves-∨ , f♭-after-η-is-f) , γ
      where
       γ : (t : (Σ h ꞉ (𝓚 X → L) , (h ∅[𝓚] ≡ ⊥)
                                 × ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
-                                × h ∘ ❴_❵[𝓚] ∼ f))
+                                × h ∘ η ∼ f))
         → (f♭ , f♭-preserves-⊥ , f♭-preserves-∨ , f♭-after-η-is-f) ≡ t
       γ (h , p₁ , p₂ , p₃) = to-subtype-≡ ψ
                              (dfunext (lower-funext (𝓤 ⁺) (𝓤 ⁺) fe)
@@ -400,7 +403,7 @@ subsingletons (as L is a set).
         ψ : (k : 𝓚 X → L)
           → is-prop ((k ∅[𝓚] ≡ ⊥)
                     × ((A B : 𝓚 X) → k (A ∪[𝓚] B) ≡ (k A ∨ k B))
-                    × k ∘ ❴_❵[𝓚] ∼ f)
+                    × k ∘ η ∼ f)
         ψ k = ×-is-prop L-is-set (×-is-prop
                                    (Π-is-prop fe
                                      (λ _ → Π-is-prop (lower-funext (𝓤 ⁺) (𝓤 ⁺) fe)

--- a/source/FreeJoinSemiLattice.lagda
+++ b/source/FreeJoinSemiLattice.lagda
@@ -1,5 +1,7 @@
 Tom de Jong, 18-24 December 2020
-(Formalizing a paper proof sketch from 12 November 2020)
+
+Formalizing a paper proof sketch from 12 November 2020.
+Refactored 24 January 2022.
 
 We construct the free join-semilattice on a set X as the Kuratowski finite
 subsets of X.
@@ -8,10 +10,12 @@ subsets of X.
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
+open import SpartanMLTT
+
 open import ArithmeticViaEquivalence
 open import Fin
-open import SpartanMLTT
-open import SpartanMLTT-List hiding (⟨_⟩)
+open import Fin-Properties
+open import JoinSemiLattices
 
 open import UF-Base
 open import UF-Equiv
@@ -27,417 +31,25 @@ module FreeJoinSemiLattice
         (pt : propositional-truncations-exist)
        where
 
+open import UF-Powerset-Fin pt hiding (κ)
+
+open binary-union-of-subsets pt
+
+open Kuratowski-finiteness pt
+
 open ImageAndSurjection pt
 open PropositionalTruncation pt hiding (_∨_)
 
 \end{code}
 
-We start with some basic constructions on the powerset.
+The proof that the Kuratowski finite subsets of X denoted by 𝓚 X and ordered by
+subset inclusion is a join-semilattice (with joins given by unions) is given in
+UF-Powerset-Fin.lagda.
 
-\begin{code}
+So we proceed directly to showing that 𝓚 X is the *free* join-semilattice on a
+set X. Concretely, if L is a join-semilattice and f : X → L is any function,
+then there is a *unique* mediating map f♭ : 𝓚 X → L such that:
 
-𝕋  : {X : 𝓤 ̇ } → 𝓟 X → 𝓤 ̇
-𝕋 {𝓤} {X} A = Σ x ꞉ X , (x ∈ A)
-
-𝕋-to-carrier : {X : 𝓤 ̇ } (A : 𝓟 X) → 𝕋 A → X
-𝕋-to-carrier A = pr₁
-
-𝕋-to-membership : {X : 𝓤 ̇ } (A : 𝓟 X) (t : 𝕋 A) → (𝕋-to-carrier A t) ∈ A
-𝕋-to-membership A = pr₂
-
-⦅_⦆[_] : {X : 𝓤 ̇ } → X → is-set X → 𝓟 X
-⦅ x ⦆[ i ] = (λ y → ((y ≡ x) , i))
-
-_∪_ : {X : 𝓤 ̇ } → 𝓟 X → 𝓟 X → 𝓟 X
-(A ∪ B) x = ∥ x ∈ A + x ∈ B ∥ , ∥∥-is-prop
-
-to-∪₁ : {X : 𝓤 ̇ } (A B : 𝓟 X) {x : X} → x ∈ A → x ∈ (A ∪ B)
-to-∪₁ A B a = ∣ inl a ∣
-
-to-∪₂ : {X : 𝓤 ̇ } (A B : 𝓟 X) {x : X} → x ∈ B → x ∈ (A ∪ B)
-to-∪₂ A B b = ∣ inr b ∣
-
-∪-is-upperbound₁ : {X : 𝓤 ̇ } (A B : 𝓟 X) → A ⊆ (A ∪ B)
-∪-is-upperbound₁ A B x a = ∣ inl a ∣
-
-∪-is-upperbound₂ : {X : 𝓤 ̇ } (A B : 𝓟 X) → B ⊆ (A ∪ B)
-∪-is-upperbound₂ A B x b = ∣ inr b ∣
-
-∪-is-lowerbound-of-upperbounds : {X : 𝓤 ̇ } (A B C : 𝓟 X)
-                               → A ⊆ C → B ⊆ C → (A ∪ B) ⊆ C
-∪-is-lowerbound-of-upperbounds {𝓤} {X} A B C s t x = ∥∥-rec (∈-is-prop C x) γ
-  where
-   γ : (x ∈ A + x ∈ B) → x ∈ C
-   γ (inl a) = s x a
-   γ (inr b) = t x b
-
-\end{code}
-
-Next we define when a type is Kuratowski finite and we construct the type 𝓚 X of
-Kuratowski finite subsets of X.
-
-\begin{code}
-
-is-Kuratowski-finite :  𝓤 ̇ → 𝓤 ̇
-is-Kuratowski-finite X = ∃ n ꞉ ℕ , Σ e ꞉ (Fin n → X) , is-surjection e
-
-being-Kuratowski-finite-is-prop : {X : 𝓤 ̇ } → is-prop (is-Kuratowski-finite X)
-being-Kuratowski-finite-is-prop = ∥∥-is-prop
-
-𝓚 : 𝓤 ̇ → 𝓤 ⁺ ̇
-𝓚 X = Σ A ꞉ 𝓟 X , is-Kuratowski-finite (𝕋 A)
-
-⟨_⟩ : {X : 𝓤 ̇ } → 𝓚 X → 𝓟 X
-⟨_⟩ = pr₁
-
-⟨_⟩₂ : {X : 𝓤 ̇ } (A : 𝓚 X) → is-Kuratowski-finite (𝕋 ⟨ A ⟩)
-⟨_⟩₂ = pr₂
-
-\end{code}
-
-The empty set and singletons and Kuratowski finite subsets.
-
-\begin{code}
-
-η : {X : 𝓤 ̇ } → is-set X → X → 𝓚 X
-η i x = ⦅ x ⦆[ i ] , κ
- where
-  κ : is-Kuratowski-finite (𝕋 ⦅ x ⦆[ i ])
-  κ = ∣ 1 , e , σ ∣
-   where
-    e : Fin 1 → 𝕋 ⦅ x ⦆[ i ]
-    e 𝟎 = x , refl
-    σ : is-surjection e
-    σ (x , refl) = ∣ inr ⋆ , refl ∣
-
-from-Fin-0 : {X : 𝓤 ̇ } → Fin 0 → X
-from-Fin-0 = unique-from-𝟘
-
-∅-is-Kuratowski-finite : {X : 𝓤 ̇ }
-                       → is-Kuratowski-finite (𝕋 {𝓤} {X} ∅)
-∅-is-Kuratowski-finite = ∣ 0 , from-Fin-0 , σ ∣
- where
-  σ : (t : 𝕋 ∅) → ∃ k ꞉ Fin 0 , from-Fin-0 k ≡ t
-  σ (x , e) = unique-from-𝟘 e
-
-⊥[𝓚] : {X : 𝓤 ̇ } → 𝓚 X
-⊥[𝓚] {X} = ∅ , ∅-is-Kuratowski-finite
-
-\end{code}
-
-As a subtype of the powerset 𝓟 X, the type of Kuratowski finite subsets can be
-partially ordered by subset inclusion and is a set.
-
-\begin{code}
-
-_⊑[𝓚]_ : {X : 𝓤 ̇ } → 𝓚 X → 𝓚 X → 𝓤 ̇
-A ⊑[𝓚] B = ⟨ A ⟩ ⊆ ⟨ B ⟩
-
-⊑[𝓚]-is-reflexive : {X : 𝓤 ̇ } (A : 𝓚 X) → A ⊑[𝓚] A
-⊑[𝓚]-is-reflexive {𝓤} {X} A = ⊆-refl ⟨ A ⟩
-
-⊑[𝓚]-is-transitive : {X : 𝓤 ̇ } (A B C : 𝓚 X) → A ⊑[𝓚] B → B ⊑[𝓚] C → A ⊑[𝓚] C
-⊑[𝓚]-is-transitive {𝓤} {X} A B C = ⊆-trans ⟨ A ⟩ ⟨ B ⟩ ⟨ C ⟩
-
-module _
-        (fe : funext 𝓤 (𝓤 ⁺))
-       where
-
- ⊑[𝓚]-is-prop-valued : {X : 𝓤 ̇ } (A B : 𝓚 X) → is-prop (A ⊑[𝓚] B)
- ⊑[𝓚]-is-prop-valued {X} A B = ⊆-is-prop (lower-funext 𝓤 (𝓤 ⁺) fe) ⟨ A ⟩ ⟨ B ⟩
-
- module _
-        (pe : propext 𝓤)
-       where
-
-  ⊑[𝓚]-is-antisymmetric : {X : 𝓤 ̇ } (A B : 𝓚 X) → A ⊑[𝓚] B → B ⊑[𝓚] A → A ≡ B
-  ⊑[𝓚]-is-antisymmetric {X} A B s t =
-   to-subtype-≡ (λ _ → being-Kuratowski-finite-is-prop)
-                (subset-extensionality pe fe s t)
-
-  𝓚-is-set : {X : 𝓤 ̇ } → is-set (𝓚 X)
-  𝓚-is-set {X} = subtypes-of-sets-are-sets ⟨_⟩ s (powersets-are-sets fe pe)
-    where
-     s : left-cancellable ⟨_⟩
-     s e = to-subtype-≡ (λ _ → being-Kuratowski-finite-is-prop) e
-
-\end{code}
-
-We proceed by showing that 𝓚 X has binary joins, specifically if A and B are
-Kuratowski finite subsets, then so is A ∪ B.
-
-\begin{code}
-
-∪-enum' : {X : 𝓤 ̇ } (A B : 𝓟 X) {n m : ℕ}
-        → (Fin n → 𝕋 A)
-        → (Fin m → 𝕋 B)
-        → (Fin n + Fin m) → 𝕋 (A ∪ B)
-∪-enum' A B e f (inl k) = (𝕋-to-carrier A (e k) ,
-                           to-∪₁ A B (𝕋-to-membership A (e k)))
-∪-enum' A B e f (inr k) = (𝕋-to-carrier B (f k) ,
-                           to-∪₂ A B (𝕋-to-membership B (f k)))
-
-∪-enum : {X : 𝓤 ̇ } (A B : 𝓟 X) {n m : ℕ}
-       → (Fin n → 𝕋 A)
-       → (Fin m → 𝕋 B)
-       → Fin (n +' m) → 𝕋 (A ∪ B)
-∪-enum A B {n} {m} e f = ∪-enum' A B e f ∘ ⌜ Fin+homo n m ⌝
-
-∪-enum'-is-surjection : {X : 𝓤 ̇ } (A B : 𝓟 X) {n m : ℕ}
-                        (e : Fin n → 𝕋 A)
-                        (f : Fin m → 𝕋 B)
-                      → is-surjection e
-                      → is-surjection f
-                      → is-surjection (∪-enum' A B e f)
-∪-enum'-is-surjection A B {n} {m} e f σ τ (x , p) = ∥∥-rec ∥∥-is-prop γ p
-  where
-   γ : (x ∈ A + x ∈ B)
-     → ∃ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
-   γ (inl a) = ∥∥-functor γ₁ (σ (x , a))
-    where
-     γ₁ : (Σ k ꞉ Fin n , e k ≡ (x , a))
-        → Σ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
-     γ₁ (k , p) = inl k , to-subtype-≡ (∈-is-prop (A ∪ B)) (ap pr₁ p)
-   γ (inr b) = ∥∥-functor γ₂ (τ (x , b))
-    where
-     γ₂ : (Σ k ꞉ Fin m , f k ≡ (x , b))
-        → Σ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
-     γ₂ (k , p) = inr k , to-subtype-≡ (∈-is-prop (A ∪ B)) (ap pr₁ p)
-
-∪-enum-is-surjection : {X : 𝓤 ̇ } (A B : 𝓟 X) {n m : ℕ}
-                       (e : Fin n → 𝕋 A)
-                       (f : Fin m → 𝕋 B)
-                     → is-surjection e
-                     → is-surjection f
-                     → is-surjection (∪-enum A B e f)
-∪-enum-is-surjection A B {n} {m} e f σ τ =
- ∘-is-surjection
-  (equivs-are-surjections (⌜⌝-is-equiv (Fin+homo n m)))
-  (∪-enum'-is-surjection A B e f σ τ)
-
-_∨[𝓚]_ : {X : 𝓤 ̇ } → 𝓚 X → 𝓚 X → 𝓚 X
-_∨[𝓚]_ {𝓤} {X} (A , κ₁) (B , κ₂) = (A ∪ B) , κ
- where
-  κ : is-Kuratowski-finite (𝕋 (A ∪ B))
-  κ = ∥∥-rec being-Kuratowski-finite-is-prop γ₁ κ₁
-   where
-    γ₁ : (Σ n ꞉ ℕ , Σ e ꞉ (Fin n → 𝕋 A) , is-surjection e)
-       → is-Kuratowski-finite (𝕋 (A ∪ B))
-    γ₁ (n , e , σ) = ∥∥-rec being-Kuratowski-finite-is-prop γ₂ κ₂
-     where
-      γ₂ : (Σ m ꞉ ℕ , Σ f ꞉ (Fin m → 𝕋 B) , is-surjection f)
-         → is-Kuratowski-finite (𝕋 (A ∪ B))
-      γ₂ (m , f , τ) = ∣ (n +' m) , g , ρ ∣
-       where
-        g : Fin (n +' m) → 𝕋 (A ∪ B)
-        g = ∪-enum A B e f
-        ρ : is-surjection g
-        ρ = ∪-enum-is-surjection A B e f σ τ
-
-∨[𝓚]-is-upperbound₁ : {X : 𝓤 ̇ } (A B : 𝓚 X) → A ⊑[𝓚] (A ∨[𝓚] B)
-∨[𝓚]-is-upperbound₁ {𝓤} {X} A B = ∪-is-upperbound₁ ⟨ A ⟩ ⟨ B ⟩
-
-∨[𝓚]-is-upperbound₂ : {X : 𝓤 ̇ } (A B : 𝓚 X) → B ⊑[𝓚] (A ∨[𝓚] B)
-∨[𝓚]-is-upperbound₂ {𝓤} {X} A B = ∪-is-upperbound₂ ⟨ A ⟩ ⟨ B ⟩
-
-∨[𝓚]-is-lowerbound-of-upperbounds : {X : 𝓤 ̇ } (A B C : 𝓚 X)
-                             → A ⊑[𝓚] C → B ⊑[𝓚] C → (A ∨[𝓚] B) ⊑[𝓚] C
-∨[𝓚]-is-lowerbound-of-upperbounds {𝓤} {X} A B C =
- ∪-is-lowerbound-of-upperbounds ⟨ A ⟩ ⟨ B ⟩ ⟨ C ⟩
-
-\end{code}
-
-Finally, the empty set (considered as a Kuratowski finite subset) is of course
-the least Kuratowski finite subset.
-
-\begin{code}
-
-⊥[𝓚]-is-least : {X : 𝓤 ̇ } (A : 𝓚 X) → ⊥[𝓚] ⊑[𝓚] A
-⊥[𝓚]-is-least {𝓤} {X} A = ∅-is-least ⟨ A ⟩
-
-\end{code}
-
-We define join-semilattices using a record. We also introduce convenient helpers
-and syntax for reasoning about the order ⊑ and we construct finite joins using
-the least element and binary joins.
-
-\begin{code}
-
-record JoinSemiLattice (𝓥 𝓣 : Universe) : 𝓤ω where
-  constructor
-    joinsemilattice
-  field
-    L : 𝓥 ̇
-    L-is-set : is-set L
-    _⊑_ : L → L → 𝓣 ̇
-    ⊑-is-prop-valued : (x y : L) → is-prop (x ⊑ y)
-    ⊑-is-reflexive : (x : L) → x ⊑ x
-    ⊑-is-transitive : (x y z : L) → x ⊑ y → y ⊑ z → x ⊑ z
-    ⊑-is-antisymmetric : (x y : L) → x ⊑ y → y ⊑ x → x ≡ y
-    ⊥ : L
-    ⊥-is-least : (x : L) → ⊥ ⊑ x
-    _∨_ : L → L → L
-    ∨-is-upperbound₁ : (x y : L) → x ⊑ (x ∨ y)
-    ∨-is-upperbound₂ : (x y : L) → y ⊑ (x ∨ y)
-    ∨-is-lowerbound-of-upperbounds : (x y z : L) → x ⊑ z → y ⊑ z → (x ∨ y) ⊑ z
-
-  transitivity' : (x : L) {y z : L}
-                → x ⊑ y → y ⊑ z → x ⊑ z
-  transitivity' x {y} {z} = ⊑-is-transitive x y z
-
-  syntax transitivity' x u v = x ⊑⟨ u ⟩ v
-  infixr 0 transitivity'
-
-  reflexivity' : (x : L) → x ⊑ x
-  reflexivity' x = ⊑-is-reflexive x
-
-  syntax reflexivity' x = x ⊑∎
-  infix 1 reflexivity'
-
-  ≡-to-⊑ : {x y : L} → x ≡ y → x ⊑ y
-  ≡-to-⊑ {x} {x} refl = reflexivity' x
-
-  ∨ⁿ : {n : ℕ} → (Fin n → L) → L
-  ∨ⁿ {zero}   e = ⊥
-  ∨ⁿ {succ m} e = (∨ⁿ (e ∘ suc)) ∨ (e 𝟎)
-
-  ∨ⁿ-is-upperbound : {n : ℕ} (σ : Fin n → L)
-                   → (k : Fin n) → σ k ⊑ ∨ⁿ σ
-  ∨ⁿ-is-upperbound {succ n} σ 𝟎       = ∨-is-upperbound₂ _ _
-  ∨ⁿ-is-upperbound {succ n} σ (suc k) = σ (suc k)    ⊑⟨ IH ⟩
-                                        ∨ⁿ (σ ∘ suc) ⊑⟨ ∨-is-upperbound₁ _ _ ⟩
-                                        ∨ⁿ σ         ⊑∎
-   where
-    IH = ∨ⁿ-is-upperbound (σ ∘ suc) k
-
-  ∨ⁿ-is-lowerbound-of-upperbounds : {n : ℕ} (σ : Fin n → L)
-                                    (x : L)
-                                  → ((k : Fin n) → σ k ⊑ x)
-                                  → ∨ⁿ σ ⊑ x
-  ∨ⁿ-is-lowerbound-of-upperbounds {zero}   σ x ub = ⊥-is-least x
-  ∨ⁿ-is-lowerbound-of-upperbounds {succ n} σ x ub =
-   ∨-is-lowerbound-of-upperbounds _ _ _ u v
-    where
-     u : ∨ⁿ (σ ∘ suc) ⊑ x
-     u = ∨ⁿ-is-lowerbound-of-upperbounds {n} (σ ∘ suc) x (ub ∘ suc)
-     v : σ 𝟎 ⊑ x
-     v = ub 𝟎
-
-\end{code}
-
-The Kuratowski finite subsets are an example of a join-semilattice.
-
-\begin{code}
-
-module _
-        (pe : propext 𝓤)
-        (fe : funext 𝓤 (𝓤 ⁺))
-        (X : 𝓤 ̇ )
-        (X-is-set : is-set X)
-       where
-
-\end{code}
-
-We use copatterns instead of the below (which we left for comparison),
-because copatterns are said to avoid unnecessary unfoldings in
-typechecking.
-
-\begin{code}
-
- 𝓚-join-semilattice : JoinSemiLattice (𝓤 ⁺) 𝓤
- JoinSemiLattice.L                              𝓚-join-semilattice = 𝓚 X
- JoinSemiLattice.L-is-set                       𝓚-join-semilattice = 𝓚-is-set fe pe
- JoinSemiLattice._⊑_                            𝓚-join-semilattice = _⊑[𝓚]_
- JoinSemiLattice.⊑-is-prop-valued               𝓚-join-semilattice = ⊑[𝓚]-is-prop-valued fe
- JoinSemiLattice.⊑-is-reflexive                 𝓚-join-semilattice = ⊑[𝓚]-is-reflexive
- JoinSemiLattice.⊑-is-transitive                𝓚-join-semilattice = ⊑[𝓚]-is-transitive
- JoinSemiLattice.⊑-is-antisymmetric             𝓚-join-semilattice = ⊑[𝓚]-is-antisymmetric fe pe
- JoinSemiLattice.⊥                              𝓚-join-semilattice = ⊥[𝓚]
- JoinSemiLattice.⊥-is-least                     𝓚-join-semilattice = ⊥[𝓚]-is-least
- JoinSemiLattice._∨_                            𝓚-join-semilattice = _∨[𝓚]_
- JoinSemiLattice.∨-is-upperbound₁               𝓚-join-semilattice = ∨[𝓚]-is-upperbound₁
- JoinSemiLattice.∨-is-upperbound₂               𝓚-join-semilattice = ∨[𝓚]-is-upperbound₂
- JoinSemiLattice.∨-is-lowerbound-of-upperbounds 𝓚-join-semilattice = ∨[𝓚]-is-lowerbound-of-upperbounds
-
- {-
- 𝓚-join-semilattice = joinsemilattice
-                        (𝓚 X)
-                        (𝓚-is-set fe pe)
-                        _⊑[𝓚]_
-                        (⊑[𝓚]-is-prop-valued fe)
-                        ⊑[𝓚]-is-reflexive
-                        ⊑[𝓚]-is-transitive
-                        (⊑[𝓚]-is-antisymmetric fe pe)
-                        ⊥[𝓚]
-                        ⊥[𝓚]-is-least
-                        _∨[𝓚]_
-                        ∨[𝓚]-is-upperbound₁
-                        ∨[𝓚]-is-upperbound₂
-                        ∨[𝓚]-is-lowerbound-of-upperbounds
- -}
-
-\end{code}
-
-The following lemma is absolutely crucial. Any Kuratowski finite subset can be
-expressed as a finite join of singletons. This lemma also allows us to prove an
-abstract induction principle for Kuratowski finite subsets.
-
-\begin{code}
-
- open JoinSemiLattice 𝓚-join-semilattice
-
- Kuratowski-finite-subset-expressed-as-finite-join : (A : 𝓚 X)
-                                                     {n : ℕ}
-                                                     {e : Fin n → 𝕋 ⟨ A ⟩}
-                                                     (σ : is-surjection e)
-                                                   → A ≡ ∨ⁿ (η X-is-set
-                                                            ∘ 𝕋-to-carrier ⟨ A ⟩
-                                                            ∘ e)
- Kuratowski-finite-subset-expressed-as-finite-join A {n} {e} σ = γ
-  where
-   ε : Fin n → 𝓚 X
-   ε = η X-is-set ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e
-   γ : A ≡ ∨ⁿ ε
-   γ = ⊑[𝓚]-is-antisymmetric fe pe A (∨ⁿ ε) u v
-    where
-     u : A ⊑[𝓚] ∨ⁿ ε
-     u x a = ∥∥-rec (∈-is-prop ⟨ ∨ⁿ ε ⟩ x) μ (σ (x , a))
-      where
-       μ : (Σ k ꞉ Fin n , e k ≡ (x , a))
-         → x ∈ ⟨ ∨ⁿ ε ⟩
-       μ (k , refl) = ∨ⁿ-is-upperbound ε k x refl
-     v : ∨ⁿ ε ⊑[𝓚] A
-     v = ∨ⁿ-is-lowerbound-of-upperbounds ε A ν
-      where
-       ν : (k : Fin n) → ε k ⊑[𝓚] A
-       ν k x refl = 𝕋-to-membership ⟨ A ⟩ (e k)
-
- Kuratowski-finite-subset-induction : {𝓣 : Universe}
-                                      (P : 𝓚 X → 𝓣 ̇ )
-                                    → ((A : 𝓚 X) → is-prop (P A))
-                                    → P (⊥[𝓚])
-                                    → ((x : X) → P (η X-is-set x))
-                                    → ((A B : 𝓚 X) → P A → P B → P (A ∨[𝓚] B))
-                                    → (A : 𝓚 X) → P A
- Kuratowski-finite-subset-induction P i p₁ p₂ p₃ A = ∥∥-rec (i A) γ ⟨ A ⟩₂
-  where
-   γ : (Σ n ꞉ ℕ , Σ e ꞉ (Fin n → 𝕋 ⟨ A ⟩) , is-surjection e)
-     → P A
-   γ (n , e , σ) = transport P ϕ (ψ n (𝕋-to-carrier ⟨ A ⟩ ∘ e))
-    where
-     ϕ : ∨ⁿ (η X-is-set ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e) ≡ A
-     ϕ = (Kuratowski-finite-subset-expressed-as-finite-join A σ) ⁻¹
-     ψ : (m : ℕ) (f : Fin m → X) → P (∨ⁿ (η X-is-set ∘ f))
-     ψ zero     f = p₁
-     ψ (succ m) f = p₃
-                     (∨ⁿ (η X-is-set ∘ f ∘ suc)) ((η X-is-set ∘ f) 𝟎)
-                     (ψ m (f ∘ suc)) (p₂ (f 𝟎))
-
-\end{code}
-
-Finally we will show that 𝓚 X is the free join-semilattice on a set X.
-Concretely, if L is a join-semilattice and f : X → L is any function, then there
-is a ⋆unique⋆ mediating map f♭ : 𝓚 X → L such that:
 (i)  f♭ is a join-semilattice homomorphism, i.e.
      - f♭ preserves the least element;
      - f♭ preserves binary joins.
@@ -456,7 +68,7 @@ The idea in defining f♭ is to map a Kuratowski finite subset A to the finite
 join ∨ⁿ (f ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e) in L, where e is some eumeration
 (i.e. surjection) e : Fin n ↠ 𝕋 ⟨ A ⟩.
 
-However, since Kuratowski finite subsets come with an ⋆unspecified⋆ such
+However, since Kuratowski finite subsets come with an *unspecified* such
 enumeration, we must show that the choice of enumeration is irrelevant, i.e. any
 two enumerations give rise to the same finite join. We then use a theorem by
 Kraus et al. [1] (see wconstant-map-to-set-factors-through-truncation-of-domain)
@@ -477,10 +89,13 @@ module _
  open JoinSemiLattice 𝓛
 
  module _
-         (X : 𝓤 ̇ )
+         {X : 𝓤 ̇ }
          (X-is-set : is-set X)
          (f : X → L)
         where
+
+  open singleton-subsets X-is-set
+  open singleton-Kuratowski-finite-subsets X-is-set
 
 \end{code}
 
@@ -491,7 +106,7 @@ the choice of enumeration is irrelevant, i.e. fₛ A is weakly constant.
   fₛ : (A : 𝓟 X)
      → (Σ n ꞉ ℕ , Σ e ꞉ (Fin n → 𝕋 A) , is-surjection e)
      → L
-  fₛ A (_ , e , _) = ∨ⁿ (f ∘ pr₁ ∘ e)
+  fₛ A (_ , e , _) = ∨ⁿ (f ∘ 𝕋-to-carrier A ∘ e)
 
   fₛ-is-wconstant : (A : 𝓟 X) → wconstant (fₛ A)
   fₛ-is-wconstant A (n , e , σ) (n' , e' , σ') = ⊑-is-antisymmetric _ _ u v
@@ -505,7 +120,7 @@ the choice of enumeration is irrelevant, i.e. fₛ A is weakly constant.
       ψ k = ∥∥-rec (⊑-is-prop-valued _ _) ϕ (σ' (e k))
        where
         ϕ : (Σ k' ꞉ Fin n' , e' k' ≡ e k) → (f' ∘ e) k ⊑ ∨ⁿ (f' ∘ e')
-        ϕ (k' , p) = (f' ∘ e) k   ⊑⟨ ≡-to-⊑ (ap f' p ⁻¹) ⟩
+        ϕ (k' , p) = (f' ∘ e) k   ⊑⟨ ≡-to-⊑ (ap f' p ⁻¹)           ⟩
                      (f' ∘ e') k' ⊑⟨ ∨ⁿ-is-upperbound (f' ∘ e') k' ⟩
                      ∨ⁿ (f' ∘ e') ⊑∎
     v : ∨ⁿ (f' ∘ e') ⊑ ∨ⁿ (f' ∘ e)
@@ -515,7 +130,7 @@ the choice of enumeration is irrelevant, i.e. fₛ A is weakly constant.
       ψ k' = ∥∥-rec (⊑-is-prop-valued _ _) ϕ (σ (e' k'))
        where
         ϕ : (Σ k ꞉ Fin n , e k ≡ e' k') → (f' ∘ e') k' ⊑ ∨ⁿ (f' ∘ e)
-        ϕ (k , p) = (f' ∘ e') k' ⊑⟨ ≡-to-⊑ (ap f' p ⁻¹) ⟩
+        ϕ (k , p) = (f' ∘ e') k' ⊑⟨ ≡-to-⊑ (ap f' p ⁻¹)         ⟩
                     (f' ∘ e) k   ⊑⟨ ∨ⁿ-is-upperbound (f' ∘ e) k ⟩
                     ∨ⁿ (f' ∘ e)  ⊑∎
 
@@ -531,7 +146,7 @@ We now use the theorem by Kraus et al. to construct the map f♭ from fₛ.
     (fₛ A) (fₛ-is-wconstant A)) κ
 
   f♭-in-terms-of-fₛ : (A : 𝓟 X) {n : ℕ} {e : (Fin n → 𝕋 A)} (σ : is-surjection e)
-                      (κ : is-Kuratowski-finite (𝕋 A))
+                      (κ : is-Kuratowski-finite-subset A)
                     → f♭ (A , κ) ≡ fₛ A (n , e , σ)
   f♭-in-terms-of-fₛ A {n} {e} σ κ = f♭ (A , κ)             ≡⟨ I  ⟩
                                     f♭ (A , ∣ n , e , σ ∣) ≡⟨ II ⟩
@@ -564,62 +179,63 @@ We show (ii) and then (i) now.
 
 \begin{code}
 
-  f♭-after-η-is-f : f♭ ∘ (η X-is-set) ∼ f
-  f♭-after-η-is-f x = f♭ (η X-is-set x) ≡⟨ I  ⟩
-                      fₛ A (1 , e , σ)  ≡⟨ II ⟩
-                      f x               ∎
+  f♭-after-η-is-f : f♭ ∘ ❴_❵[𝓚] ∼ f
+  f♭-after-η-is-f x = f♭ ❴ x ❵[𝓚]     ≡⟨ I  ⟩
+                      fₛ A (1 , e , σ) ≡⟨ II ⟩
+                      f x              ∎
    where
     A : 𝓟 X
-    A = ⦅ x ⦆[ X-is-set ]
+    A = ❴ x ❵
     e : Fin 1 → 𝕋 A
     e 𝟎 = x , refl
     σ : is-surjection e
     σ (x , refl) = ∣ 𝟎 , refl ∣
-    I = f♭-in-terms-of-fₛ A σ ⟨ η X-is-set x ⟩₂
+    I = f♭-in-terms-of-fₛ A σ ⟨ ❴ x ❵[𝓚] ⟩₂
     II = ⊑-is-antisymmetric _ _
           (∨-is-lowerbound-of-upperbounds _ _ _
            (⊥-is-least (f x)) (⊑-is-reflexive (f x)))
           (∨-is-upperbound₂ _ _)
 
-  f♭-preserves-⊥ : f♭ (⊥[𝓚]) ≡ ⊥
+  f♭-preserves-⊥ : f♭ ∅[𝓚] ≡ ⊥
   f♭-preserves-⊥ = ⊑-is-antisymmetric _ _ u v
    where
-    u : f♭ ⊥[𝓚] ⊑ ⊥
-    u = f♭ ⊥[𝓚]                                        ⊑⟨ u₁ ⟩
-        ∨ⁿ (f ∘ 𝕋-to-carrier ∅ ∘ from-Fin-0 {𝓤} {𝕋 ∅}) ⊑⟨ u₂ ⟩
-        ⊥                                              ⊑∎
+    u : f♭ ∅[𝓚] ⊑ ⊥
+    u = f♭ ∅[𝓚]                     ⊑⟨ u₁ ⟩
+        ∨ⁿ (f ∘ 𝕋-to-carrier ∅ ∘ e) ⊑⟨ u₂ ⟩
+        ⊥                           ⊑∎
      where
-      σ : is-surjection (from-Fin-0 {𝓤} {𝕋 ∅})
-      σ (x , e) = unique-from-𝟘 e
-      u₁ = ≡-to-⊑ (f♭-in-terms-of-fₛ ∅ σ ∅-is-Kuratowski-finite)
+      e : Fin 0 → 𝕋 {𝓤} {X} ∅
+      e = 𝟘-elim
+      σ : is-surjection e
+      σ (x , x-in-emptyset) = 𝟘-elim x-in-emptyset
+      u₁ = ≡-to-⊑ (f♭-in-terms-of-fₛ ∅ σ ∅-is-Kuratowski-finite-subset)
       u₂ = ⊑-is-reflexive ⊥
-    v : ⊥ ⊑ f♭ ⊥[𝓚]
-    v = ⊥-is-least (f♭ ⊥[𝓚])
+    v : ⊥ ⊑ f♭ ∅[𝓚]
+    v = ⊥-is-least (f♭ ∅[𝓚])
 
   f♭-is-monotone : (A B : 𝓚 X)
                 → ((x : X) → x ∈ ⟨ A ⟩ → x ∈ ⟨ B ⟩)
                 → f♭ A ⊑ f♭ B
-  f♭-is-monotone (A , κ₁) (B , κ₂) s = ∥∥-rec (⊑-is-prop-valued _ _) γ₁ κ₁
-   where
-    γ₁ : (Σ n ꞉ ℕ , Σ e ꞉ (Fin n → 𝕋 A) , is-surjection e)
+  f♭-is-monotone 𝔸@(A , κ₁) 𝔹@(B , κ₂) s =
+   ∥∥-rec₂ (⊑-is-prop-valued (f♭ 𝔸) (f♭ 𝔹)) γ κ₁ κ₂
+    where
+     γ : (Σ n ꞉ ℕ , Fin n ↠ 𝕋 A)
+       → (Σ m ꞉ ℕ , Fin m ↠ 𝕋 B)
        → f♭ (A , κ₁) ⊑ f♭ (B , κ₂)
-    γ₁ (n , e , σ) = ∥∥-rec (⊑-is-prop-valued _ _) γ₂ κ₂
-     where
-      γ₂ : (Σ n' ꞉ ℕ , Σ e' ꞉ (Fin n' → 𝕋 B) , is-surjection e')
-         → f♭ (A , κ₁) ⊑ f♭ (B , κ₂)
-      γ₂ (n' , e' , σ') = f♭ (A , κ₁)                  ⊑⟨ u₁ ⟩
-                          ∨ⁿ (f ∘ 𝕋-to-carrier A ∘ e)  ⊑⟨ u₂ ⟩
-                          ∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e') ⊑⟨ u₃ ⟩
-                          f♭ (B , κ₂)                  ⊑∎
+     γ (n , e , e-surj) (n' , e' , e'-surj) =
+      f♭ 𝔸                         ⊑⟨ u₁ ⟩
+      ∨ⁿ (f ∘ 𝕋-to-carrier A ∘ e)  ⊑⟨ u₂ ⟩
+      ∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e') ⊑⟨ u₃ ⟩
+      f♭ 𝔹                         ⊑∎
        where
-        u₁ = ≡-to-⊑ (f♭-in-terms-of-fₛ A σ κ₁)
-        u₃ = ≡-to-⊑ ((f♭-in-terms-of-fₛ B σ' κ₂) ⁻¹)
+        u₁ = ≡-to-⊑ (f♭-in-terms-of-fₛ A e-surj κ₁)
+        u₃ = ≡-to-⊑ ((f♭-in-terms-of-fₛ B e'-surj κ₂) ⁻¹)
         u₂ = ∨ⁿ-is-lowerbound-of-upperbounds (f ∘ 𝕋-to-carrier A ∘ e)
-                                             (∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e')) γ₃
+                                             (∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e')) γ₁
          where
-          γ₃ : (k : Fin n) → (f ∘ 𝕋-to-carrier A ∘ e) k
+          γ₁ : (k : Fin n) → (f ∘ 𝕋-to-carrier A ∘ e) k
                            ⊑ ∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e')
-          γ₃ k = ∥∥-rec (⊑-is-prop-valued _ _) γ₄ t
+          γ₁ k = ∥∥-rec (⊑-is-prop-valued _ _) γ₂ t
            where
             x : X
             x = 𝕋-to-carrier A (e k)
@@ -628,10 +244,10 @@ We show (ii) and then (i) now.
             b : x ∈ B
             b = s x a
             t : ∃ k' ꞉ Fin n' , e' k' ≡ (x , b)
-            t = σ' (x , b)
-            γ₄ : (Σ k' ꞉ Fin n' , e' k' ≡ (x , b))
+            t = e'-surj (x , b)
+            γ₂ : (Σ k' ꞉ Fin n' , e' k' ≡ (x , b))
                → (f ∘ pr₁ ∘ e) k ⊑ ∨ⁿ (f ∘ pr₁ ∘ e')
-            γ₄ (k' , p) = (f ∘ 𝕋-to-carrier A) (e k)   ⊑⟨ v₁ ⟩
+            γ₂ (k' , p) = (f ∘ 𝕋-to-carrier A) (e k)   ⊑⟨ v₁ ⟩
                           (f ∘ 𝕋-to-carrier B) (e' k') ⊑⟨ v₂ ⟩
                           ∨ⁿ (f ∘ 𝕋-to-carrier B ∘ e') ⊑∎
              where
@@ -641,23 +257,23 @@ We show (ii) and then (i) now.
                 q = ap pr₁ (p ⁻¹)
               v₂ = ∨ⁿ-is-upperbound (f ∘ 𝕋-to-carrier B ∘ e') k'
 
-  f♭-preserves-∨ : (A B : 𝓚 X) → f♭ (A ∨[𝓚] B) ≡ f♭ A ∨ f♭ B
+  f♭-preserves-∨ : (A B : 𝓚 X) → f♭ (A ∪[𝓚] B) ≡ f♭ A ∨ f♭ B
   f♭-preserves-∨ A B = ⊑-is-antisymmetric _ _ u v
    where
-    v : (f♭ A ∨ f♭ B) ⊑ f♭ (A ∨[𝓚] B)
+    v : (f♭ A ∨ f♭ B) ⊑ f♭ (A ∪[𝓚] B)
     v = ∨-is-lowerbound-of-upperbounds _ _ _
-        (f♭-is-monotone A (A ∨[𝓚] B) (∨[𝓚]-is-upperbound₁ A B))
-        (f♭-is-monotone B (A ∨[𝓚] B) (∨[𝓚]-is-upperbound₂ A B))
-    u : f♭ (A ∨[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
-    u = ∥∥-rec (⊑-is-prop-valued (f♭ (A ∨[𝓚] B)) (f♭ A ∨ f♭ B)) γ₁ (⟨ A ⟩₂)
+        (f♭-is-monotone A (A ∪[𝓚] B) (∪[𝓚]-is-upperbound₁ A B))
+        (f♭-is-monotone B (A ∪[𝓚] B) (∪[𝓚]-is-upperbound₂ A B))
+    u : f♭ (A ∪[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
+    u = ∥∥-rec (⊑-is-prop-valued (f♭ (A ∪[𝓚] B)) (f♭ A ∨ f♭ B)) γ₁ (⟨ A ⟩₂)
      where
       γ₁ : (Σ n ꞉ ℕ , Σ e ꞉ (Fin n → 𝕋 ⟨ A ⟩) , is-surjection e)
-         → f♭ (A ∨[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
+         → f♭ (A ∪[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
       γ₁ (n , e , σ) = ∥∥-rec (⊑-is-prop-valued _ _) γ₂ (⟨ B ⟩₂)
        where
         γ₂ : (Σ n' ꞉ ℕ , Σ e' ꞉ (Fin n' → 𝕋 ⟨ B ⟩) , is-surjection e')
-           → f♭ (A ∨[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
-        γ₂ (n' , e' , σ') = f♭ (A ∨[𝓚] B)    ⊑⟨ l₁ ⟩
+           → f♭ (A ∪[𝓚] B) ⊑ (f♭ A ∨ f♭ B)
+        γ₂ (n' , e' , σ') = f♭ (A ∪[𝓚] B)    ⊑⟨ l₁ ⟩
                             ∨ⁿ (f' ∘ [e,e']) ⊑⟨ l₂ ⟩
                             f♭ A ∨ f♭ B      ⊑∎
          where
@@ -669,8 +285,8 @@ We show (ii) and then (i) now.
           τ = ∪-enum-is-surjection ⟨ A ⟩ ⟨ B ⟩ e e' σ σ'
           l₁ = ≡-to-⊑ p
            where
-            p : f♭ (A ∨[𝓚] B) ≡ fₛ (⟨ A ⟩ ∪ ⟨ B ⟩) (n +' n' , [e,e'] , τ)
-            p = f♭-in-terms-of-fₛ (⟨ A ⟩ ∪ ⟨ B ⟩) τ ⟨ A ∨[𝓚] B ⟩₂
+            p : f♭ (A ∪[𝓚] B) ≡ fₛ (⟨ A ⟩ ∪ ⟨ B ⟩) (n +' n' , [e,e'] , τ)
+            p = f♭-in-terms-of-fₛ (⟨ A ⟩ ∪ ⟨ B ⟩) τ ⟨ A ∪[𝓚] B ⟩₂
           l₂ = ∨ⁿ-is-lowerbound-of-upperbounds (f' ∘ [e,e']) (f♭ A ∨ f♭ B) ϕ
            where
             ϕ : (k : Fin (n +' n'))
@@ -711,7 +327,8 @@ We show (ii) and then (i) now.
 \end{code}
 
 Finally we prove that f♭ is the unique map with the above properties (i) & (ii).
-We do so by using the aforementioned induction principle.
+We do so by using the induction principle for Kuratowski finite subsets, which
+is proved in UF-Powerset-Fin.lagda.
 
 \begin{code}
 
@@ -721,9 +338,9 @@ We do so by using the aforementioned induction principle.
          where
 
    f♭-is-unique : (h : 𝓚 X → L)
-                → h ⊥[𝓚] ≡ ⊥
-                → ((A B : 𝓚 X) → h (A ∨[𝓚] B) ≡ h A ∨ h B)
-                → (h ∘ η X-is-set ∼ f)
+                → h ∅[𝓚] ≡ ⊥
+                → ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
+                → (h ∘ ❴_❵[𝓚] ∼ f)
                 → h ∼ f♭
    f♭-is-unique h p₁ p₂ p₃ = Kuratowski-finite-subset-induction pe fe
                              X X-is-set
@@ -731,22 +348,22 @@ We do so by using the aforementioned induction principle.
                              (λ _ → L-is-set)
                              q₁ q₂ q₃
     where
-     q₁ : h ⊥[𝓚] ≡ f♭ ⊥[𝓚]
-     q₁ = h ⊥[𝓚]  ≡⟨ p₁ ⟩
+     q₁ : h ∅[𝓚] ≡ f♭ ∅[𝓚]
+     q₁ = h ∅[𝓚]  ≡⟨ p₁                ⟩
           ⊥       ≡⟨ f♭-preserves-⊥ ⁻¹ ⟩
-          f♭ ⊥[𝓚] ∎
-     q₂ : (x : X) → h (η X-is-set x) ≡ f♭ (η X-is-set x)
-     q₂ x = h (η X-is-set x)  ≡⟨ p₃ x ⟩
-            f x               ≡⟨ (f♭-after-η-is-f x) ⁻¹ ⟩
-            f♭ (η X-is-set x) ∎
+          f♭ ∅[𝓚] ∎
+     q₂ : (x : X) → h ❴ x ❵[𝓚] ≡ f♭ ❴ x ❵[𝓚]
+     q₂ x = h ❴ x ❵[𝓚]  ≡⟨ p₃ x                   ⟩
+            f x         ≡⟨ (f♭-after-η-is-f x) ⁻¹ ⟩
+            f♭ ❴ x ❵[𝓚] ∎
      q₃ : (A B : 𝓚 X)
         → h A ≡ f♭ A
         → h B ≡ f♭ B
-        → h (A ∨[𝓚] B) ≡ f♭ (A ∨[𝓚] B)
-     q₃ A B r₁ r₂ = h (A ∨[𝓚] B)  ≡⟨ p₂ A B ⟩
-                    h A ∨ h B     ≡⟨ ap₂ _∨_ r₁ r₂ ⟩
+        → h (A ∪[𝓚] B) ≡ f♭ (A ∪[𝓚] B)
+     q₃ A B r₁ r₂ = h (A ∪[𝓚] B)  ≡⟨ p₂ A B                  ⟩
+                    h A ∨ h B     ≡⟨ ap₂ _∨_ r₁ r₂           ⟩
                     f♭ A ∨ f♭ B   ≡⟨ (f♭-preserves-∨ A B) ⁻¹ ⟩
-                    f♭ (A ∨[𝓚] B) ∎
+                    f♭ (A ∪[𝓚] B) ∎
 
 \end{code}
 
@@ -763,15 +380,15 @@ subsingletons (as L is a set).
          where
 
    homotopy-uniqueness-of-f♭ :
-    ∃! h ꞉ (𝓚 X → L) , (h ⊥[𝓚] ≡ ⊥)
-                     × ((A B : 𝓚 X) → h (A ∨[𝓚] B) ≡ h A ∨ h B)
-                     × h ∘ η X-is-set ∼ f
+    ∃! h ꞉ (𝓚 X → L) , (h ∅[𝓚] ≡ ⊥)
+                     × ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
+                     × h ∘ ❴_❵[𝓚] ∼ f
    homotopy-uniqueness-of-f♭ =
     (f♭ , f♭-preserves-⊥ , f♭-preserves-∨ , f♭-after-η-is-f) , γ
      where
-      γ : (t : (Σ h ꞉ (𝓚 X → L) , (h ⊥[𝓚] ≡ ⊥)
-                                × ((A B : 𝓚 X) → h (A ∨[𝓚] B) ≡ h A ∨ h B)
-                                × h ∘ η X-is-set ∼ f))
+      γ : (t : (Σ h ꞉ (𝓚 X → L) , (h ∅[𝓚] ≡ ⊥)
+                                × ((A B : 𝓚 X) → h (A ∪[𝓚] B) ≡ h A ∨ h B)
+                                × h ∘ ❴_❵[𝓚] ∼ f))
         → (f♭ , f♭-preserves-⊥ , f♭-preserves-∨ , f♭-after-η-is-f) ≡ t
       γ (h , p₁ , p₂ , p₃) = to-subtype-≡ ψ
                              (dfunext (lower-funext (𝓤 ⁺) (𝓤 ⁺) fe)
@@ -781,9 +398,9 @@ subsingletons (as L is a set).
                                          h p₁ p₂ p₃ A) ⁻¹))
        where
         ψ : (k : 𝓚 X → L)
-          → is-prop ((k ⊥[𝓚] ≡ ⊥)
-                    × ((A B : 𝓚 X) → k (A ∨[𝓚] B) ≡ (k A ∨ k B))
-                    × k ∘ η X-is-set ∼ f)
+          → is-prop ((k ∅[𝓚] ≡ ⊥)
+                    × ((A B : 𝓚 X) → k (A ∪[𝓚] B) ≡ (k A ∨ k B))
+                    × k ∘ ❴_❵[𝓚] ∼ f)
         ψ k = ×-is-prop L-is-set (×-is-prop
                                    (Π-is-prop fe
                                      (λ _ → Π-is-prop (lower-funext (𝓤 ⁺) (𝓤 ⁺) fe)
@@ -834,12 +451,12 @@ module _
        (Σ A ꞉ 𝓤 ̇ , (A ↪ X) × κ A)                         ≃⟨ ≃-refl _ ⟩
        𝓚' X                                               ■
     where
-     I  = ≃-sym (Σ-change-of-variable (λ A → is-Kuratowski-finite (𝕋 A))
+     I  = ≃-sym (Σ-change-of-variable (λ A → is-Kuratowski-finite-subset A)
                    ⌜ φ ⌝ (⌜⌝-is-equiv φ))
      II = Σ-cong (λ A → Σ-cong (λ e → ψ A e))
       where
        ψ : (A : 𝓤 ̇ ) (e : A ↪ X)
-         → κ (𝕋 (⌜ φ ⌝ (A :: e))) ≃ κ A
+         → κ (𝕋 (⌜ φ ⌝ (A , e))) ≃ κ A
        ψ A e = idtoeq (κ A') (κ A)
                 (ap κ (eqtoid (ua 𝓤) A' A lemma))
         where

--- a/source/FreeSupLattice.lagda
+++ b/source/FreeSupLattice.lagda
@@ -23,40 +23,6 @@ open PropositionalTruncation pt
 
 \end{code}
 
-We start with some basic constructions on the powerset.
-
-\begin{code}
-
-𝕋 : {X : 𝓥 ̇ } → 𝓟 X → 𝓥 ̇
-𝕋 {𝓥} {X} A = Σ x ꞉ X , (x ∈ A)
-
-𝕋-to-carrier : {X : 𝓥 ̇ } (A : 𝓟 X) → 𝕋 A → X
-𝕋-to-carrier A = pr₁
-
-𝕋-to-membership : {X : 𝓥 ̇ } (A : 𝓟 X) (t : 𝕋 A) → (𝕋-to-carrier A t) ∈ A
-𝕋-to-membership A = pr₂
-
-⦅_⦆[_] : {X : 𝓥 ̇ } → X → is-set X → 𝓟 X
-⦅ x ⦆[ i ] = (λ y → ((y ≡ x) , i))
-
-⋃  : {X I : 𝓥 ̇ } (α : I → 𝓟 X) → 𝓟 X
-⋃ {𝓥} {X} {I} α x = (∃ i ꞉ I , x ∈ α i) , ∃-is-prop
-
-⋃-is-upperbound : {X I : 𝓥 ̇ } (α : I → 𝓟 X) (i : I)
-                → α i ⊆ ⋃ α
-⋃-is-upperbound α i x a = ∣ i , a ∣
-
-⋃-is-lowerbound-of-upperbounds : {X I : 𝓥 ̇ } (α : I → 𝓟 X) (A : 𝓟 X)
-                               → ((i : I) → α i ⊆ A)
-                               → ⋃ α ⊆ A
-⋃-is-lowerbound-of-upperbounds {𝓥} {X} {I} α A ub x u =
- ∥∥-rec (∈-is-prop A x) γ u
-  where
-   γ : (Σ i ꞉ I , x ∈ α i) → x ∈ A
-   γ (i , a) = ub i x a
-
-\end{code}
-
 We define sup-lattices using a record. We also introduce convenient helpers
 and syntax for reasoning about the order ⊑.
 
@@ -122,6 +88,8 @@ as a union of singletons (this will come in useful later).
 
 \begin{code}
 
+open unions-of-small-families pt
+
 module _
         (pe : propext 𝓥)
         (fe : funext 𝓥 (𝓥 ⁺))
@@ -141,16 +109,19 @@ module _
  SupLattice.⋁-is-upperbound 𝓟-lattice                = ⋃-is-upperbound
  SupLattice.⋁-is-lowerbound-of-upperbounds 𝓟-lattice = ⋃-is-lowerbound-of-upperbounds
 
+ open singleton-subsets X-is-set
+
  express-subset-as-union-of-singletons :
-  (A : 𝓟 X) → A ≡ ⋃ {𝓥} {X} {𝕋 A} (⦅_⦆[ X-is-set ] ∘ pr₁)
+  (A : 𝓟 X) → A ≡ ⋃ {𝓥} {X} {𝕋 A} (❴_❵ ∘ (𝕋-to-carrier A))
  express-subset-as-union-of-singletons A = subset-extensionality pe fe u v
   where
-   u : A ⊆ ⋃ (⦅_⦆[ X-is-set ] ∘ pr₁)
+   u : A ⊆ ⋃ (❴_❵ ∘ (𝕋-to-carrier A))
    u x a = ∣ (x , a) , refl ∣
-   v : ⋃ (⦅_⦆[ X-is-set ] ∘ pr₁) ⊆ A
+   v : ⋃ (❴_❵ ∘ (𝕋-to-carrier A)) ⊆ A
    v x = ∥∥-rec (∈-is-prop A x) γ
     where
-     γ : (Σ i ꞉ 𝕋 A , x ∈ (⦅_⦆[ X-is-set ] ∘ pr₁) i) → x ∈ A
+     γ : (Σ i ꞉ 𝕋 A , x ∈ (❴_❵ ∘ 𝕋-to-carrier A) i)
+       → x ∈ A
      γ ((x , a) , refl) = a
 
 \end{code}
@@ -171,6 +142,8 @@ then there is a *unique* mediating map f♭ : 𝓟 X → L such that:
           𝓟 X
      commutes.
 
+(The map η : X → 𝓟 X is of course given by x ↦ ❴ x ❵.)
+
 \begin{code}
 
 module _
@@ -185,57 +158,62 @@ module _
          (f : X → L)
         where
 
+  open singleton-subsets X-is-set
+
+  f̃ : (A : 𝓟 X) → 𝕋 A → L
+  f̃ A = f ∘ (𝕋-to-carrier A)
+
   f♭ : 𝓟 X → L
-  f♭ A = ⋁ {𝕋 A} (f ∘ pr₁)
+  f♭ A = ⋁ {𝕋 A} (f̃ A)
 
   η : X → 𝓟 X
-  η = ⦅_⦆[ X-is-set ]
+  η = ❴_❵
 
   f♭-after-η-is-f : f♭ ∘ η ∼ f
   f♭-after-η-is-f x = ⊑-is-antisymmetric ((f♭ ∘ η) x) (f x) u v
    where
-    u : ⋁ (λ x₁ → f (pr₁ x₁)) ⊑ f x
-    u = ⋁-is-lowerbound-of-upperbounds (f ∘ pr₁) (f x) γ
+    u : (f♭ ∘ η) x ⊑ f x
+    u = ⋁-is-lowerbound-of-upperbounds (f̃ (η x)) (f x) γ
      where
-      γ : (i : Σ y ꞉ X , y ≡ x) → f (pr₁ i) ⊑ f x
+      γ : (i : 𝕋 (η x)) → (f̃ (η x)) i ⊑ f x
       γ (x , refl) = ⊑-is-reflexive (f x)
-    v : f x ⊑ ⋁ (λ x₁ → f (pr₁ x₁))
+    v : f x ⊑ (f♭ ∘ η) x
     v = ⋁-is-upperbound (λ (x , _) → f x) (x , refl)
 
   f♭-is-monotone : (A B : 𝓟 X) → A ⊆ B → f♭ A ⊑ f♭ B
-  f♭-is-monotone A B s = ⋁-is-lowerbound-of-upperbounds (f ∘ pr₁) (f♭ B) γ₁
+  f♭-is-monotone A B s = ⋁-is-lowerbound-of-upperbounds (f̃ A) (f♭ B) γ
    where
-    γ₁ : (i : Σ x ꞉ X , x ∈ A) → f (pr₁ i) ⊑ ⋁ (f ∘ pr₁)
-    γ₁ (x , a) = ⋁-is-upperbound (f ∘ pr₁) (x , s x a)
+    γ : (i : Σ x ꞉ X , x ∈ A) → f̃ A i ⊑ ⋁ (f̃ B)
+    γ (x , a) = ⋁-is-upperbound (f̃ B) (x , s x a)
 
   f♭-preserves-joins : (I : 𝓥 ̇ ) (α : I → 𝓟 X)
                      → f♭ (⋃ α) ≡ ⋁ (f♭ ∘ α)
   f♭-preserves-joins I α = ⊑-is-antisymmetric (f♭ (⋃ α)) (⋁ (f♭ ∘ α)) u v
    where
-    u : ⋁ (f ∘ pr₁) ⊑ ⋁ (λ (i : I) → ⋁ (f ∘ pr₁))
-    u = ⋁-is-lowerbound-of-upperbounds (f ∘ pr₁) (⋁ (λ i → ⋁ (f ∘ pr₁))) γ
+    u : ⋁ (f̃ (⋃ α)) ⊑ ⋁ (λ (i : I) → ⋁ (f̃ (α i)))
+    u = ⋁-is-lowerbound-of-upperbounds (f̃ (⋃ α)) (⋁ (λ (i : I) → ⋁ (f̃ (α i)))) γ
      where
       γ : (p : (Σ x ꞉ X , x ∈ ⋃ α))
-        → f (pr₁ p) ⊑ ⋁ (λ i → ⋁ (λ x → f (pr₁ x)))
+        → f̃ (⋃ α) p ⊑ ⋁ (λ (i : I) → ⋁ (f̃ (α i)))
       γ (x , a) = ∥∥-rec (⊑-is-prop-valued _ _) ψ a
        where
-        ψ : (Σ i ꞉ I , x ∈ α i) → f x ⊑ ⋁ (λ i' → ⋁ (f ∘ pr₁))
-        ψ (i , a') = f x                    ⊑⟨ u₁ ⟩
-                     ⋁ (f ∘ pr₁)            ⊑⟨ u₂ ⟩
-                     ⋁ (λ i' → ⋁ (f ∘ pr₁)) ⊑∎
+        ψ : (Σ i ꞉ I , x ∈ α i) → f x ⊑ ⋁ (λ (i : I) → ⋁ (f̃ (α i)))
+        ψ (i , a') = f x                         ⊑⟨ u₁ ⟩
+                     ⋁ (f̃ (α i))                 ⊑⟨ u₂ ⟩
+                     ⋁ (λ (i : I) → ⋁ (f̃ (α i))) ⊑∎
          where
-          u₁ = ⋁-is-upperbound (f ∘ pr₁) (x , a')
-          u₂ = ⋁-is-upperbound (λ i' → ⋁ (f ∘ pr₁)) i
-    v : ⋁ (λ (i : I) → ⋁ (f ∘ pr₁)) ⊑ ⋁ (f ∘ pr₁)
-    v = ⋁-is-lowerbound-of-upperbounds (λ i → ⋁ (f ∘ pr₁)) (⋁ (f ∘ pr₁)) γ
+          u₁ = ⋁-is-upperbound (f̃ (α i)) (x , a')
+          u₂ = ⋁-is-upperbound (λ i' → ⋁ (f̃ (α i'))) i
+    v : ⋁ (λ (i : I) → ⋁ (f̃ (α i))) ⊑ ⋁ (f̃ (⋃ α))
+    v = ⋁-is-lowerbound-of-upperbounds (λ i → ⋁ (f̃ (α i))) (⋁ (f̃ (⋃ α))) γ
      where
       γ : (i : I)
-        → ⋁ {Σ x ꞉ X , x ∈ α i} (f ∘ pr₁) ⊑ ⋁ {Σ x ꞉ X , x ∈ ⋃ α} (f ∘ pr₁)
-      γ i = ⋁-is-lowerbound-of-upperbounds (f ∘ pr₁) (⋁ (f ∘ pr₁)) ψ
+        → ⋁ (f̃ (α i)) ⊑ ⋁ (f̃ (⋃ α))
+      γ i = ⋁-is-lowerbound-of-upperbounds (f̃ (α i)) (⋁ (f̃ (⋃ α))) ψ
        where
         ψ : (p : Σ x ꞉ X , x ∈ α i)
-          → f (pr₁ p) ⊑ ⋁ (f ∘ pr₁)
-        ψ (x , a) = ⋁-is-upperbound (f ∘ pr₁) (x , ∣ i , a ∣)
+          → f̃ (α i) p ⊑ ⋁ (f̃ (⋃ α))
+        ψ (x , a) = ⋁-is-upperbound (f̃ (⋃ α)) (x , ∣ i , a ∣)
 
 \end{code}
 

--- a/source/JoinSemiLattices.lagda
+++ b/source/JoinSemiLattices.lagda
@@ -1,0 +1,78 @@
+Tom de Jong, 24 January 2022
+(Refactored from FreeJoinSemiLattice.lagda)
+
+We define join-semilattices using a record. We also introduce convenient helpers
+and syntax for reasoning about the order ⊑ and we construct finite joins using
+the least element and binary joins.
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+module JoinSemiLattices where
+
+open import SpartanMLTT
+
+open import Fin
+
+open import UF-Subsingletons
+
+record JoinSemiLattice (𝓥 𝓣 : Universe) : 𝓤ω where
+  field
+    L : 𝓥 ̇
+    L-is-set : is-set L
+    _⊑_ : L → L → 𝓣 ̇
+    ⊑-is-prop-valued : (x y : L) → is-prop (x ⊑ y)
+    ⊑-is-reflexive : (x : L) → x ⊑ x
+    ⊑-is-transitive : (x y z : L) → x ⊑ y → y ⊑ z → x ⊑ z
+    ⊑-is-antisymmetric : (x y : L) → x ⊑ y → y ⊑ x → x ≡ y
+    ⊥ : L
+    ⊥-is-least : (x : L) → ⊥ ⊑ x
+    _∨_ : L → L → L
+    ∨-is-upperbound₁ : (x y : L) → x ⊑ (x ∨ y)
+    ∨-is-upperbound₂ : (x y : L) → y ⊑ (x ∨ y)
+    ∨-is-lowerbound-of-upperbounds : (x y z : L) → x ⊑ z → y ⊑ z → (x ∨ y) ⊑ z
+
+  transitivity' : (x : L) {y z : L}
+                → x ⊑ y → y ⊑ z → x ⊑ z
+  transitivity' x {y} {z} = ⊑-is-transitive x y z
+
+  syntax transitivity' x u v = x ⊑⟨ u ⟩ v
+  infixr 0 transitivity'
+
+  reflexivity' : (x : L) → x ⊑ x
+  reflexivity' x = ⊑-is-reflexive x
+
+  syntax reflexivity' x = x ⊑∎
+  infix 1 reflexivity'
+
+  ≡-to-⊑ : {x y : L} → x ≡ y → x ⊑ y
+  ≡-to-⊑ {x} {x} refl = reflexivity' x
+
+  ∨ⁿ : {n : ℕ} → (Fin n → L) → L
+  ∨ⁿ {zero}   e = ⊥
+  ∨ⁿ {succ m} e = (∨ⁿ (e ∘ suc)) ∨ (e 𝟎)
+
+  ∨ⁿ-is-upperbound : {n : ℕ} (σ : Fin n → L)
+                   → (k : Fin n) → σ k ⊑ ∨ⁿ σ
+  ∨ⁿ-is-upperbound {succ n} σ 𝟎       = ∨-is-upperbound₂ _ _
+  ∨ⁿ-is-upperbound {succ n} σ (suc k) = σ (suc k)    ⊑⟨ IH ⟩
+                                        ∨ⁿ (σ ∘ suc) ⊑⟨ ∨-is-upperbound₁ _ _ ⟩
+                                        ∨ⁿ σ         ⊑∎
+   where
+    IH = ∨ⁿ-is-upperbound (σ ∘ suc) k
+
+  ∨ⁿ-is-lowerbound-of-upperbounds : {n : ℕ} (σ : Fin n → L)
+                                    (x : L)
+                                  → ((k : Fin n) → σ k ⊑ x)
+                                  → ∨ⁿ σ ⊑ x
+  ∨ⁿ-is-lowerbound-of-upperbounds {zero}   σ x ub = ⊥-is-least x
+  ∨ⁿ-is-lowerbound-of-upperbounds {succ n} σ x ub =
+   ∨-is-lowerbound-of-upperbounds _ _ _ u v
+    where
+     u : ∨ⁿ (σ ∘ suc) ⊑ x
+     u = ∨ⁿ-is-lowerbound-of-upperbounds {n} (σ ∘ suc) x (ub ∘ suc)
+     v : σ 𝟎 ⊑ x
+     v = ub 𝟎
+
+\end{code}

--- a/source/UF-Classifiers.lagda
+++ b/source/UF-Classifiers.lagda
@@ -28,7 +28,7 @@ open import UF-FunExt
 open import UF-UA-FunExt
 open import UF-Subsingletons
 open import UF-Subsingletons-FunExt
-open import UF-Powerset
+open import UF-Powerset hiding (𝕋)
 open import UF-EquivalenceExamples
 open import UF-Retracts
 

--- a/source/UF-Powerset-Fin.lagda
+++ b/source/UF-Powerset-Fin.lagda
@@ -1,0 +1,447 @@
+Tom de Jong, 24 January 2022
+(Based on code from FreeJoinSemiLattice.lagda written 18-24 December 2020.)
+
+TODO: Comment
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+open import SpartanMLTT
+
+open import UF-PropTrunc
+
+module UF-Powerset-Fin
+        (pt : propositional-truncations-exist)
+       where
+
+open PropositionalTruncation pt
+
+open import ArithmeticViaEquivalence
+open import Fin
+open import Fin-Properties
+open import List
+open import JoinSemiLattices
+
+open import UF-Base
+open import UF-Equiv
+open import UF-EquivalenceExamples
+open import UF-FunExt
+open import UF-Lower-FunExt
+open import UF-ImageAndSurjection
+open import UF-Powerset
+open import UF-Subsingletons
+open import UF-Subsingletons-FunExt
+
+open binary-union-of-subsets pt
+open ImageAndSurjection pt
+open Kuratowski-finiteness pt
+
+is-Kuratowski-finite-subset : {X : 𝓤 ̇ } (A : 𝓟 X) → 𝓤 ̇
+is-Kuratowski-finite-subset A = is-Kuratowski-finite (𝕋 A)
+
+∅-is-Kuratowski-finite-subset : {X : 𝓤 ̇ }
+                              → is-Kuratowski-finite-subset ∅
+∅-is-Kuratowski-finite-subset {𝓤} {X} = ∣ 0 , e , σ ∣
+ where
+  e : Fin 0 → 𝕋 {𝓤} {X} ∅
+  e = 𝟘-elim
+  σ : is-surjection e
+  σ (x , x-in-emptyset) = 𝟘-elim x-in-emptyset
+
+module _
+        {X : 𝓤 ̇  }
+        (X-is-set : is-set X)
+       where
+
+ open singleton-subsets X-is-set
+
+ ❴❵-is-Kuratowski-finite-subset : {x : X}
+                                → is-Kuratowski-finite-subset ❴ x ❵
+ ❴❵-is-Kuratowski-finite-subset {x} = ∣ 1 , e , σ ∣
+  where
+   e : Fin 1 → 𝕋 ❴ x ❵
+   e 𝟎 = x , refl
+   σ : is-surjection e
+   σ (x , refl) = ∣ inr ⋆ , refl ∣
+
+\end{code}
+
+We proceed by that Kuratowski finite subsets are closed under binary unions.
+
+\begin{code}
+
+module _
+        {X : 𝓤 ̇ }
+       where
+
+ ∪-enum' : (A B : 𝓟 X) {n m : ℕ}
+         → (Fin n → 𝕋 A)
+         → (Fin m → 𝕋 B)
+         → (Fin n + Fin m) → 𝕋 (A ∪ B)
+ ∪-enum' A B e f (inl k) = (𝕋-to-carrier A (e k) ,
+                            ∪-is-upperbound₁ A B (𝕋-to-carrier A (e k))
+                                                 (𝕋-to-membership A (e k)))
+ ∪-enum' A B e f (inr k) = (𝕋-to-carrier B (f k) ,
+                            ∪-is-upperbound₂ A B (𝕋-to-carrier B (f k))
+                                                 (𝕋-to-membership B (f k)))
+
+ ∪-enum : (A B : 𝓟 X) {n m : ℕ}
+        → (Fin n → 𝕋 A)
+        → (Fin m → 𝕋 B)
+        → Fin (n +' m) → 𝕋 (A ∪ B)
+ ∪-enum A B {n} {m} e f = ∪-enum' A B e f ∘ ⌜ Fin+homo n m ⌝
+
+ ∪-enum'-is-surjection : (A B : 𝓟 X) {n m : ℕ}
+                         (e : Fin n → 𝕋 A)
+                         (f : Fin m → 𝕋 B)
+                       → is-surjection e
+                       → is-surjection f
+                       → is-surjection (∪-enum' A B e f)
+ ∪-enum'-is-surjection A B {n} {m} e f σ τ (x , p) = ∥∥-rec ∥∥-is-prop γ p
+   where
+    γ : (x ∈ A + x ∈ B)
+      → ∃ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
+    γ (inl a) = ∥∥-functor γ₁ (σ (x , a))
+     where
+      γ₁ : (Σ k ꞉ Fin n , e k ≡ (x , a))
+         → Σ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
+      γ₁ (k , p) = inl k , to-subtype-≡ (∈-is-prop (A ∪ B)) (ap pr₁ p)
+    γ (inr b) = ∥∥-functor γ₂ (τ (x , b))
+     where
+      γ₂ : (Σ k ꞉ Fin m , f k ≡ (x , b))
+         → Σ c ꞉ (Fin n + Fin m) , ∪-enum' A B e f c ≡ (x , p)
+      γ₂ (k , p) = inr k , to-subtype-≡ (∈-is-prop (A ∪ B)) (ap pr₁ p)
+
+ ∪-enum-is-surjection : (A B : 𝓟 X) {n m : ℕ}
+                        (e : Fin n → 𝕋 A)
+                        (f : Fin m → 𝕋 B)
+                      → is-surjection e
+                      → is-surjection f
+                      → is-surjection (∪-enum A B e f)
+ ∪-enum-is-surjection A B {n} {m} e f σ τ =
+  ∘-is-surjection
+   (equivs-are-surjections (⌜⌝-is-equiv (Fin+homo n m)))
+   (∪-enum'-is-surjection A B e f σ τ)
+
+ ∪-is-Kuratowski-finite-subset : (A B : 𝓟 X)
+                               → is-Kuratowski-finite-subset A
+                               → is-Kuratowski-finite-subset B
+                               → is-Kuratowski-finite-subset (A ∪ B)
+ ∪-is-Kuratowski-finite-subset A B kᴬ kᴮ = k
+  where
+   k : is-Kuratowski-finite-subset (A ∪ B)
+   k = ∥∥-functor₂ γ kᴬ kᴮ
+    where
+     γ : (Σ nᴬ ꞉ ℕ , Fin nᴬ ↠ 𝕋 A)
+       → (Σ nᴮ ꞉ ℕ , Fin nᴮ ↠ 𝕋 B)
+       → Σ n ꞉ ℕ , Fin n ↠ 𝕋 (A ∪ B)
+     γ (nᴬ , eᴬ , eᴬ-is-surj) (nᴮ , eᴮ , eᴮ-is-surj) =
+      (nᴬ +' nᴮ , ∪-enum A B eᴬ eᴮ
+                , ∪-enum-is-surjection A B eᴬ eᴮ eᴬ-is-surj eᴮ-is-surj)
+
+\end{code}
+
+The Kuratowski finite subsets (ordered by subset inclusion) are a natural
+example of a join-semilattice, which we are going to prove now.
+
+(In fact, the Kuratowski finite subsets are the free join-semilattice, see
+FreeJoinSemiLattice.lagda.)
+
+\begin{code}
+
+𝓚 : (X : 𝓤 ̇  ) → 𝓤 ⁺ ̇
+𝓚 X = Σ A ꞉ 𝓟 X , is-Kuratowski-finite-subset A
+
+module _
+        {X : 𝓤 ̇  }
+       where
+
+ ⟨_⟩ : 𝓚 X → 𝓟 X
+ ⟨_⟩ = pr₁
+
+ ⟨_⟩₂ : (A : 𝓚 X) → is-Kuratowski-finite-subset ⟨ A ⟩
+ ⟨_⟩₂ = pr₂
+
+ _⊆[𝓚]_ : 𝓚 X → 𝓚 X → 𝓤 ̇
+ A ⊆[𝓚] B = ⟨ A ⟩ ⊆ ⟨ B ⟩
+
+ ⊆[𝓚]-is-reflexive : (A : 𝓚 X) → A ⊆[𝓚] A
+ ⊆[𝓚]-is-reflexive A = ⊆-refl ⟨ A ⟩
+
+ ⊆[𝓚]-is-transitive : (A B C : 𝓚 X) → A ⊆[𝓚] B → B ⊆[𝓚] C → A ⊆[𝓚] C
+ ⊆[𝓚]-is-transitive A B C = ⊆-trans ⟨ A ⟩ ⟨ B ⟩ ⟨ C ⟩
+
+ module singleton-Kuratowski-finite-subsets
+         (X-is-set : is-set X)
+       where
+
+  open singleton-subsets X-is-set
+
+  ❴_❵[𝓚] : X → 𝓚 X
+  ❴ x ❵[𝓚] = (❴ x ❵ , ❴❵-is-Kuratowski-finite-subset X-is-set)
+
+ ∅[𝓚] : 𝓚 X
+ ∅[𝓚] = ∅ , ∅-is-Kuratowski-finite-subset
+
+ ∅[𝓚]-is-least : (A : 𝓚 X) → ∅[𝓚] ⊆[𝓚] A
+ ∅[𝓚]-is-least A = ∅-is-least ⟨ A ⟩
+
+ _∪[𝓚]_ : 𝓚 X → 𝓚 X → 𝓚 X
+ _∪[𝓚]_ (A , k₁) (B , k₂) = (A ∪ B) , k
+  where
+   k : is-Kuratowski-finite-subset (A ∪ B)
+   k = ∪-is-Kuratowski-finite-subset A B k₁ k₂
+
+ ∪[𝓚]-is-upperbound₁ : (A B : 𝓚 X) → A ⊆[𝓚] (A ∪[𝓚] B)
+ ∪[𝓚]-is-upperbound₁ A B = ∪-is-upperbound₁ ⟨ A ⟩ ⟨ B ⟩
+
+ ∪[𝓚]-is-upperbound₂ : (A B : 𝓚 X) → B ⊆[𝓚] (A ∪[𝓚] B)
+ ∪[𝓚]-is-upperbound₂ A B = ∪-is-upperbound₂ ⟨ A ⟩ ⟨ B ⟩
+
+ ∪[𝓚]-is-lowerbound-of-upperbounds : (A B C : 𝓚 X)
+                                   → A ⊆[𝓚] C → B ⊆[𝓚] C → (A ∪[𝓚] B) ⊆[𝓚] C
+ ∪[𝓚]-is-lowerbound-of-upperbounds A B C =
+  ∪-is-lowerbound-of-upperbounds ⟨ A ⟩ ⟨ B ⟩ ⟨ C ⟩
+
+ module _
+         (fe : funext 𝓤 (𝓤 ⁺))
+        where
+
+  ⊆[𝓚]-is-prop-valued : (A B : 𝓚 X) → is-prop (A ⊆[𝓚] B)
+  ⊆[𝓚]-is-prop-valued A B = ⊆-is-prop (lower-funext 𝓤 (𝓤 ⁺) fe) ⟨ A ⟩ ⟨ B ⟩
+
+  module _
+         (pe : propext 𝓤)
+        where
+
+   ⊆[𝓚]-is-antisymmetric : (A B : 𝓚 X) → A ⊆[𝓚] B → B ⊆[𝓚] A → A ≡ B
+   ⊆[𝓚]-is-antisymmetric A B s t =
+    to-subtype-≡ (λ _ → being-Kuratowski-finite-is-prop)
+                 (subset-extensionality pe fe s t)
+
+   𝓚-is-set : is-set (𝓚 X)
+   𝓚-is-set = subtypes-of-sets-are-sets ⟨_⟩ s (powersets-are-sets fe pe)
+     where
+      s : left-cancellable ⟨_⟩
+      s e = to-subtype-≡ (λ _ → being-Kuratowski-finite-is-prop) e
+
+\end{code}
+
+We are now ready to prove that the Kuratowski finite subsets are a join-semilattice.
+
+\begin{code}
+
+module _
+        (pe : propext 𝓤)
+        (fe : funext 𝓤 (𝓤 ⁺))
+        (X : 𝓤 ̇  )
+       where
+
+ 𝓚-join-semilattice : JoinSemiLattice (𝓤 ⁺) 𝓤
+ 𝓚-join-semilattice = record {
+   L                              = 𝓚 X ;
+   L-is-set                       = 𝓚-is-set fe pe;
+   _⊑_                            = _⊆[𝓚]_;
+   ⊑-is-prop-valued               = ⊆[𝓚]-is-prop-valued fe;
+   ⊑-is-reflexive                 = ⊆[𝓚]-is-reflexive;
+   ⊑-is-transitive                = ⊆[𝓚]-is-transitive;
+   ⊑-is-antisymmetric             = ⊆[𝓚]-is-antisymmetric fe pe;
+   ⊥                              = ∅[𝓚];
+   ⊥-is-least                     = ∅[𝓚]-is-least;
+   _∨_                            = _∪[𝓚]_;
+   ∨-is-upperbound₁               = ∪[𝓚]-is-upperbound₁;
+   ∨-is-upperbound₂               = ∪[𝓚]-is-upperbound₂;
+   ∨-is-lowerbound-of-upperbounds = ∪[𝓚]-is-lowerbound-of-upperbounds
+  }
+
+\end{code}
+
+Now that we have that the Kuratowski finite subsets are a join-semilattice, we
+automatically have binary joins available, which will come in useful when
+proving a general induction principle for Kuratowski finite subsets.
+
+\begin{code}
+
+ module _
+         (X-is-set : is-set X)
+        where
+
+  open JoinSemiLattice 𝓚-join-semilattice
+  open singleton-Kuratowski-finite-subsets X-is-set
+
+  Kuratowski-finite-subset-expressed-as-finite-join :
+     (A : 𝓚 X)
+     {n : ℕ}
+     {e : Fin n → 𝕋 ⟨ A ⟩}
+     (σ : is-surjection e)
+   → A ≡ ∨ⁿ (❴_❵[𝓚] ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e)
+  Kuratowski-finite-subset-expressed-as-finite-join A {n} {e} σ = γ
+   where
+    ε : Fin n → 𝓚 X
+    ε = ❴_❵[𝓚] ∘ 𝕋-to-carrier ⟨ A ⟩ ∘ e
+    γ : A ≡ ∨ⁿ ε
+    γ = ⊆[𝓚]-is-antisymmetric fe pe A (∨ⁿ ε) u v
+     where
+      u : A ⊆[𝓚] ∨ⁿ ε
+      u x a = ∥∥-rec (∈-is-prop ⟨ ∨ⁿ ε ⟩ x) μ (σ (x , a))
+       where
+        μ : (Σ k ꞉ Fin n , e k ≡ (x , a))
+          → x ∈ ⟨ ∨ⁿ ε ⟩
+        μ (k , refl) = ∨ⁿ-is-upperbound ε k x refl
+      v : ∨ⁿ ε ⊆[𝓚] A
+      v = ∨ⁿ-is-lowerbound-of-upperbounds ε A ν
+       where
+        ν : (k : Fin n) → ε k ⊆[𝓚] A
+        ν k x refl = 𝕋-to-membership ⟨ A ⟩ (e k)
+
+  Kuratowski-finite-subset-induction :
+     (Q : 𝓚 X → 𝓣 ̇  )
+   → ((A : 𝓚 X) → is-prop (Q A))
+   → Q (∅[𝓚])
+   → ((x : X) → Q (❴ x ❵[𝓚]))
+   → ((A B : 𝓚 X) → Q A → Q B → Q (A ∪[𝓚] B))
+   → (A : 𝓚 X) → Q A
+  Kuratowski-finite-subset-induction
+   Q Q-is-prop-valued Q-empty Q-singletons Q-unions 𝔸@(A , k) =
+    ∥∥-rec (Q-is-prop-valued 𝔸) γ k
+     where
+      γ : (Σ n ꞉ ℕ , Fin n ↠ 𝕋 A) → Q 𝔸
+      γ (n , e , e-surj) = transport Q ϕ (ψ n (𝕋-to-carrier A ∘ e))
+       where
+        ϕ : ∨ⁿ (❴_❵[𝓚] ∘ 𝕋-to-carrier A ∘ e) ≡ 𝔸
+        ϕ = (Kuratowski-finite-subset-expressed-as-finite-join 𝔸 e-surj) ⁻¹
+        ψ : (m : ℕ) (f : Fin m → X) → Q (∨ⁿ (❴_❵[𝓚] ∘ f))
+        ψ zero     f = Q-empty
+        ψ (succ m) f = Q-unions
+                        (∨ⁿ (❴_❵[𝓚] ∘ f ∘ suc))
+                        ((❴_❵[𝓚] ∘ f) 𝟎)
+                        IH
+                        (Q-singletons (f 𝟎))
+         where
+          IH : Q (∨ⁿ (❴_❵[𝓚] ∘ f ∘ suc))
+          IH = ψ m (f ∘ suc)
+
+\end{code}
+
+We consider the canonical map from lists on X to the powerset of X and prove
+that its image is exactly the type of Kuratowski finite powersets of X.
+
+\begin{code}
+
+module _
+        {X : 𝓤 ̇  }
+        (X-is-set : is-set X)
+       where
+
+ open singleton-subsets X-is-set
+ open singleton-Kuratowski-finite-subsets X-is-set
+
+ κ : List X → 𝓟 X
+ κ [] = ∅
+ κ (x ∷ xs) = ❴ x ❵ ∪ κ xs
+
+ κ-of-concatenated-lists-is-union : propext 𝓤
+                                  → funext 𝓤 (𝓤 ⁺)
+                                  → (l l' : List X)
+                                  → κ (l ++ l') ≡ κ l ∪ κ l'
+ κ-of-concatenated-lists-is-union pe fe [] l' =
+  ∅-left-neutral-for-∪ pe fe (κ l') ⁻¹
+ κ-of-concatenated-lists-is-union pe fe (x ∷ l) l' =
+  ❴ x ❵ ∪ κ (l ++ l')  ≡⟨ ap (❴ x ❵ ∪_) IH                      ⟩
+  ❴ x ❵ ∪ (κ l ∪ κ l') ≡⟨ (∪-assoc pe fe ❴ x ❵ (κ l) (κ l')) ⁻¹ ⟩
+  (❴ x ❵ ∪ κ l) ∪ κ l' ∎
+   where
+    IH : κ (l ++ l') ≡ (κ l ∪ κ l')
+    IH = κ-of-concatenated-lists-is-union pe fe l l'
+
+ κ-of-list-is-Kuratowski-finite-subset : (l : List X)
+                                       → is-Kuratowski-finite-subset (κ l)
+ κ-of-list-is-Kuratowski-finite-subset [] = ∅-is-Kuratowski-finite-subset
+ κ-of-list-is-Kuratowski-finite-subset (x ∷ l) =
+  ∪-is-Kuratowski-finite-subset ❴ x ❵ (κ l)
+   (❴❵-is-Kuratowski-finite-subset X-is-set)
+   (κ-of-list-is-Kuratowski-finite-subset l)
+
+ Kuratowski-finite-subset-if-in-image-of-κ : (A : 𝓟 X)
+                                           → A ∈image κ
+                                           → is-Kuratowski-finite-subset A
+ Kuratowski-finite-subset-if-in-image-of-κ A =
+  ∥∥-rec being-Kuratowski-finite-is-prop γ
+   where
+    γ : (Σ l ꞉ List X , κ l ≡ A)
+      → is-Kuratowski-finite-subset A
+    γ (l , refl) = κ-of-list-is-Kuratowski-finite-subset l
+
+\end{code}
+
+For proving the converse, the aforementioned induction principle for
+Kuroratowski finite subsets comes in handy (as suggested by Martín Escardó
+during an Agda Club meeting).
+
+\begin{code}
+
+ in-image-of-κ-if-Kuratowski-finite-subset : propext 𝓤
+                                           → funext 𝓤 (𝓤 ⁺)
+                                           → (A : 𝓟 X)
+                                           → is-Kuratowski-finite-subset A
+                                           → A ∈image κ
+ in-image-of-κ-if-Kuratowski-finite-subset pe fe = goal
+  where
+   Q : 𝓚 X → 𝓤 ⁺ ̇
+   Q A = ⟨ A ⟩ ∈image κ
+   Q-is-prop-valued : (A : 𝓚 X) → is-prop (Q A)
+   Q-is-prop-valued A = being-in-the-image-is-prop ⟨ A ⟩ κ
+   Q-empty : Q ∅[𝓚]
+   Q-empty = ∣ [] , refl ∣
+   Q-singleton : (x : X) → Q ❴ x ❵[𝓚]
+   Q-singleton x = ∣ [ x ] , subset-extensionality pe fe s t ∣
+    where
+     s : κ [ x ] ⊆ ❴ x ❵
+     s y = ∥∥-rec (∈-is-prop ❴ x ❵ y) γ
+      where
+       γ : (y ∈ ❴ x ❵ + y ∈ κ []) → y ∈ ❴ x ❵
+       γ (inl p) = p
+       γ (inr q) = 𝟘-elim q
+     t : ❴ x ❵ ⊆ κ [ x ]
+     t y p = ∣ inl p ∣
+   Q-unions : (A B : 𝓚 X) → Q A → Q B → Q (A ∪[𝓚] B)
+   Q-unions A B qᴬ qᴮ = ∥∥-functor₂ γ qᴬ qᴮ
+    where
+     γ : (Σ lᴬ ꞉ List X , κ lᴬ ≡ ⟨ A ⟩)
+       → (Σ lᴮ ꞉ List X , κ lᴮ ≡ ⟨ B ⟩)
+       → (Σ l  ꞉ List X , κ l  ≡ ⟨ A ∪[𝓚] B ⟩)
+     γ (lᴬ , pᴬ) (lᴮ , pᴮ) = ((lᴬ ++ lᴮ) , p)
+      where
+       p = κ (lᴬ ++ lᴮ)  ≡⟨ κ-of-concatenated-lists-is-union pe fe lᴬ lᴮ ⟩
+           κ lᴬ ∪ κ lᴮ   ≡⟨ ap₂ _∪_ pᴬ pᴮ ⟩
+           ⟨ A ⟩ ∪ ⟨ B ⟩ ∎
+   Q-holds-everywhere : (A : 𝓚 X) → Q A
+   Q-holds-everywhere = Kuratowski-finite-subset-induction pe fe X X-is-set
+                         Q Q-is-prop-valued
+                         Q-empty
+                         Q-singleton
+                         Q-unions
+   goal : (A : 𝓟 X) → is-Kuratowski-finite-subset A → A ∈image κ
+   goal A k = Q-holds-everywhere (A , k)
+
+\end{code}
+
+Putting this all together, we obtained the promised equivalence between the
+image of κ and the Kuratowski finite subsets of X.
+
+\begin{code}
+
+ image-of-κ-is-the-Kuratowski-finite-powerset : propext 𝓤
+                                              → funext 𝓤 (𝓤 ⁺)
+                                              → image κ ≃ 𝓚 X
+ image-of-κ-is-the-Kuratowski-finite-powerset pe fe = Σ-cong γ
+  where
+   γ : (A : 𝓟 X) → (A ∈image κ) ≃ is-Kuratowski-finite-subset A
+   γ A = logically-equivalent-props-are-equivalent
+          (being-in-the-image-is-prop A κ)
+          being-Kuratowski-finite-is-prop
+          (Kuratowski-finite-subset-if-in-image-of-κ A)
+          (in-image-of-κ-if-Kuratowski-finite-subset pe fe A)
+
+\end{code}

--- a/source/UF-Powerset.lagda
+++ b/source/UF-Powerset.lagda
@@ -276,3 +276,32 @@ module binary-union-of-subsets
         t₂ (inr c) = ∪-is-upperbound₂ (A ∪ B) C x c
 
 \end{code}
+
+Again assuming propositional truncations, we can construct arbitrary suprema in
+𝓟 (X : 𝓤) of families indexed by types in 𝓤.
+
+\begin{code}
+
+module unions-of-small-families
+        (pt : propositional-truncations-exist)
+       where
+
+ open PropositionalTruncation pt
+
+ ⋃  : {X I : 𝓤 ̇ } (α : I → 𝓟 X) → 𝓟 X
+ ⋃ {𝓤} {X} {I} α x = (∃ i ꞉ I , x ∈ α i) , ∃-is-prop
+
+ ⋃-is-upperbound : {X I : 𝓤 ̇ } (α : I → 𝓟 X) (i : I)
+                 → α i ⊆ ⋃ α
+ ⋃-is-upperbound α i x a = ∣ i , a ∣
+
+ ⋃-is-lowerbound-of-upperbounds : {X I : 𝓤 ̇ } (α : I → 𝓟 X) (A : 𝓟 X)
+                                → ((i : I) → α i ⊆ A)
+                                → ⋃ α ⊆ A
+ ⋃-is-lowerbound-of-upperbounds {𝓤} {X} {I} α A ub x u =
+  ∥∥-rec (∈-is-prop A x) γ u
+   where
+    γ : (Σ i ꞉ I , x ∈ α i) → x ∈ A
+    γ (i , a) = ub i x a
+
+\end{code}

--- a/source/UF-Powerset.lagda
+++ b/source/UF-Powerset.lagda
@@ -123,3 +123,156 @@ infix  40 _∈_
 infix  40 _∉_
 
 \end{code}
+
+Tom de Jong, 24 January 2022
+(Based on code from FreeJoinSemiLattice.lagda written 18-24 December 2020.)
+
+Notation for the "total space" of a subset.
+
+\begin{code}
+
+module _
+        {X : 𝓤 ̇ }
+       where
+
+ 𝕋 : 𝓟 X → 𝓤 ̇
+ 𝕋 A = Σ x ꞉ X , x ∈ A
+
+ 𝕋-to-carrier : (A : 𝓟 X) → 𝕋 A → X
+ 𝕋-to-carrier A = pr₁
+
+ 𝕋-to-membership : (A : 𝓟 X) → (t : 𝕋 A) → (𝕋-to-carrier A t) ∈ A
+ 𝕋-to-membership A = pr₂
+
+\end{code}
+
+We use a named module when defining singleton subsets, so that we can write
+❴ x ❵ without having to keep supplying the proof that the ambient type is a set.
+
+\begin{code}
+
+module singleton-subsets
+        {X : 𝓤 ̇  }
+        (X-is-set : is-set X)
+       where
+
+ ❴_❵ : X → 𝓟 X
+ ❴ x ❵ = λ y → ((x ≡ y) , X-is-set)
+
+ ❴❵-is-singleton : {x : X} → is-singleton (𝕋 ❴ x ❵)
+ ❴❵-is-singleton {x} = singleton-types-are-singletons x
+
+\end{code}
+
+Next, we consider binary intersections and unions in the powerset. For the
+latter, we need propositional truncations.
+
+\begin{code}
+
+module _
+        {X : 𝓤 ̇ }
+       where
+
+ _∩_ : 𝓟 X → 𝓟 X → 𝓟 X
+ (A ∩ B) x = (x ∈ A × x ∈ B) , ×-is-prop (∈-is-prop A x) (∈-is-prop B x)
+
+ ∩-is-lowerbound₁ : (A B : 𝓟 X) → (A ∩ B) ⊆ A
+ ∩-is-lowerbound₁ A B x = pr₁
+
+ ∩-is-lowerbound₂ : (A B : 𝓟 X) → (A ∩ B) ⊆ B
+ ∩-is-lowerbound₂ A B x = pr₂
+
+ ∩-is-upperbound-of-lowerbounds : (A B C : 𝓟 X)
+                                → C ⊆ A → C ⊆ B → C ⊆ (A ∩ B)
+ ∩-is-upperbound-of-lowerbounds A B C s t x c = (s x c , t x c)
+
+open import UF-PropTrunc
+
+module binary-union-of-subsets
+        (pt : propositional-truncations-exist)
+       where
+
+ open PropositionalTruncation pt
+
+ module _
+         {X : 𝓤 ̇ }
+        where
+
+  _∪_ : 𝓟 X → 𝓟 X → 𝓟 X
+  (A ∪ B) x = ∥ x ∈ A + x ∈ B ∥ , ∥∥-is-prop
+
+  ∪-is-upperbound₁ : (A B : 𝓟 X) → A ⊆ (A ∪ B)
+  ∪-is-upperbound₁ A B x a = ∣ inl a ∣
+
+  ∪-is-upperbound₂ : (A B : 𝓟 X) → B ⊆ (A ∪ B)
+  ∪-is-upperbound₂ A B x b = ∣ inr b ∣
+
+  ∪-is-lowerbound-of-upperbounds : (A B C : 𝓟 X)
+                                 → A ⊆ C → B ⊆ C → (A ∪ B) ⊆ C
+  ∪-is-lowerbound-of-upperbounds A B C s t x = ∥∥-rec (∈-is-prop C x) γ
+    where
+     γ : (x ∈ A + x ∈ B) → x ∈ C
+     γ (inl a) = s x a
+     γ (inr b) = t x b
+
+  ∅-left-neutral-for-∪ : propext 𝓤
+                       → funext 𝓤 (𝓤 ⁺)
+                       → (A : 𝓟 X) → ∅ ∪ A ≡ A
+  ∅-left-neutral-for-∪ pe fe A = subset-extensionality pe fe
+                                  s (∪-is-upperbound₂ ∅ A)
+   where
+    s : (∅ ∪ A) ⊆ A
+    s x = ∥∥-rec (∈-is-prop A x) γ
+     where
+      γ : x ∈ ∅ + x ∈ A → x ∈ A
+      γ (inl p) = 𝟘-elim p
+      γ (inr a) = a
+
+  ∅-right-neutral-for-∪ : propext 𝓤
+                        → funext 𝓤 (𝓤 ⁺)
+                        → (A : 𝓟 X) → A ≡ A ∪ ∅
+  ∅-right-neutral-for-∪ pe fe A = subset-extensionality pe fe
+                                   (∪-is-upperbound₁ A ∅) s
+   where
+    s : (A ∪ ∅) ⊆ A
+    s x = ∥∥-rec (∈-is-prop A x) γ
+     where
+      γ : x ∈ A + x ∈ ∅ → x ∈ A
+      γ (inl a) = a
+      γ (inr p) = 𝟘-elim p
+
+  ∪-assoc : propext 𝓤
+          → funext 𝓤 (𝓤 ⁺)
+          → associative (_∪_)
+  ∪-assoc pe fe A B C = subset-extensionality pe fe s t
+   where
+    s : ((A ∪ B) ∪ C) ⊆ (A ∪ (B ∪ C))
+    s x = ∥∥-rec i s₁
+     where
+      i : is-prop (x ∈ (A ∪ (B ∪ C)))
+      i = ∈-is-prop (A ∪ (B ∪ C)) x
+      s₁ : x ∈ (A ∪ B) + x ∈ C
+         → x ∈ (A ∪ (B ∪ C))
+      s₁ (inl u) = ∥∥-rec i s₂ u
+       where
+        s₂ : x ∈ A + x ∈ B
+           → x ∈ (A ∪ (B ∪ C))
+        s₂ (inl a) = ∪-is-upperbound₁ A (B ∪ C) x a
+        s₂ (inr b) = ∪-is-upperbound₂ A (B ∪ C) x (∪-is-upperbound₁ B C x b)
+      s₁ (inr c) = ∪-is-upperbound₂ A (B ∪ C) x (∪-is-upperbound₂ B C x c)
+    t : (A ∪ (B ∪ C)) ⊆ ((A ∪ B) ∪ C)
+    t x = ∥∥-rec i t₁
+     where
+      i : is-prop (x ∈ ((A ∪ B) ∪ C))
+      i = ∈-is-prop ((A ∪ B) ∪ C) x
+      t₁ : x ∈ A + x ∈ (B ∪ C)
+         → x ∈ ((A ∪ B) ∪ C)
+      t₁ (inl a) = ∪-is-upperbound₁ (A ∪ B) C x (∪-is-upperbound₁ A B x a)
+      t₁ (inr u) = ∥∥-rec i t₂ u
+       where
+        t₂ : x ∈ B + x ∈ C
+           → x ∈ ((A ∪ B) ∪ C)
+        t₂ (inl b) = ∪-is-upperbound₁ (A ∪ B) C x (∪-is-upperbound₂ A B x b)
+        t₂ (inr c) = ∪-is-upperbound₂ (A ∪ B) C x c
+
+\end{code}

--- a/source/index.lagda
+++ b/source/index.lagda
@@ -163,6 +163,7 @@ import InitialBinarySystem    -- More work than needed!
 import InitialBinarySystem2   -- No need to work with subtype of normal elements.
 import InjectiveTypes-article
 import InjectiveTypes
+import JoinSemiLattices                -- By Tom de Jong
 import LawvereFPT
 import LexicographicCompactness
 import LexicographicOrder
@@ -269,6 +270,7 @@ import UF-KrausLemma
 import UF-LeftCancellable
 import UF-Miscelanea
 import UF-Powerset
+import UF-Powerset-Fin                 -- By Tom de Jong
 import UF-PropIndexedPiSigma
 import UF-PropTrunc
 import UF-PropTrunc-F


### PR DESCRIPTION
1. Created a new file on Kuratowski finite subsets called `UF-Powerset-Fin.lagda`. In particular, it contains a proof that the type of Kuratowski finite subsets of a set X is equivalent to the image of the canonical map List X → 𝓟 X.
1. Added some basic constructions to `UF-Powerset.lagda`, e.g. the total space of a subset, notation for singleton subsets, binary intersections/unions, etc.
1. Cleaned up `FreeJoinSemiLattice.lagda` and `FreeSupLattice.lagda`. In particular:
    - Both files now import the total space of a subset, singletons, unions, etc. from `UF-Powerset.lagda`.
    - Factored out the definition of a join-semilattice and put this in `JoinSemiLattices.lagda`, so it could be used in `UF-Powerset-Fin.lagda`.
    - Moved the basic lemmas about Kuratowski finite subsets from `FreeJoinSemiLattice.lagda` to the new file `UF-Powerset-Fin.lagda`.
1. Added the new files `UF-Powerset-Fin.lagda` and `JoinSemiLattices.lagda` to `index.lagda`.