### PR TITLE
Document two more conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,9 @@ document, we provide a list of conventions and practices that we expect
   `∶` (i.e. the Unicode symbol `RATIO`), which is what you get by typing `\:` in
   Agda mode. To get the former, you have to type `\:4`
 - Avoid `with` clauses when defining functions.
+- In the index files, whose purposes are to import modules in subdirectories,
+  make sure to alphabetically sort the `import` lines. This is preferable in all
+  modules but it is a rule only for index files.
 
 [1]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/MLTT.Universes.html
 [2]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/DomainTheory.Basics.Dcpo.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,15 @@ document, we provide a list of conventions and practices that we expect
 - In the index files, whose purposes are to import modules in subdirectories,
   make sure to _alphabetically sort_ the `import` lines. This is preferable in
   all modules but it is a rule only for index files.
+- When the type signature for a function `foo : A → B → C → D` gets over the
+  character limit of 80 characters, break and indent it as:
+  ```
+  foo
+   : A
+   → B
+   → C
+   → D
+  ```
 
 [1]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/MLTT.Universes.html
 [2]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/DomainTheory.Basics.Dcpo.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ document, we provide a list of conventions and practices that we expect
 - In the index files, whose purposes are to import modules in subdirectories,
   make sure to _alphabetically sort_ the `import` lines. This is preferable in
   all modules but it is a rule only for index files.
-- When the type signature for a function `foo : A → B → C → D` gets over the
+- When the type signature for a function `foo : A → B → C → D` goes over the
   character limit of 80 characters, break and indent it as:
   ```
   foo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ document, we provide a list of conventions and practices that we expect
   Agda mode. To get the former, you have to type `\:4`
 - Avoid `with` clauses when defining functions.
 - In the index files, whose purposes are to import modules in subdirectories,
-  make sure to alphabetically sort the `import` lines. This is preferable in all
-  modules but it is a rule only for index files.
+  make sure to _alphabetically sort_ the `import` lines. This is preferable in
+  all modules but it is a rule only for index files.
 
 [1]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/MLTT.Universes.html
 [2]: https://www.cs.bham.ac.uk/~mhe/TypeTopology/DomainTheory.Basics.Dcpo.html


### PR DESCRIPTION
Document two more conventions:

  1. Sorting import lines.
  1. Indentation for type signatures that go over the character limit.