### PR TITLE
Suggest general reasoning chain notation

### DIFF
--- a/source/Notation/Order.lagda
+++ b/source/Notation/Order.lagda
@@ -118,3 +118,31 @@ record Order-Chain {𝓤} {𝓥} {𝓦} {𝓣} {𝓧 : Universe}
 open Order-Chain {{...}} public
 
 \end{code}
+
+Lane Biocini, 10 October 2023
+
+Define a general notation for reasoning chains
+
+\begin{code}
+record Reflexive-Order {𝓤} (X : 𝓤 ̇ )
+ (_R_ : X → X → 𝓤 ̇ ) : 𝓤 ̇  where
+ field
+  _▨ : (x : X) → x R x
+
+ infix 1 _▨
+
+open Reflexive-Order {{...}} public
+
+record Reasoning-Chain {𝓤} {𝓥} {𝓦} {𝓣} {𝓧 : Universe}
+ (X : 𝓤 ̇ ) (Y : 𝓥 ̇ ) (Z : 𝓦 ̇ )
+ (_R₁_ : X → Y → 𝓦 ̇ )
+ (_R₂_ : Y → Z → 𝓣 ̇ )
+ (_R₃_ : X → Z → 𝓧 ̇ ) : (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓣 ⊔ 𝓧)⁺ ̇  where
+ field
+  _⸴_⊢_ : (x : X) {y : Y} {z : Z} → x R₁ y → y R₂ z → x R₃ z
+
+ infixr 0 _⸴_⊢_
+
+open Reasoning-Chain {{...}} public
+
+\end{code}


### PR DESCRIPTION
I'd like to propose a new notation type class to generalize Reasoning Chain notation. All partial orders have transitivity, and as I'm sure anyone who has spent time coding an order module might agree, it would be extremely useful to have reasoning chain notation similar to the one we use for the identity type to make proofs neat and tidy.

The definition I propose reads as follows:
```
record Reflexive-Order {𝓤} (X : 𝓤 ̇ )
 (_R_ : X → X → 𝓤 ̇ ) : 𝓤 ̇  where
 field
  _▨ : (x : X) → x R x

 infix 1 _▨

open Reflexive-Order {{...}} public

record Reasoning-Chain {𝓤} {𝓥} {𝓦} {𝓣} {𝓧 : Universe}
 (X : 𝓤 ̇ ) (Y : 𝓥 ̇ ) (Z : 𝓦 ̇ )
 (_R₁_ : X → Y → 𝓦 ̇ )
 (_R₂_ : Y → Z → 𝓣 ̇ )
 (_R₃_ : X → Z → 𝓧 ̇ ) : (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓣 ⊔ 𝓧)⁺ ̇  where
 field
  _⸴_⊢_ : (x : X) {y : Y} {z : Z} → x R₁ y → y R₂ z → x R₃ z

 infixr 0 _⸴_⊢_
```

Where '⊢' reads 'entails' (as one would expect) and '⸴' reads as 'with', which are respectively typed in by '\\|-' and the fourth option for '\\,'. '▨' can be typed in with the 13th option for '\\sq'.

This is what it looks like in a proof:

```
≼-triangle-inequality zero (succ y) (succ z) =
   succ z                          ⸴ α
 ⊢ succ ∣ zero - z ∣               ⸴ ap succ Δ
 ⊢ succ (∣ zero - y ∣ + ∣ y - z ∣) ⸴ β
 ⊢ succ (y + ∣ y - z ∣)            ⸴ δ
 ⊢ succ y + ∣ y - z ∣              ▨
  where
   Δ : ∣ zero - z ∣ ≼ℕ (∣ zero - y ∣ + ∣ y - z ∣)
   Δ = ≼-triangle-inequality zero y z

   α : succ z ≼ℕ succ ∣ zero - z ∣
   α = ≼-＝ (succ z) (succ ∣ zero - z ∣) (ap succ (minus-nothing z ⁻¹))
 
   β : succ (∣ zero - y ∣ + ∣ y - z ∣) ≼ℕ succ (y + ∣ y - z ∣)
   β = ap succ (≼-＝ (∣ zero - y ∣ + ∣ y - z ∣) (y + ∣ y - z ∣)
    (ap (_+ ∣ y - z ∣) (minus-nothing y)))

   δ : succ (y + ∣ y - z ∣) ≼ℕ (succ y + ∣ y - z ∣)
   δ = ≼-＝ (succ (y + ∣ y - z ∣)) (succ y + ∣ y - z ∣) 
    (succ-left y ∣ y - z ∣ ⁻¹)
```

Obviously, this should only be used in cases where one type of reasoning chain will predominate in a module. To define it, as usual, one instantiates it. This is what that looks like for the example module I'm working on:

```
_≼ℕ⟨_⟩_ : (x : ℕ) {y z : ℕ} → x ≼ y → y ≼ z → x ≼ z
(_≼ℕ⟨_⟩_) x {y} {z} p q = ≼-trans x y z p q

private instance
 Reasoning-Chain-≼ℕ : Reasoning-Chain ℕ ℕ ℕ (_≼ℕ_) (_≼ℕ_) (_≼ℕ_)
 _⸴_⊢_ {{Reasoning-Chain-≼ℕ}} = _≼ℕ⟨_⟩_

 Reflexive-Order-≼ℕ : Reflexive-Order ℕ (_≼ℕ_)
 _▨ {{Reflexive-Order-≼ℕ}} = ≼-refl
```

Testing on my end, it works just as well as the one we use for identity types. I believe this notation is clean, intuitive, ergonomic, and expressive as a general notation format for reasoning chains, so I submit it for the project's consideration. 