### PR TITLE
Add sigma closed subuniverses

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Please add yourself the first time you contribute.
 
 * Alice Laroche
 * Andrew Sneap
+* Andrew Swan
 * Ayberk Tosun
 * Brendan Hart
 * Bruno Paiva

--- a/source/Modal/SigmaClosedReflectiveSubuniverse.lagda
+++ b/source/Modal/SigmaClosedReflectiveSubuniverse.lagda
@@ -1,0 +1,63 @@
+Andrew Swan, 6th February 2024
+
+Σ-closed reflective subuniverse is one of the three definitions of
+modalities given in [1] (Definition 1.3). The aim of this file is
+to collect together results about them. For now we just have one
+result that is often useful in practice: for Σ-closed universes, we have
+not just recursion, but induction.
+
+[1] Rijke, Shulman, Spitters, Modalities in homotopy type theory,
+https://doi.org/10.23638/LMCS-16(1:2)2020
+
+\begin{code}
+{-# OPTIONS --safe --without-K --exact-split --auto-inline #-}
+
+open import MLTT.Spartan
+open import UF.Base
+open import UF.FunExt
+open import Modal.Subuniverse
+
+module Modal.SigmaClosedReflectiveSubuniverse
+ (P : subuniverse 𝓤 𝓥)
+ (P-is-reflective : subuniverse-is-reflective P)
+ (P-is-sigma-closed : subuniverse-is-sigma-closed P)
+ where
+\end{code}
+
+A Σ-closed reflective subuniverse is in particular a reflective
+subuniverse, so we first import everything already proved for
+reflective subuniverses in general.
+
+\begin{code}
+open import Modal.ReflectiveSubuniverse P P-is-reflective public
+\end{code}
+
+We can now prove the induction principle. We do this as a direct
+proof from the Σ-closed condition, using it together with the
+recursion principle to construct a map g : ○ A → Σ a : ○ A, B a and
+then using uniqueness to show that composition pr₁ ∘ g is the identity
+on ○ A.
+
+\begin{code}
+○-induction
+ : (fe : funext 𝓤 𝓤)
+ → (A : 𝓤 ̇)
+ → (B : ○ A → 𝓤 ̇)
+ → (B-modal : (α : ○ A) → is-modal (B α))
+ → ((a : A) → B (η A a))
+ → (α : ○ A) → B α
+○-induction fe A B B-modal f α = transport B (happly h α) (pr₂ (g α))
+ where
+  g : ○ A → Σ B
+  g = ○-rec
+       _ _
+       (P-is-sigma-closed _ _ (○-is-modal _) B-modal)
+       λ a → (η _ a) , (f a)
+
+  h : pr₁ ∘ g ＝ id
+  h = ○-rec-ext
+       _ _
+       (○-is-modal _)
+       _ _
+       (dfunext fe (λ a → ap pr₁ (○-rec-compute _ _ _ _ a)))
+\end{code}

--- a/source/Modal/Subuniverse.lagda
+++ b/source/Modal/Subuniverse.lagda
@@ -1,4 +1,5 @@
 Jon Sterling, started 27th Sep 2022
+Andrew Swan, 7th Februrary 2024, definition of Σ-closed subuniverse added
 
 \begin{code}
 
@@ -83,3 +84,14 @@ univalence-implies-subuniverse-is-replete ua P A B e =
  transport⁻¹
   (subuniverse-contains P)
   (eqtoid ua A B e)
+
+subuniverse-is-sigma-closed
+ : (P : subuniverse 𝓤 𝓥)
+ → 𝓤 ⁺ ⊔ 𝓥  ̇
+subuniverse-is-sigma-closed P =
+ (A : _) →
+ (B : A → _) →
+ pr₁ P A →
+ ((a : A) → pr₁ P (B a)) →
+ pr₁ P (Σ B)
+\end{code}

--- a/source/Modal/index.lagda
+++ b/source/Modal/index.lagda
@@ -14,6 +14,7 @@ module Modal.index where
 
 import Modal.Subuniverse
 import Modal.ReflectiveSubuniverse
+import Modal.SigmaClosedReflectiveSubuniverse
 import Modal.Homotopy
 
 \end{code}


### PR DESCRIPTION
At the moment the library has definitions of subuniverse and reflective subuniverse. In order to get one of the 3 definitions of modalities given by Rijke, Shulman, Spitters, Modalities in HoTT, we have to add an extra condition to reflective subuniverse - that it is sigma closed. This patch adds the definition and a proof of the induction principle for sigma closed subuniverses.