### PR TITLE
Move the family-related definitions to the `Slice` directory

### DIFF
--- a/source/DomainTheory/Topology/ScottTopology.lagda
+++ b/source/DomainTheory/Topology/ScottTopology.lagda
@@ -21,6 +21,7 @@ open import UF.Subsingletons-FunExt
 open import Posets.Poset fe
 open import UF.ImageAndSurjection pt
 open import UF.Powerset
+open import Slice.Family
 
 open import UF.Logic
 open Universal fe
@@ -29,17 +30,6 @@ open Implication fe
 open Conjunction
 
 open import DomainTheory.Basics.Dcpo pt fe 𝓥
-
-Fam : (𝓤 : Universe) → 𝓦  ̇ → 𝓤 ⁺ ⊔ 𝓦  ̇
-Fam 𝓤 A = Σ I ꞉ 𝓤  ̇ , (I → A)
-
-index : {A : 𝓤  ̇ } → Fam 𝓦 A → 𝓦  ̇
-index (I , _) = I
-
-_[_] : {A : 𝓤 ̇ } → (U : Fam 𝓥 A) → index U → A
-(_ , f) [ i ] = f i
-
-infix 9 _[_]
 
 underlying-orderₚ : (𝓓 : DCPO {𝓤} {𝓣}) → ⟨ 𝓓 ⟩ → ⟨ 𝓓 ⟩ → Ω 𝓣
 underlying-orderₚ 𝓓 x y = (x ⊑⟨ 𝓓 ⟩ y) , prop-valuedness 𝓓 x y

--- a/source/Locales/AdjointFunctorTheoremForFrames.lagda
+++ b/source/Locales/AdjointFunctorTheoremForFrames.lagda
@@ -16,6 +16,7 @@ module Locales.AdjointFunctorTheoremForFrames
 
 open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe
+open import Slice.Family
 open import UF.Subsingletons
 open import UF.Logic
 

--- a/source/Locales/BooleanAlgebra.lagda
+++ b/source/Locales/BooleanAlgebra.lagda
@@ -13,6 +13,7 @@ open import UF.PropTrunc
 open import UF.FunExt
 open import UF.Size
 open import UF.PropTrunc
+open import Slice.Family
 open import MLTT.List hiding ([_])
 
 module Locales.BooleanAlgebra

--- a/source/Locales/CompactRegular.lagda
+++ b/source/Locales/CompactRegular.lagda
@@ -21,6 +21,7 @@ module Locales.CompactRegular
 
 open import UF.Subsingletons
 open import UF.Logic
+open import Slice.Family
 open import UF.Equiv using (_≃_; logically-equivalent-props-give-is-equiv)
 open import Locales.Frame pt fe hiding (is-directed)
 open import Locales.AdjointFunctorTheoremForFrames

--- a/source/Locales/Frame.lagda
+++ b/source/Locales/Frame.lagda
@@ -24,6 +24,7 @@ module Locales.Frame
 open import UF.Subsingletons
 open import UF.Logic
 open import UF.Subsingletons-FunExt
+open import Slice.Family
 
 open AllCombinators pt fe
 
@@ -31,47 +32,11 @@ open AllCombinators pt fe
 
 \section{Preliminaries}
 
-By Fam_𝓤(A), we denote the type of families on type A with index types
-living in universe 𝓤.
-
 \begin{code}
 
 private
   variable
     𝓤′ 𝓥′ 𝓦′ 𝓤′′ 𝓥′′ : Universe
-
-Fam : (𝓤 : Universe) → 𝓥 ̇ → 𝓤 ⁺ ⊔ 𝓥 ̇
-Fam 𝓤 A = Σ I ꞉ (𝓤 ̇ ), (I → A)
-
-fmap-syntax : {A : 𝓤 ̇ } {B : 𝓥 ̇ }
-            → (A → B) → Fam 𝓦 A → Fam 𝓦 B
-fmap-syntax h (I , f) = I , h ∘ f
-
-infix 2 fmap-syntax
-
-syntax fmap-syntax (λ x → e) U = ⁅ e ∣ x ε U ⁆
-
-compr-syntax : {A : 𝓤 ̇ } (I : 𝓦 ̇ )→ (I → A) → Fam 𝓦 A
-compr-syntax I f = I , f
-
-infix 2 compr-syntax
-
-syntax compr-syntax I (λ x → e) = ⁅ e ∣ x ∶ I ⁆
-
-\end{code}
-
-We define two projections for families: (1) for the index type,
-and (2) for the enumeration function.
-
-\begin{code}
-
-index : {A : 𝓤 ̇ } → Fam 𝓥 A → 𝓥 ̇
-index (I , _) = I
-
-_[_] : {A : 𝓤 ̇ } → (U : Fam 𝓥 A) → index U → A
-(_ , f) [ i ] = f i
-
-infix 9 _[_]
 
 \end{code}
 

--- a/source/Locales/InitialFrame.lagda
+++ b/source/Locales/InitialFrame.lagda
@@ -19,6 +19,7 @@ module Locales.InitialFrame
 open import UF.Subsingletons
 open import UF.Logic
 open import UF.Subsingletons-FunExt
+open import Slice.Family
 open import Locales.Frame pt fe
 open AllCombinators pt fe
 

--- a/source/Locales/PatchLocale.lagda
+++ b/source/Locales/PatchLocale.lagda
@@ -13,6 +13,7 @@ open import UF.FunExt
 open import UF.Univalence
 open import UF.UA-FunExt
 open import UF.EquivalenceExamples
+open import Slice.Family
 open import MLTT.List hiding ([_])
 open import MLTT.Pi
 

--- a/source/Locales/PatchProperties.lagda
+++ b/source/Locales/PatchProperties.lagda
@@ -13,6 +13,7 @@ open import UF.FunExt
 open import UF.Univalence
 open import UF.UA-FunExt
 open import UF.EquivalenceExamples
+open import Slice.Family
 open import MLTT.List hiding ([_])
 
 \end{code}

--- a/source/Locales/ScottLocale.lagda
+++ b/source/Locales/ScottLocale.lagda
@@ -16,6 +16,7 @@ open import UF.UA-FunExt
 open import UF.EquivalenceExamples
 open import MLTT.List hiding ([_])
 open import MLTT.Pi
+open import Slice.Family
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.Logic
@@ -38,7 +39,7 @@ open Existential pt
 open Conjunction
 open import Locales.Frame pt fe
 open import DomainTheory.Basics.Dcpo pt fe 𝓥 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Topology.ScottTopology pt fe 𝓥 hiding (Fam; index; _[_])
+open import DomainTheory.Topology.ScottTopology pt fe 𝓥
 
 open PropositionalTruncation pt
 

--- a/source/Locales/UniversalPropertyOfPatch.lagda
+++ b/source/Locales/UniversalPropertyOfPatch.lagda
@@ -17,6 +17,7 @@ open import UF.Equiv renaming (_■ to _𝔔𝔈𝔇)
 open import UF.Retracts
 open import UF.Embeddings
 open import UF.PropTrunc
+open import Slice.Family
 open import MLTT.List hiding ([_])
 
 module Locales.UniversalPropertyOfPatch

--- a/source/Slice/Family.lagda
+++ b/source/Slice/Family.lagda
@@ -1,0 +1,61 @@
+\begin{code}
+
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+module Slice.Family where
+
+open import MLTT.Spartan
+
+\end{code}
+
+By `Fam_𝓤(A)`, we denote the type of families on type A with index types living in
+universe `𝓤`.
+
+\begin{code}
+
+Fam : (𝓤 : Universe) → 𝓦  ̇ → 𝓤 ⁺ ⊔ 𝓦  ̇
+Fam 𝓤 A = Σ I ꞉ 𝓤  ̇ , (I → A)
+
+index : {A : 𝓤  ̇ } → Fam 𝓦 A → 𝓦  ̇
+index (I , _) = I
+
+\end{code}
+
+Indexing for families.
+
+\begin{code}
+
+_[_] : {A : 𝓤 ̇ } → (U : Fam 𝓥 A) → index U → A
+(_ , f) [ i ] = f i
+
+infix 9 _[_]
+
+\end{code}
+
+Comprehension notation.
+
+\begin{code}
+
+compr-syntax : {A : 𝓤 ̇ } (I : 𝓦 ̇ )→ (I → A) → Fam 𝓦 A
+compr-syntax I f = I , f
+
+infix 2 compr-syntax
+
+syntax compr-syntax I (λ x → e) = ⁅ e ∣ x ∶ I ⁆
+
+\end{code}
+
+Comprehension over another family.
+
+\begin{code}
+
+fmap-syntax : {A : 𝓤 ̇ } {B : 𝓥 ̇ }
+            → (A → B) → Fam 𝓦 A → Fam 𝓦 B
+fmap-syntax h (I , f) = I , h ∘ f
+
+infix 2 fmap-syntax
+
+syntax fmap-syntax (λ x → e) U = ⁅ e ∣ x ε U ⁆
+
+\end{code}
+


### PR DESCRIPTION
Definition of `Fam` and some related definitions (e.g. comprehension syntax) are moved by this PR to the new `Family` module in the `Slice` directory.