### PR TITLE
Idempotents in wild category theory

### DIFF
--- a/source/UF/Base.lagda
+++ b/source/UF/Base.lagda
@@ -323,6 +323,13 @@ left-inverse {𝓤} {X} {x} {y} refl = refl
 right-inverse : {X : 𝓤 ̇ } {x y : X} (p : x ＝ y) → refl ＝ p ∙ p ⁻¹
 right-inverse {𝓤} {X} {x} {y} refl = refl
 
+cancel-right
+ : {X : 𝓤 ̇ } {x y z : X}
+ → (p : x ＝ y) (q : x ＝ y) (r : y ＝ z)
+ → p ∙ r ＝ q ∙ r
+ → p ＝ q
+cancel-right refl refl refl refl = refl
+
 cancel-left : {X : 𝓤 ̇ } {x y z : X} {p : x ＝ y} {q r : y ＝ z}
             → p ∙ q ＝ p ∙ r
             → q ＝ r

--- a/source/WildCategories/Base.lagda
+++ b/source/WildCategories/Base.lagda
@@ -1,0 +1,36 @@
+Jon Sterling and Mike Shulman, September 2023.
+
+\begin{code}
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+module WildCategories.Base where
+
+open import MLTT.Spartan
+open import UF.Subsingletons
+
+record WildCategory 𝓤 𝓥 : (𝓤 ⊔ 𝓥)⁺ ̇ where
+ field
+  ob : 𝓤 ̇
+  hom : ob → ob → 𝓥 ̇
+  idn : (x : ob) → hom x x
+  _<<_ : {x y z : ob} (g : hom y z) (f : hom x y) → hom x z
+  assoc
+   : {u v w x : ob} (f : hom u v) (g : hom v w) (h : hom w x)
+   → h << (g << f) ＝ (h << g) << f
+  lunit
+   : {x y : ob} (f : hom x y)
+   → f << idn x ＝ f
+  runit
+   : {x y : ob} (f : hom x y)
+   → idn y << f ＝ f
+
+module _ {𝓤 𝓥} (C : WildCategory 𝓤 𝓥) where
+ open WildCategory C
+
+ is-initial-object : ob → 𝓤 ⊔ 𝓥 ̇
+ is-initial-object I = (x : ob) → is-singleton (hom I x)
+
+ has-initial-object : 𝓤 ⊔ 𝓥 ̇
+ has-initial-object = Σ is-initial-object
+
+\end{code}

--- a/source/WildCategories/Cones.lagda
+++ b/source/WildCategories/Cones.lagda
@@ -1,0 +1,158 @@
+Jon Sterling and Mike Shulman, September 2023.
+
+Arguments due to Mike Shulman, typed into Agda by Jon Sterling.
+
+The results of this module are as follows:
+
+1. Let P : Δ I → Id[C] be an incoherent cone over the identity functor on a
+   wild category C. If the “generic point” P[I] : I → I is the identity map,
+   then I is an initial object of C.
+
+2. Let P : Δ I → Id[C] be a incoherent cone over the identity functor on a
+   wild category C. If the generic point p[I] : I → I admits a splitting
+   I → J → I, then J is the initial object of C.
+
+3. Let P : Δ I → Id[C] be a “semicoherent cone”. Then the generic point
+   p[I] : I → I has the structure of a quasi-idempotent in the sense of Shulman.
+
+It follows therefore that a wild category in which all quasi-idempotents split
+has an initial object when it possesses a semicoherent cone over the identity
+functor.
+
+\begin{code}
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+module WildCategories.Cones where
+
+open import MLTT.Spartan
+open import UF.Base
+open import UF.Subsingletons
+
+open import WildCategories.Base
+open import WildCategories.Idempotents
+
+module _ {𝓤 𝓥} (C : WildCategory 𝓤 𝓥) where
+ open WildCategory C
+
+ record IncohIdnCone : 𝓤 ⊔ 𝓥 ̇ where
+  field
+   apex : ob
+   cone : (x : ob) → hom apex x
+   nat
+    : {x y : ob} (f : hom x y)
+    → f << cone x ＝ cone y
+
+  gen : hom apex apex
+  gen = cone apex
+
+  gen# : (gen << cone apex) ＝ cone apex
+  gen# = nat gen
+
+  has-coherent-generic-point : 𝓥 ̇
+  has-coherent-generic-point = gen ＝ idn apex
+
+ record SemicohIdnCone : 𝓤 ⊔ 𝓥 ̇ where
+  field
+   apex : ob
+   cone : (x : ob) → hom apex x
+   nat
+    : {x y : ob} (f : hom x y)
+    → f << cone x ＝ cone y
+   coh
+    : {x y z : ob} (f : hom x y) (g : hom y z) (h : hom x z)
+    → (K : g << f ＝ h)
+    → ap (_<< cone x) K ∙ nat h
+    ＝ assoc (cone x) f g ⁻¹ ∙ ap (g <<_) (nat f) ∙ nat g
+
+  underlying-incoh-cone : IncohIdnCone
+  underlying-incoh-cone = record { apex = apex ; cone = cone ; nat = nat }
+
+  open IncohIdnCone underlying-incoh-cone public hiding (apex; cone; nat)
+
+
+ module _ (P : IncohIdnCone) where
+  private
+   module P = IncohIdnCone P
+
+  apex-is-initial : P.has-coherent-generic-point → is-initial-object C P.apex
+  pr₁ (apex-is-initial coh x) = P.cone x
+  pr₂ (apex-is-initial coh x) f =
+   P.cone x ＝⟨ P.nat f ⁻¹ ⟩
+   f << P.gen ＝⟨ ap (f <<_) coh ⟩
+   f << idn P.apex ＝⟨ lunit f ⟩
+   f ∎
+
+ module _ (P : IncohIdnCone) where
+  private
+   module P = IncohIdnCone P
+
+  module _ (gen-split : Splitting C _ P.gen) where
+   private
+    module gen-split = Splitting gen-split
+
+   S : IncohIdnCone
+   IncohIdnCone.apex S = gen-split.mid
+   IncohIdnCone.cone S x = P.cone x << gen-split.sec
+   IncohIdnCone.nat S f =
+    assoc gen-split.sec (P.cone _) f
+    ∙ ap (_<< gen-split.sec) (P.nat f)
+
+   private
+    module S = IncohIdnCone S
+
+   coh : S.has-coherent-generic-point
+   coh = ap (_<< gen-split.sec) H ∙ gen-split.sec-is-section
+    where
+     H : P.cone gen-split.mid ＝ gen-split.ret
+     H =
+      P.cone gen-split.mid
+       ＝⟨ P.nat gen-split.ret ⁻¹ ⟩
+      gen-split.ret << P.gen
+       ＝⟨ ap (gen-split.ret <<_) (gen-split.splitting ⁻¹) ⟩
+      gen-split.ret << (gen-split.sec << gen-split.ret)
+       ＝⟨ assoc gen-split.ret gen-split.sec gen-split.ret ⟩
+      (gen-split.ret << gen-split.sec) << gen-split.ret
+       ＝⟨ ap (_<< gen-split.ret) gen-split.sec-is-section ⟩
+      idn _ << gen-split.ret
+       ＝⟨ runit gen-split.ret ⟩
+      gen-split.ret ∎
+
+   initiality : has-initial-object C
+   pr₁ initiality = S.apex
+   pr₂ initiality = apex-is-initial S coh
+
+
+ module _ (P : SemicohIdnCone) where
+  private
+   module P = SemicohIdnCone P
+   gen-gen# = ap (P.gen <<_) P.gen#
+   gen#-gen = ap (_<< P.gen) P.gen#
+
+  open QuasiIdempotence
+
+  gen-qidem : QuasiIdempotence C P.apex P.gen
+  Q0 gen-qidem = P.gen#
+  Q1 gen-qidem = cancel-right _ _ P.gen# H2
+
+   where
+    H0 : gen#-gen ∙ P.gen# ＝ assoc P.gen P.gen P.gen ⁻¹ ∙ gen-gen# ∙ P.gen#
+    H0 = P.coh P.gen P.gen P.gen P.gen#
+
+    H1 : assoc P.gen P.gen P.gen ∙ (gen#-gen ∙ P.gen#) ＝ gen-gen# ∙ P.gen#
+    H1 =
+     assoc P.gen P.gen P.gen ∙ (gen#-gen ∙ P.gen#)
+      ＝⟨ ap (assoc P.gen P.gen P.gen ∙_) H0 ⟩
+     assoc P.gen P.gen P.gen ∙ (assoc P.gen P.gen P.gen ⁻¹ ∙ gen-gen# ∙ P.gen#)
+      ＝⟨ ap (assoc P.gen P.gen P.gen ∙_) (∙assoc (assoc P.gen P.gen P.gen ⁻¹) (gen-gen#) P.gen#) ⟩
+     assoc P.gen P.gen P.gen ∙ (assoc P.gen P.gen P.gen ⁻¹ ∙ (gen-gen# ∙ P.gen#))
+      ＝⟨ ∙assoc (assoc P.gen P.gen P.gen) (assoc P.gen P.gen P.gen ⁻¹) (gen-gen# ∙ P.gen#) ⁻¹ ⟩
+     (assoc P.gen P.gen P.gen ∙ assoc P.gen P.gen P.gen ⁻¹) ∙ (gen-gen# ∙ P.gen#)
+      ＝⟨ ap (_∙ (gen-gen# ∙ P.gen#)) (right-inverse (assoc P.gen P.gen P.gen) ⁻¹) ⟩
+     refl ∙ (gen-gen# ∙ P.gen#)
+      ＝⟨ refl-left-neutral ⟩
+     gen-gen# ∙ P.gen# ∎
+
+    H2 : assoc _ _ _ ∙ gen#-gen ∙ P.gen# ＝ gen-gen# ∙ P.gen#
+    H2 = ∙assoc (assoc _ _ _ ) (gen#-gen) P.gen# ∙ H1
+
+\end{code}

--- a/source/WildCategories/Idempotents.lagda
+++ b/source/WildCategories/Idempotents.lagda
@@ -1,0 +1,36 @@
+Jon Sterling and Mike Shulman, September 2023.
+
+\begin{code}
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+module WildCategories.Idempotents where
+
+open import MLTT.Spartan
+open import UF.Base
+open import UF.Subsingletons
+
+open import WildCategories.Base
+
+module _ {𝓤 𝓥} (C : WildCategory 𝓤 𝓥) where
+ open WildCategory C
+
+ record QuasiIdempotence (x : ob) (m : hom x x) : 𝓥 ̇ where
+  field
+   Q0 : m << m ＝ m
+   Q1 : assoc m m m ∙ ap (_<< m) Q0 ＝ ap (m <<_) Q0
+
+ record Splitting (x : ob) (m : hom x x) : 𝓤 ⊔ 𝓥 ̇ where
+  field
+   mid : ob
+   sec : hom mid x
+   ret : hom x mid
+   sec-is-section : ret << sec ＝ idn mid
+   splitting : sec << ret ＝ m
+
+ quasi-idempotents-split : 𝓤 ⊔ 𝓥 ̇
+ quasi-idempotents-split =
+  (x : ob) (m : hom x x)
+  → QuasiIdempotence x m
+  → Splitting x m
+
+\end{code}

--- a/source/WildCategories/index.lagda
+++ b/source/WildCategories/index.lagda
@@ -1,0 +1,15 @@
+Jon Sterling and Mike Shulman, September 2023.
+
+Arguments due to Mike Shulman, typed into Agda by Jon Sterling.
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+module WildCategories.index where
+
+import WildCategories.Base
+import WildCategories.Idempotents
+import WildCategories.Cones
+
+\end{code}

--- a/source/index.lagda
+++ b/source/index.lagda
@@ -166,6 +166,7 @@ import TypeTopology.index
 import UF.index
 import Various.index
 import W.index
+import WildCategories.index
 
 \end{code}
 


### PR DESCRIPTION
I have been formalizing some arguments due to [Mike Shulman](https://homotopytypetheory.org/2018/11/26/impredicative-encodings-part-3/). The idea is to deduce that a wild category has an initial object (in the sense of certain contractible hom spaces) when it possesses an incoherent cone `\Delta I ---> Id` over its identity functor, whose "generic" component at `I` itself splits as `(I --> I) == (I --> J --> I)`. In particular, `J` is the initial object.

Furthermore, if you have a "semicoherent" cone (this semicoherence is basically the next dimension of naturality wrt. binary composition), then its generic component is a quasi-idempotent in the sense of Shulman's paper on idempotents in ITT. Therefore, if quasi-idempotents split, you can use this to find an initial object.