### PR TITLE
Complete TODO in the `Continuity` module

### DIFF
--- a/source/EffectfulForcing/Continuity.lagda
+++ b/source/EffectfulForcing/Continuity.lagda
@@ -8,6 +8,7 @@ module EffectfulForcing.Continuity where
 
 open import MLTT.Spartan
 open import MLTT.Athenian
+open import Naturals.Order
 
 Baire : 𝓤₀ ̇
 Baire = ℕ → ℕ
@@ -75,3 +76,198 @@ C-restriction = _∘ embedding-C-B
 
 TODO. Formulate the usual notions of (uniform) continuity and prove
 that they are logically equivalent to the above.
+
+TODO completed below by Ayberk Tosun on 13/06/2023.
+
+We first formulate the `α ＝⦅ n ⦆ β` relation that expresses that two sequences
+`α`, `β` of natural numbers are equal up to (not inclusive) some bound `n`.
+These have adapted from the `CantorSearch` module authored by Martín Escardó
+(including the proofs `agreement→` and `agreement←`).
+
+\begin{code}
+
+hd : Baire → ℕ
+hd α = α 0
+
+tl : Baire → Baire
+tl α = α ∘ succ
+
+_＝⦅_⦆_ : Baire → ℕ → Baire → 𝓤₀  ̇
+α ＝⦅ 0      ⦆ β = 𝟙
+α ＝⦅ succ n ⦆ β = (hd α ＝ hd β) × tl α ＝⦅ n ⦆ tl β
+
+\end{code}
+
+\begin{code}
+
+agreement→ : (α α′ : Baire) (n : ℕ)
+           → α ＝⦅ n ⦆ α′
+           → (i : ℕ) → (i <ℕ n) → α i ＝ α′ i
+agreement→ α α′ zero     p         zero     ()
+agreement→ α α′ (succ n) (p₁ , p₂) zero     q = p₁
+agreement→ α α′ (succ n) (p₁ , p₂) (succ i) q = IH i q
+ where
+  IH : (j : ℕ) → j <ℕ n → α (succ j) ＝ α′ (succ j)
+  IH = agreement→ (tl α) (tl α′) n p₂
+
+agreement← : (α α′ : Baire) (n : ℕ)
+           → ((i : ℕ) → (i <ℕ n) → α i ＝ α′ i)
+           → α ＝⦅ n ⦆ α′
+agreement← α α′ zero     φ = ⋆
+agreement← α α′ (succ n) φ = φ 0 ⋆ , (agreement← (tl α) (tl α′) n ψ)
+ where
+  ψ : (j : ℕ) → j <ℕ n → tl α j ＝ tl α′ j
+  ψ j p = φ (succ j) (succ-monotone (succ j) n p)
+
+\end{code}
+
+Using the `_＝⦅_⦆_` relation, we express the "usual" notion of continuity
+mentioned in the TODO. We denote this `is-continuous₀`. At the end of the
+module, we prove that this is logically equivalent to `is-continuous`.
+
+\begin{code}
+
+is-continuous₀ : (Baire → ℕ) → 𝓤₀  ̇
+is-continuous₀ f =
+ (α : Baire) → Σ n ꞉ ℕ , ((α′ : Baire) → α ＝⦅ n ⦆ α′ → f α ＝ f α′)
+
+\end{code}
+
+We now formulate an alternative non-inductive version of the `_＝⟪_⟫_` relation
+that we call `_＝⟪_⟫₀_` and prove its logical equivalence with `_＝⟪_⟫_`. The
+motivation for the non-inductive formulation is that it simplifies the proof a
+bit.
+
+\begin{code}
+
+_＝⟪_⟫₀_ : Baire → List ℕ → Baire → 𝓤₀  ̇
+_＝⟪_⟫₀_ α s α′ = (i : ℕ) → member i s → α i ＝ α′ i
+
+＝⟪⟫₀-cons : (α α′ : Baire) (i : ℕ) (is : List ℕ)
+           → α ＝⟪ i ∷ is ⟫₀ α′ → α ＝⟪ is ⟫₀ α′
+＝⟪⟫₀-cons α α′ i is t j p = t j (in-tail p)
+
+\end{code}
+
+\begin{code}
+
+＝⟪⟫₀-implies-＝⟪⟫ : (α α′ : Baire) (s : List ℕ)
+                   → α ＝⟪ s ⟫₀ α′
+                   → α ＝⟪ s ⟫  α′
+＝⟪⟫₀-implies-＝⟪⟫ α α′ []       t = []
+＝⟪⟫₀-implies-＝⟪⟫ α α′ (i ∷ is) t =
+ (t i in-head) ∷ (＝⟪⟫₀-implies-＝⟪⟫ α α′ is (＝⟪⟫₀-cons α α′ i is t))
+
+＝⟪⟫-implies-＝⟪⟫₀ : (α α′ : Baire) (s : List ℕ) → α ＝⟪ s ⟫ α′ → α ＝⟪ s ⟫₀ α′
+＝⟪⟫-implies-＝⟪⟫₀ α α′ []       []       i ()
+＝⟪⟫-implies-＝⟪⟫₀ α α′ (i ∷ is) (p ∷ ps) i in-head     = p
+＝⟪⟫-implies-＝⟪⟫₀ α α′ (_ ∷ is) (p ∷ ps) j (in-tail q) =
+ ＝⟪⟫-implies-＝⟪⟫₀ α α′ is ps j q
+
+\end{code}
+
+We define the `maximum` function computing the maximum of a given list of
+natural numbers.
+
+\begin{code}
+
+maximum : List ℕ → ℕ
+maximum = foldr max 0
+
+\end{code}
+
+\section{`is-continuous` implies `is-continuous₀`}
+
+The fact that `is-continuous` implies `is-continuous₀` is the easy direction of
+the proof. We need only need two minor lemmas to conclude this proof.
+
+\begin{code}
+
+member-implies-below-max : (s : List ℕ) (i : ℕ) → member i s → i ≤ℕ maximum s
+member-implies-below-max (m ∷ ns) m in-head     = max-≤-upper-bound m (maximum ns)
+member-implies-below-max (n ∷ ns) m (in-tail p) =
+ ≤-trans m _ _ (member-implies-below-max ns m p) (max-≤-upper-bound' (maximum ns) n)
+
+
+＝⦅⦆-implies-＝⟪⟫-for-suitable-modulus : (α α′ : Baire) (s : List ℕ)
+       → α ＝⦅ succ (maximum s) ⦆ α′
+       → α ＝⟪ s ⟫ α′
+＝⦅⦆-implies-＝⟪⟫-for-suitable-modulus α α′ s t = ＝⟪⟫₀-implies-＝⟪⟫ α α′ s †
+ where
+  m : ℕ
+  m = succ (maximum s)
+
+  † : α ＝⟪ s ⟫₀ α′
+  † i p = agreement→ α α′ m t i (member-implies-below-max s i p)
+
+continuity-implies-continuity₀ : (f : Baire → ℕ)
+                               → is-continuous f → is-continuous₀ f
+continuity-implies-continuity₀ f c = †
+ where
+  † : is-continuous₀ f
+  † α = m , γ
+   where
+    s = pr₁ (c α)
+    m = succ (maximum s)
+
+    γ : (α′ : Baire) → α ＝⦅ m ⦆ α′ → f α ＝ f α′
+    γ α′ p = pr₂ (c α) α′ (＝⦅⦆-implies-＝⟪⟫-for-suitable-modulus α α′ s p)
+
+\end{code}
+
+\section{`is-continuous₀` implies `is-continuous`}
+
+We now address the other direction.
+
+We first define the `range` function such that `range n` is the list `[0..n]`
+ad prove its completeness.
+
+\begin{code}
+
+range : ℕ → List ℕ
+range zero     = [ 0 ]
+range (succ n) = succ n ∷ range n
+
+range-succ : (i n : ℕ) → member i (range n) → member (succ i) (range (succ n))
+range-succ zero     zero     p            = in-head
+range-succ (succ i) zero     (in-tail ())
+range-succ zero     (succ n) (in-tail p)  = in-tail (range-succ zero n p)
+range-succ (succ i) (succ i) in-head      = in-head
+range-succ (succ i) (succ n) (in-tail p)  = in-tail (range-succ (succ i) n p)
+
+range-is-complete : (i n : ℕ) → (i ≤ℕ n) → member i (range n)
+range-is-complete zero     zero     p = in-head
+range-is-complete zero     (succ n) p = in-tail (range-is-complete zero n p)
+range-is-complete (succ i) (succ n) p = range-succ i n (range-is-complete i n p)
+
+\end{code}
+
+We combine all these into a final lemma that we need:
+
+\begin{code}
+
+＝⟪⟫-range-implies-＝⦅⦆ : (α α′ : Baire) (n : ℕ) → α ＝⟪ range n ⟫ α′ → α ＝⦅ n ⦆ α′
+＝⟪⟫-range-implies-＝⦅⦆ α α′ n p = agreement← α α′ n †
+ where
+  † : (j : ℕ) → j <ℕ n → α j ＝ α′ j
+  † j q = ＝⟪⟫-implies-＝⟪⟫₀ α α′ (range n) p j ‡
+   where
+    ‡ : member j (range n)
+    ‡ = range-is-complete j n (<-coarser-than-≤ j n q)
+
+\end{code}
+
+The result that we wanted now easily follows:
+
+\begin{code}
+
+continuity₀-implies-continuity : (f : Baire → ℕ)
+                               → is-continuous₀ f → is-continuous f
+continuity₀-implies-continuity f c α = range m , γ
+ where
+  m = pr₁ (c α)
+
+  γ : (α′ : Baire) → α ＝⟪ range m ⟫ α′ → f α ＝ f α′
+  γ α′ p = pr₂ (c α) α′ (＝⟪⟫-range-implies-＝⦅⦆ α α′ m p)
+
+\end{code}


### PR DESCRIPTION
I saw the following TODO in the `Continuity` module

https://github.com/martinescardo/TypeTopology/blob/7909978897bd38fec666f6142a2917fd472673be/source/EffectfulForcing/Continuity.lagda#L76-L77

This pull request completes this TODO by adding a proof that `is-continuous` is logically equivalent to the “usual“ notion of continuity mentioned here.