### PR TITLE
[Categories] Better type inference; add associators and unitors

### DIFF
--- a/source/Categories/Adjunction.lagda
+++ b/source/Categories/Adjunction.lagda
@@ -22,12 +22,13 @@ open import Categories.NaturalTransformation fe
 
 module adjunction-of-precategories (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory 𝓤' 𝓥') where
  open functor-of-precategories
+ open natural-transformation
 
  private
-  [𝓒,𝓒] = natural-transformation.functor-category.precat 𝓒 𝓒
-  [𝓓,𝓓] = natural-transformation.functor-category.precat 𝓓 𝓓
-  [𝓒,𝓓] = natural-transformation.functor-category.precat 𝓒 𝓓
-  [𝓓,𝓒] = natural-transformation.functor-category.precat 𝓓 𝓒
+  [𝓒,𝓒] = functor-category.precat 𝓒 𝓒
+  [𝓓,𝓓] = functor-category.precat 𝓓 𝓓
+  [𝓒,𝓓] = functor-category.precat 𝓒 𝓓
+  [𝓓,𝓒] = functor-category.precat 𝓓 𝓒
 
   module [𝓒,𝓒] = precategory [𝓒,𝓒]
   module [𝓓,𝓓] = precategory [𝓓,𝓓]
@@ -37,19 +38,23 @@ module adjunction-of-precategories (𝓒 : precategory 𝓤 𝓥) (𝓓 : precat
   1[𝓒] = identity-functor.fun 𝓒
   1[𝓓] = identity-functor.fun 𝓓
 
+
  module _ (F : functor 𝓒 𝓓) (G : functor 𝓓 𝓒) where
   private
-   module F = functor 𝓒 𝓓 F
-   module G = functor 𝓓 𝓒 G
-   F-G = composite-functor.fun 𝓒 𝓓 𝓒 F G
-   G-F = composite-functor.fun 𝓓 𝓒 𝓓 G F
-   [F-G]-F = composite-functor.fun 𝓒 𝓒 𝓓 F-G F
-   [G-F]-G = composite-functor.fun 𝓓 𝓓 𝓒 G-F G
-   module F-G = functor 𝓒 𝓒 F-G
-   module G-F = functor 𝓓 𝓓 G-F
+   module F = functor F
+   module G = functor G
+   F-G = composite-functor.fun F G
+   G-F = composite-functor.fun G F
+   [F-G]-F = composite-functor.fun F-G F
+   [G-F]-G = composite-functor.fun G-F G
+   F-[G-F] = composite-functor.fun F G-F
+   G-[F-G] = composite-functor.fun G F-G
+   module F-G = functor F-G
+   module G-F = functor G-F
 
   adjunction-structure : 𝓤 ⊔ 𝓥 ⊔ 𝓤' ⊔ 𝓥' ̇
   adjunction-structure = [𝓒,𝓒].hom 1[𝓒] F-G × [𝓓,𝓓].hom G-F 1[𝓓]
+
 
   module adjunction-structure (str : adjunction-structure) where
    unit : [𝓒,𝓒].hom 1[𝓒] F-G
@@ -58,19 +63,37 @@ module adjunction-of-precategories (𝓒 : precategory 𝓤 𝓥) (𝓓 : precat
    counit : [𝓓,𝓓].hom G-F 1[𝓓]
    counit = pr₂ str
 
+
   module _ (str : adjunction-structure) where
    open adjunction-structure str
 
    private
-    F·η = right-whiskering.whisk 𝓒 𝓒 𝓓 1[𝓒] F-G F unit
-    ϵ·F = left-whiskering.whisk 𝓒 𝓓 𝓓 F G-F 1[𝓓] counit
-    η·G = left-whiskering.whisk 𝓓 𝓒 𝓒 G 1[𝓒] F-G unit
-    G·ϵ = right-whiskering.whisk 𝓓 𝓓 𝓒 G-F 1[𝓓] G counit
+    η-F : [𝓒,𝓓].hom F [F-G]-F
+    η-F = [𝓒,𝓓].seq (left-unitor-inverse F) (right-whiskering.whisk unit F)
+
+    F-ϵ : [𝓒,𝓓].hom [F-G]-F F
+    F-ϵ =
+     [𝓒,𝓓].seq
+      (associator-inverse F G F)
+      ([𝓒,𝓓].seq
+       (left-whiskering.whisk F counit)
+       (left-unitor F))
+
+    G-η : [𝓓,𝓒].hom G G-[F-G]
+    G-η = [𝓓,𝓒].seq (left-unitor-inverse G) (left-whiskering.whisk G unit)
+
+    ϵ-G : [𝓓,𝓒].hom G-[F-G] G
+    ϵ-G =
+     [𝓓,𝓒].seq
+      (associator G F G)
+      ([𝓓,𝓒].seq
+       (right-whiskering.whisk counit G)
+       (left-unitor G))
 
    adjunction-axioms : 𝓥 ⊔ 𝓥' ⊔ 𝓤 ⊔ 𝓤' ̇
    adjunction-axioms =
-    ([𝓒,𝓓].seq {F} {[F-G]-F} {F} F·η ϵ·F ＝ [𝓒,𝓓].idn F)
-    × ([𝓓,𝓒].seq {G} {[G-F]-G} {G} η·G G·ϵ ＝ [𝓓,𝓒].idn G)
+    ([𝓒,𝓓].seq η-F F-ϵ ＝ [𝓒,𝓓].idn F)
+    × ([𝓓,𝓒].seq G-η ϵ-G ＝ [𝓓,𝓒].idn G)
 
    adjunction-axioms-is-prop : is-prop adjunction-axioms
    adjunction-axioms-is-prop =
@@ -78,7 +101,12 @@ module adjunction-of-precategories (𝓒 : precategory 𝓤 𝓥) (𝓓 : precat
      ([𝓒,𝓓].hom-is-set F F)
      ([𝓓,𝓒].hom-is-set G G)
 
-  adjunction : 𝓥 ⊔ 𝓥' ⊔ 𝓤 ⊔ 𝓤' ̇
-  adjunction = Σ str ꞉ adjunction-structure , adjunction-axioms str
+  record adjunction : 𝓥 ⊔ 𝓥' ⊔ 𝓤 ⊔ 𝓤' ̇ where
+   constructor make
+   field
+    str : adjunction-structure
+    ax : adjunction-axioms str
+
+   open adjunction-structure str public
 
 \end{code}

--- a/source/Categories/Category.lagda
+++ b/source/Categories/Category.lagda
@@ -126,15 +126,27 @@ module _ (𝓒 : category-structure 𝓤 𝓥) where
   assoc : statement-assoc
   assoc = pr₂ (pr₂ (pr₂ ax))
 
-precategory : (𝓤 𝓥 : Universe) → (𝓤 ⊔ 𝓥)⁺ ̇
-precategory 𝓤 𝓥 =
- Σ 𝓒 ꞉ category-structure 𝓤 𝓥 ,
- precategory-axioms 𝓒
+record precategory (𝓤 𝓥 : Universe) : (𝓤 ⊔ 𝓥)⁺ ̇ where
+ constructor make
+ field
+  str : category-structure 𝓤 𝓥
+  ax : precategory-axioms str
 
-module precategory (𝓒 : precategory 𝓤 𝓥) where
- open category-structure (pr₁ 𝓒) public
- open precategory-axioms (pr₁ 𝓒) (pr₂ 𝓒) public
+ open category-structure str public
+ open precategory-axioms str ax public
 
+module precategory-as-sum {𝓤 𝓥} where
+ to-sum : precategory 𝓤 𝓥 → (Σ 𝓒 ꞉ category-structure 𝓤 𝓥 , precategory-axioms 𝓒)
+ to-sum 𝓒 = let open precategory 𝓒 in str , ax
+
+ from-sum : (Σ 𝓒 ꞉ category-structure 𝓤 𝓥 , precategory-axioms 𝓒) → precategory 𝓤 𝓥
+ from-sum 𝓒 = make (pr₁ 𝓒) (pr₂ 𝓒)
+
+ to-sum-is-equiv : is-equiv to-sum
+ pr₁ (pr₁ to-sum-is-equiv) = from-sum
+ pr₂ (pr₁ to-sum-is-equiv) _ = refl
+ pr₁ (pr₂ to-sum-is-equiv) = from-sum
+ pr₂ (pr₂ to-sum-is-equiv) _ = refl
 
 module _ (𝓒 : precategory 𝓤 𝓥) where
  open precategory 𝓒

--- a/source/Categories/Functor.lagda
+++ b/source/Categories/Functor.lagda
@@ -81,12 +81,31 @@ module functor-of-precategories (𝓒 : precategory 𝓤 𝓥) (𝓓 : precatego
     preserving-idn-is-prop
     preserving-seq-is-prop
 
- functor : 𝓤 ⊔ 𝓥 ⊔ 𝓤' ⊔ 𝓥' ̇
- functor = Σ F ꞉ functor-structure , functor-axioms F
+ record functor : 𝓤 ⊔ 𝓥 ⊔ 𝓤' ⊔ 𝓥' ̇ where
+  constructor make
+  field
+   str : functor-structure
+   ax : functor-axioms str
 
- module functor (F : functor) where
-  open functor-structure (pr₁ F) public
-  open functor-axioms (pr₁ F) (pr₂ F) public
+  open functor-structure str public
+  open functor-axioms str ax public
+
+ module functor-as-sum where
+  to-sum : functor → Σ functor-axioms
+  to-sum F = let open functor F in str , ax
+
+  from-sum : Σ functor-axioms → functor
+  from-sum F = make (pr₁ F) (pr₂ F)
+
+  to-sum-is-equiv : is-equiv to-sum
+  pr₁ (pr₁ to-sum-is-equiv) = from-sum
+  pr₂ (pr₁ to-sum-is-equiv) _ = refl
+  pr₁ (pr₂ to-sum-is-equiv) = from-sum
+  pr₂ (pr₂ to-sum-is-equiv) _ = refl
+
+  equiv : functor ≃ Σ functor-axioms
+  equiv = to-sum , to-sum-is-equiv
+
 
 module functor-of-categories (𝓒 𝓓 : category 𝓤 𝓥) where
   open
@@ -106,10 +125,10 @@ module identity-functor (𝓒 : precategory 𝓤 𝓥) where
  ax = (λ A → refl) , (λ A B C f g → refl)
 
  fun : functor 𝓒 𝓒
- fun = str , ax
+ fun = make str ax
 
 module composite-functor
- (𝓒 : precategory 𝓣 𝓤) (𝓓 : precategory 𝓣' 𝓤') (𝓔 : precategory 𝓥 𝓦)
+ {𝓒 : precategory 𝓣 𝓤} {𝓓 : precategory 𝓣' 𝓤'} {𝓔 : precategory 𝓥 𝓦}
  (open functor-of-precategories)
  (F : functor 𝓒 𝓓)
  (G : functor 𝓓 𝓔)
@@ -119,8 +138,8 @@ module composite-functor
   module 𝓒 = precategory 𝓒
   module 𝓓 = precategory 𝓓
   module 𝓔 = precategory 𝓔
-  module F = functor 𝓒 𝓓 F
-  module G = functor 𝓓 𝓔 G
+  module F = functor F
+  module G = functor G
 
  ob : 𝓒.ob → 𝓔.ob
  ob A = G.ob (F.ob A)
@@ -151,4 +170,4 @@ module composite-functor
  ax = preserves-idn , preserves-seq
 
  fun : functor 𝓒 𝓔
- fun = str , ax
+ fun = make str ax

--- a/source/Categories/NaturalTransformation.lagda
+++ b/source/Categories/NaturalTransformation.lagda
@@ -44,8 +44,27 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
    (A B : 𝓒.ob) (f : 𝓒.hom A B)
    → 𝓓.seq (F.hom f) (α B) ＝ 𝓓.seq (α A) (G.hom f)
 
-  nat-transf : 𝓤 ⊔ 𝓥 ⊔ 𝓥' ̇
-  nat-transf = Σ α ꞉ transf , is-natural α
+  record nat-transf : 𝓤 ⊔ 𝓥 ⊔ 𝓥' ̇ where
+   constructor make
+   field
+    str : transf
+    ax : is-natural str
+
+  module nat-transf-as-sum where
+   to-sum : nat-transf → Σ is-natural
+   to-sum α = let open nat-transf α in str , ax
+
+   from-sum : Σ is-natural → nat-transf
+   from-sum α = make (pr₁ α) (pr₂ α)
+
+   to-sum-is-equiv : is-equiv to-sum
+   pr₁ (pr₁ to-sum-is-equiv) = from-sum
+   pr₂ (pr₁ to-sum-is-equiv) _ = refl
+   pr₁ (pr₂ to-sum-is-equiv) = from-sum
+   pr₂ (pr₂ to-sum-is-equiv) (make str ax) = refl
+
+   equiv : nat-transf ≃ Σ is-natural
+   equiv = to-sum , to-sum-is-equiv
 
   being-natural-is-prop : {α : transf} → is-prop (is-natural α)
   being-natural-is-prop =
@@ -56,12 +75,18 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
 
   nat-transf-is-set : is-set nat-transf
   nat-transf-is-set =
-   Σ-is-set transf-is-set λ _ →
-   props-are-sets being-natural-is-prop
+   equiv-to-set
+    nat-transf-as-sum.equiv
+    (Σ-is-set transf-is-set λ _ →
+     props-are-sets being-natural-is-prop)
 
   module _ {α β : nat-transf} where
-   to-nat-transf-＝ : pr₁ α ＝ pr₁ β → α ＝ β
-   to-nat-transf-＝ h = to-Σ-＝ (h , being-natural-is-prop _ _)
+   to-nat-transf-＝ : nat-transf.str α ＝ nat-transf.str β → α ＝ β
+   to-nat-transf-＝ h =
+    equivs-are-lc
+     nat-transf-as-sum.to-sum
+     nat-transf-as-sum.to-sum-is-equiv
+     (to-Σ-＝ (h , being-natural-is-prop _ _))
 
   -- TODO : characterize identity type
 
@@ -78,7 +103,7 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
     𝓓.seq (𝓓.idn _) (F.hom f) ∎
 
   nat-transf-idn : nat-transf F F
-  nat-transf-idn = transf-idn , transf-idn-natural
+  nat-transf-idn = make transf-idn transf-idn-natural
 
  module _ (F G H : functor) where
   private
@@ -107,8 +132,12 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
       𝓓.seq (𝓓.seq (α A) (β A)) (H.hom f) ∎
 
   nat-transf-seq : nat-transf F G  → nat-transf G H → nat-transf F H
-  pr₁ (nat-transf-seq α β) = transf-seq (pr₁ α) (pr₁ β)
-  pr₂ (nat-transf-seq α β) = transf-seq-natural (pr₁ α) (pr₁ β) (pr₂ α) (pr₂ β)
+  nat-transf-seq α β =
+   let module α = nat-transf α in
+   let module β = nat-transf β in
+   make
+    (transf-seq α.str β.str)
+    (transf-seq-natural α.str β.str α.ax β.ax)
 
  module _ (F G : functor) (α : transf F G) where
   transf-idn-L : transf-seq F F G (transf-idn F) α ＝ α
@@ -135,23 +164,25 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
    𝓓.assoc _ _ _ _ _ _ _
 
  module nat-transf-laws (F G : functor) (α : nat-transf F G) where
-  nat-transf-idn-L : nat-transf-seq F F G (nat-transf-idn F) α ＝ α
+  module α = nat-transf α
+
+  nat-transf-idn-L : nat-transf-seq _ _ _ (nat-transf-idn F) α ＝ α
   nat-transf-idn-L =
    to-nat-transf-＝ F G
-    (transf-idn-L F G (pr₁ α))
+    (transf-idn-L F G α.str)
 
-  nat-transf-idn-R : nat-transf-seq F G G α (nat-transf-idn G) ＝ α
+  nat-transf-idn-R : nat-transf-seq _ _ _ α (nat-transf-idn G) ＝ α
   nat-transf-idn-R =
    to-nat-transf-＝ F G
-    (transf-idn-R F G (pr₁ α))
+    (transf-idn-R F G α.str)
 
  module _ (F G H I : functor) (α : nat-transf F G) (β : nat-transf G H) (γ : nat-transf H I) where
   nat-transf-assoc
-   : nat-transf-seq F G I α (nat-transf-seq G H I β γ)
-   ＝ nat-transf-seq F H I (nat-transf-seq F G H α β) γ
+   : nat-transf-seq _ _ _ α (nat-transf-seq _ _ _ β γ)
+   ＝ nat-transf-seq _ _ _ (nat-transf-seq _ _ _ α β) γ
   nat-transf-assoc =
    to-nat-transf-＝ F I
-    (transf-assoc F G H I (pr₁ α) (pr₁ β) (pr₁ γ))
+    (transf-assoc F G H I _ _ _)
 
  module functor-category where
   structure : category-structure (𝓤 ⊔ 𝓥 ⊔ 𝓤' ⊔ 𝓥') (𝓤 ⊔ 𝓥 ⊔ 𝓥')
@@ -166,100 +197,248 @@ module natural-transformation (𝓒 : precategory 𝓤 𝓥) (𝓓 : precategory
    nat-transf-assoc
 
   precat : precategory (𝓤 ⊔ 𝓥 ⊔ 𝓤' ⊔ 𝓥') (𝓤 ⊔ 𝓥 ⊔ 𝓥')
-  precat = structure , axioms
+  precat = make structure axioms
 
-module _ (𝓒 : precategory 𝓣 𝓤) (𝓓 : precategory 𝓣' 𝓤') (𝓔 : precategory 𝓥 𝓦) where
+module _ {𝓒 : precategory 𝓣 𝓤} {𝓓 : precategory 𝓣' 𝓤'} {𝓔 : precategory 𝓥 𝓦} where
  private
   module 𝓒 = precategory 𝓒
   module 𝓓 = precategory 𝓓
   module 𝓔 = precategory 𝓔
+
  open functor-of-precategories
  open natural-transformation
 
  module horizontal-composition
-  (F1 G1 : functor 𝓒 𝓓)
-  (F2 G2 : functor 𝓓 𝓔)
+  {F1 G1 : functor 𝓒 𝓓}
+  {F2 G2 : functor 𝓓 𝓔}
   (α : nat-transf 𝓒 𝓓 F1 G1)
   (β : nat-transf 𝓓 𝓔 F2 G2)
   where
 
   private
-   F3 = composite-functor.fun 𝓒 𝓓 𝓔 F1 F2
-   G3 = composite-functor.fun 𝓒 𝓓 𝓔 G1 G2
-   module F1 = functor 𝓒 𝓓 F1
-   module F2 = functor 𝓓 𝓔 F2
-   module G1 = functor 𝓒 𝓓 G1
-   module G2 = functor 𝓓 𝓔 G2
-   module F3 = functor 𝓒 𝓔 F3
-   module G3 = functor 𝓒 𝓔 G3
+   F3 = composite-functor.fun F1 F2
+   G3 = composite-functor.fun G1 G2
+   module F1 = functor F1
+   module F2 = functor F2
+   module G1 = functor G1
+   module G2 = functor G2
+   module F3 = functor F3
+   module G3 = functor G3
+   module α = nat-transf α
+   module β = nat-transf β
 
   hcomp-str : transf 𝓒 𝓔 F3 G3
-  hcomp-str A = 𝓔.seq (pr₁ β (F1.ob A)) (G2.hom (pr₁ α A))
+  hcomp-str A = 𝓔.seq (β.str (F1.ob A)) (G2.hom (α.str A))
 
   abstract
    hcomp-ax : is-natural 𝓒 𝓔 F3 G3 hcomp-str
    hcomp-ax A B f =
-    𝓔.seq (F2.hom (F1.hom f)) (𝓔.seq (pr₁ β (F1.ob B)) (G2.hom (pr₁ α B)))
+    𝓔.seq (F2.hom (F1.hom f)) (𝓔.seq (β.str (F1.ob B)) (G2.hom (α.str B)))
      ＝⟨ 𝓔.assoc _ _ _ _ _ _ _ ⟩
-    𝓔.seq (𝓔.seq (F3.hom f) (pr₁ β (F1.ob B))) (G2.hom (pr₁ α B))
+    𝓔.seq (𝓔.seq (F3.hom f) (β.str (F1.ob B))) (G2.hom (α.str B))
      ＝⟨ ap (λ x → 𝓔.seq x _) h0 ⟩
-    𝓔.seq (𝓔.seq (pr₁ β (F1.ob A)) (G2.hom (F1.hom f))) (G2.hom (pr₁ α B))
+    𝓔.seq (𝓔.seq (β.str (F1.ob A)) (G2.hom (F1.hom f))) (G2.hom (α.str B))
      ＝⟨ 𝓔.assoc _ _ _ _ _ _ _ ⁻¹ ⟩
-    𝓔.seq (pr₁ β (F1.ob A)) (𝓔.seq (G2.hom (F1.hom f)) (G2.hom (pr₁ α B)))
-     ＝⟨ ap (𝓔.seq (pr₁ β (F1.ob A))) h1 ⟩
-    𝓔.seq (pr₁ β (F1.ob A)) (𝓔.seq (G2.hom (pr₁ α A)) (G3.hom f))
+    𝓔.seq (β.str (F1.ob A)) (𝓔.seq (G2.hom (F1.hom f)) (G2.hom (α.str B)))
+     ＝⟨ ap (𝓔.seq (β.str (F1.ob A))) h1 ⟩
+    𝓔.seq (β.str (F1.ob A)) (𝓔.seq (G2.hom (α.str A)) (G3.hom f))
      ＝⟨ 𝓔.assoc _ _ _ _ _ _ _ ⟩
-    𝓔.seq (𝓔.seq (pr₁ β (F1.ob A)) (G2.hom (pr₁ α A))) (G3.hom f) ∎
+    𝓔.seq (𝓔.seq (β.str (F1.ob A)) (G2.hom (α.str A))) (G3.hom f) ∎
     where
      h0
-      : 𝓔.seq (F2.hom (F1.hom f)) (pr₁ β (F1.ob B))
-      ＝ 𝓔.seq (pr₁ β (F1.ob A)) (G2.hom (F1.hom f))
-     h0 = pr₂ β (F1.ob A) (F1.ob B) (F1.hom f)
+      : 𝓔.seq (F2.hom (F1.hom f)) (β.str (F1.ob B))
+      ＝ 𝓔.seq (β.str (F1.ob A)) (G2.hom (F1.hom f))
+     h0 = β.ax (F1.ob A) (F1.ob B) (F1.hom f)
 
      h1
-      : 𝓔.seq (G2.hom (F1.hom f)) (G2.hom (pr₁ α B))
-      ＝ 𝓔.seq (G2.hom (pr₁ α A)) (G3.hom f)
+      : 𝓔.seq (G2.hom (F1.hom f)) (G2.hom (α.str B))
+      ＝ 𝓔.seq (G2.hom (α.str A)) (G3.hom f)
      h1 =
-      𝓔.seq (G2.hom (F1.hom f)) (G2.hom (pr₁ α B))
+      𝓔.seq (G2.hom (F1.hom f)) (G2.hom (α.str B))
        ＝⟨ G2.preserves-seq _ _ _ _ _ ⁻¹ ⟩
-      G2.hom (𝓓.seq (F1.hom f) (pr₁ α B))
-       ＝⟨ ap G2.hom (pr₂ α _ _ _) ⟩
-      G2.hom (𝓓.seq (pr₁ α A) (G1.hom f))
+      G2.hom (𝓓.seq (F1.hom f) (α.str B))
+       ＝⟨ ap G2.hom (α.ax _ _ _) ⟩
+      G2.hom (𝓓.seq (α.str A) (G1.hom f))
        ＝⟨ G2.preserves-seq _ _ _ _ _ ⟩
-      𝓔.seq (G2.hom (pr₁ α A)) (G3.hom f) ∎
+      𝓔.seq (G2.hom (α.str A)) (G3.hom f) ∎
 
   hcomp : nat-transf 𝓒 𝓔 F3 G3
-  hcomp = hcomp-str , hcomp-ax
-
+  hcomp = make hcomp-str hcomp-ax
 
  module left-whiskering
+  {G H : functor 𝓓 𝓔}
   (W : functor 𝓒 𝓓)
-  (G H : functor 𝓓 𝓔)
   (β : nat-transf 𝓓 𝓔 G H)
   where
 
   private
-   G∘W = composite-functor.fun 𝓒 𝓓 𝓔 W G
-   H∘W = composite-functor.fun 𝓒 𝓓 𝓔 W H
+   W-G = composite-functor.fun W G
+   W-H = composite-functor.fun W H
+   module W = functor W
+   module H = functor H
+   module β = nat-transf β
 
-  open horizontal-composition W W G H (nat-transf-idn 𝓒 𝓓 W) β
+  whisk-str : transf _ _ W-G W-H
+  whisk-str A = β.str (W.ob A)
 
-  whisk : nat-transf 𝓒 𝓔 G∘W H∘W
-  whisk = hcomp
+  whisk-ax : is-natural _ _ W-G W-H whisk-str
+  whisk-ax A B f = β.ax (W.ob A) (W.ob B) (W.hom f)
+
+  whisk : nat-transf _ _ W-G W-H
+  whisk = make whisk-str whisk-ax
 
  module right-whiskering
-  (G H : functor 𝓒 𝓓)
+  {G H : functor 𝓒 𝓓}
+  (β : nat-transf _ _ G H)
   (W : functor 𝓓 𝓔)
-  (β : nat-transf 𝓒 𝓓 G H)
   where
 
   private
-   W∘G = composite-functor.fun 𝓒 𝓓 𝓔 G W
-   W∘H = composite-functor.fun 𝓒 𝓓 𝓔 H W
+   G-W = composite-functor.fun G W
+   H-W = composite-functor.fun H W
+   module W = functor W
+   module G = functor G
+   module H = functor H
+   module β = nat-transf β
 
-  open horizontal-composition G H W W β (nat-transf-idn 𝓓 𝓔 W)
+  whisk-str : transf _ _ G-W H-W
+  whisk-str A = W.hom (β.str A)
 
-  whisk : nat-transf 𝓒 𝓔 W∘G W∘H
-  whisk = hcomp
+  whisk-ax : is-natural _ _ G-W H-W whisk-str
+  whisk-ax A B f =
+   𝓔.seq (W.hom (G.hom f)) (W.hom (β.str B)) ＝⟨ W.preserves-seq _ _ _ _ _ ⁻¹ ⟩
+   W.hom (𝓓.seq (G.hom f) (β.str B)) ＝⟨ ap W.hom (β.ax _ _ _) ⟩
+   W.hom (𝓓.seq (β.str A) (H.hom f)) ＝⟨ W.preserves-seq _ _ _ _ _ ⟩
+   𝓔.seq (W.hom (β.str A)) (W.hom (H.hom f)) ∎
+
+  whisk : nat-transf 𝓒 𝓔 G-W H-W
+  whisk = make whisk-str whisk-ax
+
+
+module
+ _
+  {𝓒 : precategory 𝓣 𝓤} {𝓓 : precategory 𝓥 𝓦}
+  (open functor-of-precategories)
+  (F : functor 𝓒 𝓓)
+ where
+ open natural-transformation
+
+ private
+  module 𝓓 = precategory 𝓓
+  module F = functor F
+  1[𝓒] = identity-functor.fun 𝓒
+  1[𝓓] = identity-functor.fun 𝓓
+  1[𝓒]-F = composite-functor.fun 1[𝓒] F
+  F-1[𝓓] = composite-functor.fun F 1[𝓓]
+  [𝓒,𝓓] = functor-category.precat 𝓒 𝓓
+  module [𝓒,𝓓] = precategory [𝓒,𝓓]
+
+ left-unitor : [𝓒,𝓓].hom 1[𝓒]-F F
+ nat-transf.str left-unitor A = 𝓓.idn (F.ob A)
+ nat-transf.ax left-unitor A B f =
+  𝓓.seq (F.hom f) (𝓓.idn (F.ob B)) ＝⟨ 𝓓.idn-R _ _ _ ⟩
+  F.hom f ＝⟨ 𝓓.idn-L _ _ _ ⁻¹ ⟩
+  𝓓.seq (𝓓.idn (F.ob A)) (F.hom f) ∎
+
+ left-unitor-inverse : [𝓒,𝓓].hom F 1[𝓒]-F
+ nat-transf.str left-unitor-inverse A = 𝓓.idn (F.ob A)
+ nat-transf.ax left-unitor-inverse A B f =
+  𝓓.seq (F.hom f) (𝓓.idn (F.ob B)) ＝⟨ 𝓓.idn-R _ _ _ ⟩
+  F.hom f ＝⟨ 𝓓.idn-L _ _ _ ⁻¹ ⟩
+  𝓓.seq (𝓓.idn (F.ob A)) (F.hom f) ∎
+
+ right-unitor : [𝓒,𝓓].hom F-1[𝓓] F
+ nat-transf.str right-unitor A = 𝓓.idn (F.ob A)
+ nat-transf.ax right-unitor A B f =
+  𝓓.seq (F.hom f) (𝓓.idn (F.ob B)) ＝⟨ 𝓓.idn-R _ _ _ ⟩
+  F.hom f ＝⟨ 𝓓.idn-L _ _ _ ⁻¹ ⟩
+  𝓓.seq (𝓓.idn (F.ob A)) (F.hom f) ∎
+
+ right-unitor-inverse : [𝓒,𝓓].hom F F-1[𝓓]
+ nat-transf.str right-unitor-inverse A = 𝓓.idn (F.ob A)
+ nat-transf.ax right-unitor-inverse A B f =
+  𝓓.seq (F.hom f) (𝓓.idn (F.ob B)) ＝⟨ 𝓓.idn-R _ _ _ ⟩
+  F.hom f ＝⟨ 𝓓.idn-L _ _ _ ⁻¹ ⟩
+  𝓓.seq (𝓓.idn (F.ob A)) (F.hom f) ∎
+
+ abstract
+  left-unitor-is-section : [𝓒,𝓓].seq left-unitor left-unitor-inverse ＝ [𝓒,𝓓].idn 1[𝓒]-F
+  left-unitor-is-section =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓓.seq (𝓓.idn (F.ob A)) (𝓓.idn (F.ob A)) ＝⟨ 𝓓.idn-L _ _ _ ⟩
+     𝓓.idn (F.ob A) ∎)
+
+  left-unitor-is-retraction : [𝓒,𝓓].seq left-unitor-inverse left-unitor ＝ [𝓒,𝓓].idn F
+  left-unitor-is-retraction =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓓.seq (𝓓.idn (F.ob A)) (𝓓.idn (F.ob A)) ＝⟨ 𝓓.idn-L _ _ _ ⟩
+     𝓓.idn (F.ob A) ∎)
+
+  right-unitor-is-section : [𝓒,𝓓].seq right-unitor right-unitor-inverse ＝ [𝓒,𝓓].idn F-1[𝓓]
+  right-unitor-is-section =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓓.seq (𝓓.idn (F.ob A)) (𝓓.idn (F.ob A)) ＝⟨ 𝓓.idn-L _ _ _ ⟩
+     𝓓.idn (F.ob A) ∎)
+
+  right-unitor-is-retraction : [𝓒,𝓓].seq right-unitor-inverse right-unitor ＝ [𝓒,𝓓].idn F
+  right-unitor-is-retraction =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓓.seq (𝓓.idn (F.ob A)) (𝓓.idn (F.ob A)) ＝⟨ 𝓓.idn-L _ _ _ ⟩
+     𝓓.idn (F.ob A) ∎)
+
+
+module
+ _
+  {𝓒 : precategory 𝓣 𝓤} {𝓓 : precategory 𝓥 𝓦}
+  {𝓔 : precategory 𝓣' 𝓤'} {𝓕 : precategory 𝓥' 𝓦'}
+  (open functor-of-precategories)
+  (F : functor 𝓒 𝓓) (G : functor 𝓓 𝓔) (H : functor 𝓔 𝓕)
+ where
+ open natural-transformation
+
+ private
+  [𝓒,𝓕] = functor-category.precat 𝓒 𝓕
+  module [𝓒,𝓕] = precategory [𝓒,𝓕]
+  module 𝓕 = precategory 𝓕
+  module H = functor H
+  module G = functor G
+  module F = functor F
+  F-G = composite-functor.fun F G
+  G-H = composite-functor.fun G H
+  F-[G-H] = composite-functor.fun F G-H
+  [F-G]-H = composite-functor.fun F-G H
+
+ associator : [𝓒,𝓕].hom F-[G-H] [F-G]-H
+ nat-transf.str associator A = 𝓕.idn (H.ob (G.ob (F.ob A)))
+ nat-transf.ax associator A B f =
+  𝓕.seq (H.hom (G.hom (F.hom f))) (𝓕.idn _) ＝⟨ 𝓕.idn-R _ _ _ ⟩
+  H.hom (G.hom (F.hom f)) ＝⟨ 𝓕.idn-L _ _ _ ⁻¹ ⟩
+  𝓕.seq (𝓕.idn _) (H.hom (G.hom (F.hom f))) ∎
+
+ associator-inverse : [𝓒,𝓕].hom [F-G]-H F-[G-H]
+ nat-transf.str associator-inverse A = 𝓕.idn (H.ob (G.ob (F.ob A)))
+ nat-transf.ax associator-inverse A B f =
+  𝓕.seq (H.hom (G.hom (F.hom f))) (𝓕.idn _) ＝⟨ 𝓕.idn-R _ _ _ ⟩
+  H.hom (G.hom (F.hom f)) ＝⟨ 𝓕.idn-L _ _ _ ⁻¹ ⟩
+  𝓕.seq (𝓕.idn _) (H.hom (G.hom (F.hom f))) ∎
+
+ abstract
+  associator-is-section : [𝓒,𝓕].seq associator associator-inverse ＝ [𝓒,𝓕].idn F-[G-H]
+  associator-is-section =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓕.seq (𝓕.idn _) (𝓕.idn _) ＝⟨ 𝓕.idn-L _ _ _ ⟩
+     𝓕.idn _ ∎)
+
+  associator-is-retraction : [𝓒,𝓕].seq associator-inverse associator ＝ [𝓒,𝓕].idn [F-G]-H
+  associator-is-retraction =
+   to-nat-transf-＝ _ _ _ _
+    (dfunext fe λ A →
+     𝓕.seq (𝓕.idn _) (𝓕.idn _) ＝⟨ 𝓕.idn-L _ _ _ ⟩
+     𝓕.idn _ ∎)
 
 \end{code}

--- a/source/Duploids/DeductiveSystem.lagda
+++ b/source/Duploids/DeductiveSystem.lagda
@@ -65,15 +65,35 @@ module _ (𝓓 : deductive-system-structure 𝓤 𝓥) where
   idn-R : statement-idn-R
   idn-R = pr₂ (pr₂ ax)
 
-deductive-system : (𝓤 𝓥 : Universe) → (𝓤 ⊔ 𝓥)⁺ ̇
-deductive-system 𝓤 𝓥 =
- Σ 𝓓 ꞉ deductive-system-structure 𝓤 𝓥 ,
- deductive-system-axioms 𝓓
+record deductive-system (𝓤 𝓥 : Universe) : (𝓤 ⊔ 𝓥)⁺ ̇ where
+ constructor make
+ field
+  str : deductive-system-structure 𝓤 𝓥
+  ax : deductive-system-axioms str
+ open deductive-system-structure str public
+ open deductive-system-axioms str ax public
 
-module deductive-system (𝓓 : deductive-system 𝓤 𝓥) where
- open deductive-system-structure (pr₁ 𝓓) public
- open deductive-system-axioms (pr₁ 𝓓) (pr₂ 𝓓) public
+module deductive-system-as-sum {𝓤 𝓥 : Universe} where
+ to-sum
+  : deductive-system 𝓤 𝓥
+  → Σ str ꞉ deductive-system-structure 𝓤 𝓥 , deductive-system-axioms str
+ to-sum 𝓓 = let open deductive-system 𝓓 in str , ax
 
+ from-sum
+  : (Σ str ꞉ deductive-system-structure 𝓤 𝓥 , deductive-system-axioms str)
+  → deductive-system 𝓤 𝓥
+ from-sum 𝓓 = make (pr₁ 𝓓) (pr₂ 𝓓)
+
+ to-sum-is-equiv : is-equiv to-sum
+ pr₁ (pr₁ to-sum-is-equiv) = from-sum
+ pr₂ (pr₁ to-sum-is-equiv) _ = refl
+ pr₁ (pr₂ to-sum-is-equiv) = from-sum
+ pr₂ (pr₂ to-sum-is-equiv) _ = refl
+
+ equiv
+  : deductive-system 𝓤 𝓥
+  ≃ (Σ str ꞉ deductive-system-structure 𝓤 𝓥 , deductive-system-axioms str)
+ equiv = to-sum , to-sum-is-equiv
 \end{code}
 
 We now begin to state the associativity properties that hold of certain

--- a/source/Duploids/Depolarization.lagda
+++ b/source/Duploids/Depolarization.lagda
@@ -29,7 +29,8 @@ open import Categories.Category fe
 open import Duploids.DeductiveSystem fe
 
 module _ (𝓓 : deductive-system 𝓤 𝓥) where
- open deductive-system 𝓓
+ module 𝓓 = deductive-system 𝓓
+ open 𝓓
  open polarities 𝓓
 
  is-pos-depolarized : 𝓤 ⊔ 𝓥 ̇
@@ -70,10 +71,10 @@ gives rise to a precategory.
 
 \begin{code}
  module depolarization-and-precategories (H : is-pos-depolarized) where
-  depolarization-gives-assoc : category-axiom-statements.statement-assoc (pr₁ 𝓓)
+  depolarization-gives-assoc : category-axiom-statements.statement-assoc 𝓓.str
   depolarization-gives-assoc A B C D f g h = H C D h A B g f ⁻¹
 
-  depolarization-gives-precategory-axioms : precategory-axioms (pr₁ 𝓓)
+  depolarization-gives-precategory-axioms : precategory-axioms 𝓓.str
   depolarization-gives-precategory-axioms =
    ⊢-is-set ,
    idn-L ,
@@ -82,15 +83,15 @@ gives rise to a precategory.
 
   precategory-of-depolarized-deductive-system : precategory 𝓤 𝓥
   precategory-of-depolarized-deductive-system =
-   make (pr₁ 𝓓) depolarization-gives-precategory-axioms
+   make 𝓓.str depolarization-gives-precategory-axioms
 \end{code}
 
 Conversely, any deductive system enjoying the axioms of a precategory is
 depolarized.
 
 \begin{code}
- module _ (ax : precategory-axioms (pr₁ 𝓓)) where
-  module ax = precategory-axioms (pr₁ 𝓓) ax
+ module _ (ax : precategory-axioms 𝓓.str) where
+  module ax = precategory-axioms 𝓓.str ax
 
   precategory-gives-pos-depolarized : is-pos-depolarized
   precategory-gives-pos-depolarized A B f U V g h =
@@ -156,7 +157,7 @@ precategory-to-depolarized-deductive-system 𝓒 =
   open precategory 𝓒
   open depolarization-and-precategories
   𝓓 : deductive-system _ _
-  𝓓 = precategory.str 𝓒 , hom-is-set , idn-L , idn-R
+  𝓓 = make (precategory.str 𝓒) (hom-is-set , idn-L , idn-R)
 
 depolarized-deductive-system-to-precategory-is-equiv
  : is-equiv (depolarized-deductive-system-to-precategory {𝓤} {𝓥})

--- a/source/Duploids/Depolarization.lagda
+++ b/source/Duploids/Depolarization.lagda
@@ -82,8 +82,7 @@ gives rise to a precategory.
 
   precategory-of-depolarized-deductive-system : precategory 𝓤 𝓥
   precategory-of-depolarized-deductive-system =
-   pr₁ 𝓓 ,
-   depolarization-gives-precategory-axioms
+   make (pr₁ 𝓓) depolarization-gives-precategory-axioms
 \end{code}
 
 Conversely, any deductive system enjoying the axioms of a precategory is
@@ -152,12 +151,12 @@ precategory-to-depolarized-deductive-system
  : precategory 𝓤 𝓥
  → depolarized-deductive-system 𝓤 𝓥
 precategory-to-depolarized-deductive-system 𝓒 =
- 𝓓 , precategory-gives-pos-depolarized 𝓓 (pr₂ 𝓒)
+ 𝓓 , precategory-gives-pos-depolarized 𝓓 (precategory.ax 𝓒)
  where
   open precategory 𝓒
   open depolarization-and-precategories
   𝓓 : deductive-system _ _
-  𝓓 = pr₁ 𝓒 , hom-is-set , idn-L , idn-R
+  𝓓 = precategory.str 𝓒 , hom-is-set , idn-L , idn-R
 
 depolarized-deductive-system-to-precategory-is-equiv
  : is-equiv (depolarized-deductive-system-to-precategory {𝓤} {𝓥})
@@ -165,8 +164,11 @@ depolarized-deductive-system-to-precategory-is-equiv = H
  where
   H : is-equiv (depolarized-deductive-system-to-precategory {𝓤} {𝓥})
   pr₁ H =
-   precategory-to-depolarized-deductive-system ,
-   λ 𝓒 → to-Σ-＝ (refl , precategory-axioms-is-prop (pr₁ 𝓒) _ _)
+   precategory-to-depolarized-deductive-system , λ 𝓒 →
+    equivs-are-lc
+     precategory-as-sum.to-sum
+     precategory-as-sum.to-sum-is-equiv
+     (to-Σ-＝ (refl , precategory-axioms-is-prop (precategory.str 𝓒) _ _))
   pr₂ H =
    precategory-to-depolarized-deductive-system ,
    λ (𝓓 , _) → to-Σ-＝ (refl , being-pos-depolarized-is-prop 𝓓 _ _)

--- a/source/Duploids/Duploid.lagda
+++ b/source/Duploids/Duploid.lagda
@@ -282,9 +282,6 @@ module unrestricted-upshift-functor (𝓓 : duploid 𝓤 𝓥) where
   axioms = preserves-idn , preserves-seq
 
  ⇑-functor : functor 𝓟 𝓝
- ⇑-functor = str.structure , ax.axioms
-
-
-
+ ⇑-functor = make str.structure ax.axioms
 
 \end{code}

--- a/source/Duploids/Duploid.lagda
+++ b/source/Duploids/Duploid.lagda
@@ -180,7 +180,7 @@ module _ (𝓓 : deductive-system 𝓤 𝓥) where
 
  module duploid-structure (str : duploid-structure) where
   underlying-preduploid : preduploid 𝓤 𝓥
-  underlying-preduploid = 𝓓 , pr₁ str
+  underlying-preduploid = make 𝓓 (pr₁ str)
 
   module _ (A : ob) where
    private
@@ -224,7 +224,7 @@ module unrestricted-upshift-functor (𝓓 : duploid 𝓤 𝓥) where
  module 𝓝 = precategory 𝓝
  module 𝓟 = precategory 𝓟
 
- open ⊢-properties (pr₁ 𝓓.underlying-preduploid)
+ open ⊢-properties (preduploid.underlying-deductive-system 𝓓.underlying-preduploid)
  open functor-of-precategories
  open duploid-notation 𝓓
 

--- a/source/Duploids/Preduploid.lagda
+++ b/source/Duploids/Preduploid.lagda
@@ -48,17 +48,35 @@ module _ (𝓓 : deductive-system 𝓤 𝓥) where
   Π-is-prop fe λ _ →
   being-polarized-is-prop
 
-preduploid : (𝓤 𝓥 : Universe) → (𝓤 ⊔ 𝓥)⁺ ̇
-preduploid 𝓤 𝓥 =  Σ 𝓓 ꞉ deductive-system 𝓤 𝓥 , preduploid-axioms 𝓓
+-- TODO: consider flattening the structure
+record preduploid (𝓤 𝓥 : Universe) : (𝓤 ⊔ 𝓥)⁺ ̇ where
+ constructor make
+ field
+  str : deductive-system 𝓤 𝓥
+  ax : preduploid-axioms str
 
-module preduploid (𝓓 : preduploid 𝓤 𝓥) where
- underlying-deductive-system : deductive-system 𝓤 𝓥
- underlying-deductive-system = pr₁ 𝓓
+ underlying-deductive-system = str
 
- open deductive-system underlying-deductive-system public
+ open deductive-system underlying-deductive-system hiding (str ; ax) public
 
- ob-is-polarized : (A : ob) → is-polarized underlying-deductive-system A
- ob-is-polarized = pr₂ 𝓓
+ ob-is-polarized : (A : ob) → is-polarized str A
+ ob-is-polarized = ax
+
+module preduploid-as-sum (𝓤 𝓥 : Universe) where
+ to-sum : preduploid 𝓤 𝓥 → Σ str ꞉ deductive-system 𝓤 𝓥 , preduploid-axioms str
+ to-sum 𝓓 = let open preduploid 𝓓 in str , ax
+
+ from-sum : (Σ str ꞉ deductive-system 𝓤 𝓥 , preduploid-axioms str) → preduploid 𝓤 𝓥
+ from-sum 𝓓 = make (pr₁ 𝓓) (pr₂ 𝓓)
+
+ to-sum-is-equiv : is-equiv to-sum
+ pr₁ (pr₁ to-sum-is-equiv) = from-sum
+ pr₂ (pr₁ to-sum-is-equiv) _ = refl
+ pr₁ (pr₂ to-sum-is-equiv) = from-sum
+ pr₂ (pr₂ to-sum-is-equiv) _ = refl
+
+ equiv : preduploid 𝓤 𝓥 ≃ (Σ str ꞉ deductive-system 𝓤 𝓥 , preduploid-axioms str)
+ equiv = to-sum , to-sum-is-equiv
 \end{code}
 
 It is currently not totally clear what the correct statement of univalence for a
@@ -67,6 +85,9 @@ with adjunctions) is to have two univalence conditions: one for thunkable maps
 between positive objects and another for linear maps between negative objects.
 
 \begin{code}
+module _ (𝓓 : preduploid 𝓤 𝓥) where
+ open preduploid 𝓓
+
  module preduploid-univalence where
   open polarities underlying-deductive-system
   open ⊢-properties underlying-deductive-system
@@ -126,7 +147,7 @@ implemented these yet.
 \begin{code}
 module NegativesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
  module 𝓓 = preduploid 𝓓
- open polarities (pr₁ 𝓓)
+ open polarities 𝓓.underlying-deductive-system
 
  ob : 𝓤 ⊔ 𝓥 ̇
  ob = Σ A ꞉ 𝓓.ob , is-negative A
@@ -161,7 +182,7 @@ module NegativesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
 
 module PositivesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
  module 𝓓 = preduploid 𝓓
- open polarities (pr₁ 𝓓)
+ open polarities 𝓓.underlying-deductive-system
 
  ob : 𝓤 ⊔ 𝓥 ̇
  ob = Σ A ꞉ 𝓓.ob , is-positive A
@@ -197,8 +218,8 @@ module PositivesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
 
 module NegativesAndLinearMaps (𝓓 : preduploid 𝓤 𝓥) where
  module 𝓓 = preduploid 𝓓
- open polarities (pr₁ 𝓓)
- open ⊢-properties (pr₁ 𝓓)
+ open polarities 𝓓.underlying-deductive-system
+ open ⊢-properties 𝓓.underlying-deductive-system
 
  ob : 𝓤 ⊔ 𝓥 ̇
  ob = Σ A ꞉ 𝓓.ob , is-negative A
@@ -245,8 +266,8 @@ module NegativesAndLinearMaps (𝓓 : preduploid 𝓤 𝓥) where
 
 module PositivesAndThunkableMaps (𝓓 : preduploid 𝓤 𝓥) where
  module 𝓓 = preduploid 𝓓
- open polarities (pr₁ 𝓓)
- open ⊢-properties (pr₁ 𝓓)
+ open polarities 𝓓.underlying-deductive-system
+ open ⊢-properties 𝓓.underlying-deductive-system
 
  ob : 𝓤 ⊔ 𝓥 ̇
  ob = Σ A ꞉ 𝓓.ob , is-positive A

--- a/source/Duploids/Preduploid.lagda
+++ b/source/Duploids/Preduploid.lagda
@@ -157,7 +157,7 @@ module NegativesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
   assoc A B C D f g h = pr₂ B (pr₁ A) f (pr₁ C) (pr₁ D) g h ⁻¹
 
   precat : precategory (𝓤 ⊔ 𝓥) 𝓥
-  precat = cat-data , hom-is-set , idn-L , idn-R , assoc
+  precat = make cat-data (hom-is-set , idn-L , idn-R , assoc)
 
 module PositivesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
  module 𝓓 = preduploid 𝓓
@@ -192,7 +192,7 @@ module PositivesAndAllMaps (𝓓 : preduploid 𝓤 𝓥) where
   assoc A B C D f g h = pr₂ C (pr₁ D) h (pr₁ A) (pr₁ B) g f ⁻¹
 
   precat : precategory (𝓤 ⊔ 𝓥) 𝓥
-  precat = cat-data , hom-is-set , idn-L , idn-R , assoc
+  precat = make cat-data (hom-is-set , idn-L , idn-R , assoc)
 
 
 module NegativesAndLinearMaps (𝓓 : preduploid 𝓤 𝓥) where
@@ -240,7 +240,7 @@ module NegativesAndLinearMaps (𝓓 : preduploid 𝓤 𝓥) where
    (pr₂ B (pr₁ A) (pr₁ f) (pr₁ C) (pr₁ D) (pr₁ g) (pr₁ h) ⁻¹)
 
  precat : precategory (𝓤 ⊔ 𝓥) (𝓤 ⊔ 𝓥)
- precat = cat-data , hom-is-set , idn-L , idn-R , assoc
+ precat = make cat-data (hom-is-set , idn-L , idn-R , assoc)
 
 
 module PositivesAndThunkableMaps (𝓓 : preduploid 𝓤 𝓥) where
@@ -288,7 +288,7 @@ module PositivesAndThunkableMaps (𝓓 : preduploid 𝓤 𝓥) where
    (pr₂ C (pr₁ D) (pr₁ h) (pr₁ A) (pr₁ B) (pr₁ g) (pr₁ f) ⁻¹)
 
  precat : precategory (𝓤 ⊔ 𝓥) (𝓤 ⊔ 𝓥)
- precat = cat-data , hom-is-set , idn-L , idn-R , assoc
+ precat = make cat-data (hom-is-set , idn-L , idn-R , assoc)
 
 
 \end{code}


### PR DESCRIPTION
When Σ-types are used, Agda is for some reason unable to infer a lot of implicit parameters; this becomes too unwieldy when doing category theory (e.g. natural transformations). I do not fully understand what it is about Σ-types that causes this information-loss, but switching to records solves the problem. In each case that I introduced a record, I proved it equivalent to a Σ-type. This is necessary when characterizing path spaces.

In the course of making this change, it was necessary to define the associators and unitors for functor composition. I think this is because when records are used instead of sums, various type dependencies end up involving the entire data of a functor, rather than just its action on objects and morphisms. (I still don't fully understand why that is, btw — but it seems to *also* be the reason why inference works better when records are used.)