### PR TITLE
Fix typo in extension file, add reals abs function

### DIFF
--- a/source/DedekindReals/Extension.lagda
+++ b/source/DedekindReals/Extension.lagda
@@ -1,7 +1,7 @@
 Andrew Sneap - 19 April 2023
 
-This file proves an extension theorem, which takes lifts functions (f : ℚ → ℚ)
-to functions (f̂ : ℝ → ℝ), given that f is uniformly continuous.
+This file proves an extension theorem, which extends functions (f : ℚ → ℚ) to
+functions (f̂ : ℝ → ℝ), given that f is uniformly continuous.
 
 Escardo contributed the Dedekind cut definition of the extension construction,
 suggested the "ball" notation and the paper proof that the "extend" function is
@@ -539,5 +539,90 @@ below). Hence we simply apply the extension thereom and we are done.
 
 ℝ-incr-agrees-with-ℚ-incr : (q : ℚ) → ℝ-incr (ι q) ＝ ι (ℚ-incr q)
 ℝ-incr-agrees-with-ℚ-incr q = extend-is-extension q ℚ-incr ℚ-incr-uc
+
+ℚ-neg-is-uc : ℚ-is-uniformly-continuous (-_)
+ℚ-neg-is-uc (ε , 0<ε) = (ε , 0<ε) , γ
+ where
+  γ : (x x₀ : ℚ) → x ∈𝐁 ε , 0<ε ⦅ x₀ ⦆ → (- x) ∈𝐁 ε , 0<ε ⦅ - x₀ ⦆
+  γ x x₀ (l₁ , l₂) = l₃ , l₄
+   where
+    l₃ : (- x₀) - ε < - x
+    l₃ = ℚ<-swap-right-add x x₀ ε l₂
+
+    l₄ : - x < (- x₀) + ε
+    l₄ = ℚ<-swap-left-neg x₀ ε x l₁
+
+ℝ-_ : ℝ → ℝ
+ℝ-_ = extend -_ ℚ-neg-is-uc
+
+open import Rationals.Abs
+
+abs-uc : ℚ-is-uniformly-continuous abs
+abs-uc (ε , 0<ε) = (ε , 0<ε) , γ
+ where
+  γ : (x x₀ : ℚ) → x ∈𝐁 ε , 0<ε ⦅ x₀ ⦆ → abs x ∈𝐁 ε , 0<ε ⦅ abs x₀ ⦆
+  γ x x₀ (l₁ , l₂) = γ' (ℚ-abs-inverse x) (ℚ-abs-inverse x₀)
+   where
+    I : (- x₀) - ε < - x
+    I = ℚ<-swap-right-add x x₀ ε l₂
+
+    II : - x < (- x₀) + ε
+    II = ℚ<-swap-left-neg x₀ ε x l₁
+
+    γ' : (abs x ＝ x) ∔ (abs x ＝ - x)
+       → (abs x₀ ＝ x₀) ∔ (abs x₀ ＝ - x₀)
+       → abs x ∈𝐁 ε , 0<ε ⦅ abs x₀ ⦆
+    γ' (inl e₁) (inl e₂) = l₃ , l₄
+     where
+      l₃ : abs x₀ - ε < abs x
+      l₃ = transport₂ (λ a b → a - ε < b) (e₂ ⁻¹) (e₁ ⁻¹) l₁
+
+      l₄ : abs x < abs x₀ + ε
+      l₄ = transport₂ (λ a b → b < a + ε) (e₂ ⁻¹) (e₁ ⁻¹) l₂
+
+    γ' (inl e₁) (inr e₂) = l₃ , l₄
+     where
+      III : abs x₀ - ε < - abs x
+      III = transport₂ (λ a b → a - ε < - b) (e₂ ⁻¹) (e₁ ⁻¹) I
+
+      l₃ : abs x₀ - ε < abs x
+      l₃ = ℚ<-≤-trans (abs x₀ - ε) (- abs x) (abs x) III (ℚ≤-abs-neg x)
+
+      IV : abs x < x₀ + ε
+      IV = transport (_< x₀ + ε) (e₁ ⁻¹) l₂
+
+      V : x₀ + ε ≤ abs x₀ + ε
+      V = ℚ≤-addition-preserves-order x₀ (abs x₀) ε (ℚ≤-abs-all x₀)
+
+      l₄ : abs x <ℚ abs x₀ + ε
+      l₄ = ℚ<-≤-trans (abs x) (x₀ + ε) (abs x₀ + ε) IV V
+
+    γ' (inr e₁) (inl e₂) = l₃ , l₄
+     where
+      III : abs x₀ - ε < x
+      III = transport (λ a → a - ε < x) (e₂ ⁻¹) l₁
+
+      l₃ : abs x₀ - ε < abs x
+      l₃ = ℚ<-≤-trans (abs x₀ - ε) x (abs x) III (ℚ≤-abs-all x)
+
+      IV : abs x < (- abs x₀) + ε
+      IV = transport₂ (λ a b → b < (- a) + ε) (e₂ ⁻¹) (e₁ ⁻¹) II
+
+      V : (- abs x₀) + ε ≤ abs x₀ + ε
+      V = ℚ≤-addition-preserves-order (- abs x₀) (abs x₀) ε (ℚ≤-abs-neg x₀)
+
+      l₄ : abs x < abs x₀ + ε
+      l₄ = ℚ<-≤-trans (abs x) ((- abs x₀) + ε) (abs x₀ + ε) IV V
+
+    γ' (inr e₁) (inr e₂) = l₃ , l₄
+     where
+      l₃ : abs x₀ - ε < abs x
+      l₃ = transport₂ (λ a b → a - ε < b) (e₂ ⁻¹) (e₁ ⁻¹) I
+
+      l₄ : abs x < abs x₀ + ε
+      l₄ = transport₂ (λ a b → b < a + ε) (e₂ ⁻¹) (e₁ ⁻¹) II
+
+ℝ-abs : ℝ → ℝ
+ℝ-abs = extend abs abs-uc
 
 \end{code}

--- a/source/Rationals/Abs.lagda
+++ b/source/Rationals/Abs.lagda
@@ -392,4 +392,13 @@ abs-mult x y = γ (ℚ-dichotomous' x 0ℚ) (ℚ-dichotomous' y 0ℚ)
   γ (inr l₁) (inl l₂) = γ₃ x y l₁ l₂
   γ (inr l₁) (inr l₂) = γ₁ l₁ l₂
 
+ℚ≤-abs-neg : (p : ℚ) → - abs p ≤ abs p
+ℚ≤-abs-neg p = γ (ℚ-abs-≤ p)
+ where
+  γ : - abs p ≤ p × p ≤ abs p → - abs p ≤ abs p
+  γ (l₁ , l₂) = ℚ≤-trans (- abs p) p (abs p) l₁ l₂
+
+ℚ≤-abs-all : (p : ℚ) → p ≤ abs p
+ℚ≤-abs-all p = pr₂ (ℚ-abs-≤ p)
+
 \end{code}

--- a/source/Rationals/Order.lagda
+++ b/source/Rationals/Order.lagda
@@ -1044,4 +1044,30 @@ order-lemma' p q r l = γ
   γ : p < r - 1/4 * ε ∔ r + 1/4 * ε < q
   γ = order-lemma (r + 1/4 * ε) (r - 1/4 * ε) q p IV
 
+ℚ<-swap-right-add : (p q r : ℚ) → p < q + r → (- q) - r < - p
+ℚ<-swap-right-add p q r l = γ
+ where
+  I : - (q + r) < - p
+  I = ℚ<-swap p (q + r) l
+
+  II : - (q + r) ＝ (- q) - r
+  II = ℚ-minus-dist q r ⁻¹
+
+  γ : (- q) - r < - p
+  γ = transport (_< - p) II I
+
+ℚ<-swap-left-neg : (p q r : ℚ) → p - q < r → - r < (- p) + q
+ℚ<-swap-left-neg p q r l = γ
+ where
+  I : - r <ℚ - (p - q)
+  I = ℚ<-swap (p - q) r l
+
+  II : - (p - q) ＝ (- p) + q
+  II = - (p - q)     ＝⟨ ℚ-minus-dist p (- q) ⁻¹            ⟩
+       (- p) - (- q) ＝⟨ ap ((- p) +_) (ℚ-minus-minus q ⁻¹) ⟩
+       (- p) + q     ∎
+
+  γ : - r < (- p) + q
+  γ = transport (- r <_) II I
+
 \end{code}


### PR DESCRIPTION
This pull request fixes the typo at the top of the extension file, and adds one more example (absolute value) of a uniformly continuous extension function extended from rationals to reals. 