### PR TITLE
Absoluteness of compactness example

### DIFF
--- a/source/Modal/Open.lagda
+++ b/source/Modal/Open.lagda
@@ -130,3 +130,20 @@ open-is-sigma-closed A B A-modal B-modal =
     (λ a → (open-unit (B a)) , (B-modal a))
 
 \end{code}
+
+We add a useful lemma for the absoluteness of compactness: if P is a
+true proposition then the open modality is trivial, in the sense that
+all types are modal.
+
+\begin{code}
+
+P-true-implies-all-modal
+ : (z : P) → (A : 𝓤 ̇ ) → is-open-modal A
+P-true-implies-all-modal z A =
+ qinvs-are-equivs
+  (open-unit A)
+  ((λ f → f z) ,
+   ((λ a → refl) ,
+   (λ f → dfunext fe (λ z' → ap f (P-is-prop z z')))))
+
+\end{code}

--- a/source/TypeTopology/AbsolutenessOfCompactness.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactness.lagda
@@ -400,13 +400,11 @@ result which is closer to the statement of prop-tychonoff. This says ○
 "preserves compactness" in the sense that if ○ (A is compact), then
 (○ A) is compact.
 
-We note that the arguments in prop-tychonoff show that we can think of
-the family of types Y : X → 𝓥 ̇  without loss of generality as a
-constant family. Aside from that and the assumption here of
-univalence, we can view the remainder of theorem prop-tychonoff as a
-special case of the one below. To see this, note that when X is a
-proposition the functor X → - is a modality, and so can derive
-is-compact∙ (X → A) from X → is-compact∙ A.
+In order to derive prop-tychonoff from this statement we will need a
+few extra arguments. This will be covered in a separate module,
+AbsolutenessOfCompactnessExample, which works specifically with open
+modalities, as opposed to this module that applies to modalities in
+general.
 
 \begin{code}
 

--- a/source/TypeTopology/AbsolutenessOfCompactness.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactness.lagda
@@ -57,7 +57,7 @@ open import TypeTopology.CompactTypes
 
 open import UF.Base
 open import UF.Equiv
-open import UF.UA-FunExt
+open import UF.FunExt
 open import UF.Univalence
 open import UF.UniverseEmbedding
 
@@ -263,30 +263,26 @@ internal-compact-implies-compact A A-modal c =
 \end{code}
 
 The remaining theorems in this module all require a couple of extra
-assumptions: the universe needs to be univalent, and the subuniverse
-needs to be Σ-closed, making it an actual modality.
+assumptions: function extensionality, and the subuniverse
+needs to be Σ-closed, making it an actual modality, and replete.
 
 \begin{code}
 
-module WithUnivalenceAndSigmaClosedness
- (ua : is-univalent 𝓤)
+module WithFunExtAndRepleteSigmaClosed
+ (fe : funext 𝓤 𝓤)
  (P-is-sigma-closed : subuniverse-is-sigma-closed P)
+ (repleteness : subuniverse-is-replete P)
  where
 
 \end{code}
 
-We import some theorems about Σ-closed reflective subuniverses, and
-recall proofs of the two ways that we will use univalence: function
-extensionality and repleteness of the subuniverse.
+We import some theorems about Σ-closed reflective subuniverses.
 
 \begin{code}
 
  module S =
   Modal.SigmaClosedReflectiveSubuniverse
    P P-is-reflective P-is-sigma-closed
-
- fe = univalence-gives-funext ua
- repleteness = univalence-implies-subuniverse-is-replete ua P
 
 \end{code}
 

--- a/source/TypeTopology/AbsolutenessOfCompactness.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactness.lagda
@@ -5,11 +5,11 @@ TypeTopology.PropTychonoff, based on the observation that for
 propositions P, the functor sending A to P → A is a
 modality. Modalities of this form are an important special case and
 they have a name; they are *open modalities* (Example 1.7 in
-[1]). However, we will show a version of the theorem is not only true
+[2]). However, we will show a version of the theorem is not only true
 for open modalities, but for all modalities.
 
 For another example, let ∇ be the modality of double negation sheaves
-(Example 3.41 of [1]). The internal logic in this reflective universe
+(Example 3.41 of [2]). The internal logic in this reflective universe
 is boolean. It follows that ∇ (is-compact∙ A) holds for all types A,
 and so we can deduce that ∇ A is always compact.
 
@@ -19,6 +19,11 @@ We can also see as a special case that truncation preserves
 compactness, although it seems unlikely there are any good examples of
 compact higher types where it isn't already clear that the
 0-truncation is compact.
+
+We note that the results hold for all modalities with no further
+conditions and in particular the modality is not required to be lex,
+or to preserve 𝟘. For the main theorem, we don't even need a full
+modality, and the weaker notion of reflective subuniverse suffices.
 
 When formulated in terms of modalities, the result is best thought of
 as an "absoluteness result." When working in models of some theory, a
@@ -32,17 +37,46 @@ theory. We will show that compactness is an upwards absolute
 notion. That is, if a type inside the reflective subuniverse is
 compact with respect to the internal logic of the subuniverse then it
 is compact viewed outside the subuniverse as just a type. The converse
-does not quite hold, so potentially there could be compact types where
-the internal statement of compactness is not true, and we don't get
-full absoluteness.
+does not quite hold, so there can be compact types where the internal
+statement of compactness is not true, and we don't get full
+absoluteness.
 
-We note that the result holds for all modalities with no further
-conditions and in particular the modality is not required to be lex,
-or to preserve 𝟘. For the main theorem, we don't even need a full
-modality, and the weaker notion of reflective subuniverse suffices.
+We sketch out an example from realizabilty to illustrate how downwards
+absoluteness can fail. We recall from section 17 of [1] that each
+Turing degree can be viewed as a local operator in the effective
+topos, and from section 3.3 of [2] we recall that local operators can
+be viewed as modalities via sheafification. We will use that fact that
+for such modalities, the unit maps A → ○ A are ¬¬-connected (or
+equivalently that the corresponding subtoposes all contain the
+subtopos of sets).
 
-[1] Rijke, Shulman, Spitters, Modalities in homotopy type theory,
+Furthermore, we recall from section 3.3 of [3] that the object R of
+real numbers is isomorphic to the computable real numbers and that
+every function R → R is continuous. The latter implies that every
+function R → 2 is constant, and so vacuously R is compact in the
+effective topos.
+
+Let ○ be the modality corresponding to the halting set, as described
+above. Since the unit map R → ○ R is ¬¬-connected, it is also true
+that every map ○ R → 2 is constant: the composition of any such map
+with the unit map, R → ○ R is constant, but every element of ○ R does
+not not belong to R, and 2 is ¬¬-separated, so the restriction to ○ R
+must also be constant. However, the halting set allows us to construct
+new functions R → ○ 2, and thereby functions ○ R → ○ 2: we can use the
+halting set to decide whether or not two computable real numbers are
+equal, and so extend any function ○ N → ○ 2 to ○ R, mapping everything
+outside ○ N to 0. However, ○ N is not compact in the reflective
+subuniverse, by the same argument as for the effective topos, so ○ R
+is not compact either.
+
+
+[1] Hyland, The effective topos,
+https://doi.org/10.1016/S0049-237X(09)70129-6
+
+[2] Rijke, Shulman, Spitters, Modalities in homotopy type theory,
 https://doi.org/10.23638/LMCS-16(1:2)2020
+
+[3] Van Oosten, Realizability: An introduction to its categorical side
 
 \begin{code}
 

--- a/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
@@ -21,7 +21,7 @@ open import UF.FunExt
 open import UF.PropIndexedPiSigma
 open import UF.Subsingletons
 
-module AbsolutenessOfCompactnessExample
+module TypeTopology.AbsolutenessOfCompactnessExample
  (fe : funext 𝓤 𝓤)
  (P : 𝓤 ̇ )
  (P-is-prop : is-prop P)

--- a/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
@@ -1,0 +1,181 @@
+Andrew Swan, started 13th February 2024
+
+We demonstrate the upwards absoluteness of compactness, by using it to
+give an alternative proof of the propositional Tychonoff theorem.
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K #-}
+open import MLTT.Spartan
+
+import Modal.Open
+import Modal.SigmaClosedReflectiveSubuniverse
+
+import TypeTopology.AbsolutenessOfCompactness
+open import TypeTopology.CompactTypes
+
+open import UF.Base
+open import UF.Equiv
+open import UF.Equiv-FunExt
+open import UF.FunExt
+open import UF.PropIndexedPiSigma
+open import UF.Subsingletons
+
+module AbsolutenessOfCompactnessExample
+ (fe : funext 𝓤 𝓤)
+ (P : 𝓤 ̇ )
+ (P-is-prop : is-prop P)
+ where
+
+\end{code}
+
+We are given a proposition P as a parameter and function
+extensionality. We use this in a sequence of module imports.
+
+First of all, we give P to the open modality module to get results
+about the open modality on P.
+
+\begin{code}
+
+open Modal.Open fe P P-is-prop
+
+\end{code}
+
+The open modality module gives us proofs that the open modality is
+reflective and Σ-closed. We hand these off to the
+SigmaClosedReflectiveSubuniverse module.
+
+\begin{code}
+
+open Modal.SigmaClosedReflectiveSubuniverse
+ open-subuniverse open-is-reflective open-is-sigma-closed
+
+\end{code}
+
+We also hand off the open modality as a parameter to the
+AbsolutenessOfCompactness module.
+
+\begin{code}
+
+open TypeTopology.AbsolutenessOfCompactness
+ open-subuniverse open-is-reflective
+
+\end{code}
+
+Finally, we recall that AbsolutenessOfCompactness has a submodule that
+requires the extra assumptions of function extensionality and that the
+reflective subuniverse is Σ-closed and replete. We have all of these,
+so we pass them on as parameters to the submodule.
+
+\begin{code}
+
+open WithFunExtAndRepleteSigmaClosed
+ fe open-is-sigma-closed open-is-replete
+
+\end{code}
+
+If we apply the theorems in AbsolutenessOfCompactness directly, the
+best we can get is the following non dependent version of
+propositional Tychonoff.
+
+\begin{code}
+
+non-dependent-prop-tychonoff
+ : (A : 𝓤 ̇ )
+ → (P → is-compact∙ A)
+ → is-compact∙ (P → A)
+non-dependent-prop-tychonoff = modalities-preserve-compact
+
+\end{code}
+
+In order to get a new proof of propositional Tychonoff, we need to
+show how to derive it from the non-dependent version.
+
+\begin{code}
+
+prop-tychonoff2
+ : (A : P → 𝓤 ̇ )
+ → ((z : P) → is-compact∙ (A z))
+ → is-compact∙ (Π A)
+prop-tychonoff2 A A-compact = ΠA-compact
+ where
+ 
+\end{code}
+
+We are given a family of types A : P → 𝓤 ̇  and we aim to apply the
+non-dependent version above to the product Π A. In order to do this,
+there are two things to check. Firstly, we have to show that P implies
+Π A is compact. This allows us to apply the non-dependent version
+above, which shows that P → Π A is compact. We then need to deduce
+from this that in fact Π A is compact.
+
+The first step, of showing that P implies Π A compact is copied
+straight from the original propositional Tychonoff proof. Namely, if P
+is true, as witnessed by an inhabitant z, then Π A is equivalent to A
+z, and so is compact.
+
+\begin{code}
+
+  𝕗 : (z : P) → Π A ≃ A z
+  𝕗 = prop-indexed-product fe P-is-prop
+
+  product-locally-compact : P → is-compact∙ (Π A)
+  product-locally-compact z =
+   compact∙-types-are-closed-under-equiv
+    (≃-sym (𝕗 z)) (A-compact z)
+
+\end{code}
+
+We can now apply the non dependent version above to show that P → Π A
+is compact.
+
+\begin{code}
+
+  P→ΠA-compact : is-compact∙ (P → Π A)
+  P→ΠA-compact =
+   non-dependent-prop-tychonoff (Π A) product-locally-compact
+
+\end{code}
+
+To deduce that Π A is compact, it suffices to show that it is
+equivalent to P → Π A. This can be shown directly, but we will give a
+slightly more abstract proof using general results about
+modalities.
+
+First note that given z : P, we known that P is true and so every type
+is modal for the open modality on P. Hence, in particular A z is
+modal.
+
+\begin{code}
+
+  A-modal : (z : P) → is-modal (A z)
+  A-modal z = P-true-implies-all-modal z (A z)
+
+\end{code}
+
+Since A is a family of modal types its product Π A is also modal.
+
+\begin{code}
+
+  ΠA-modal : is-modal (Π A)
+  ΠA-modal =
+   products-of-modal-types-are-modal
+    fe open-is-replete P A A-modal
+
+\end{code}
+
+However, the fact that Π A is modal precisely tells us that the unit
+map of the modality Π A → (P → Π A) is an equivalence.
+
+Putting this together with the earlier proof that P → Π A is modal
+allows us to complete the proof of the theorem.
+
+\begin{code}
+
+  ΠA-compact : is-compact∙ (Π A)
+  ΠA-compact =
+   compact∙-types-are-closed-under-equiv
+    (≃-sym ((open-unit (Π A)) , ΠA-modal))
+    P→ΠA-compact
+  
+\end{code}

--- a/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
+++ b/source/TypeTopology/AbsolutenessOfCompactnessExample.lagda
@@ -32,8 +32,8 @@ module AbsolutenessOfCompactnessExample
 We are given a proposition P as a parameter and function
 extensionality. We use this in a sequence of module imports.
 
-First of all, we give P to the open modality module to get results
-about the open modality on P.
+First of all, we give P to the open modality module, as well as
+function extensionality to get results about the open modality on P.
 
 \begin{code}
 
@@ -99,7 +99,7 @@ prop-tychonoff2
  → is-compact∙ (Π A)
 prop-tychonoff2 A A-compact = ΠA-compact
  where
- 
+
 \end{code}
 
 We are given a family of types A : P → 𝓤 ̇  and we aim to apply the
@@ -109,7 +109,7 @@ there are two things to check. Firstly, we have to show that P implies
 above, which shows that P → Π A is compact. We then need to deduce
 from this that in fact Π A is compact.
 
-The first step, of showing that P implies Π A compact is copied
+The first step, of showing that P implies Π A compact, is copied
 straight from the original propositional Tychonoff proof. Namely, if P
 is true, as witnessed by an inhabitant z, then Π A is equivalent to A
 z, and so is compact.
@@ -177,5 +177,5 @@ allows us to complete the proof of the theorem.
    compact∙-types-are-closed-under-equiv
     (≃-sym ((open-unit (Π A)) , ΠA-modal))
     P→ΠA-compact
-  
+
 \end{code}

--- a/source/TypeTopology/index.lagda
+++ b/source/TypeTopology/index.lagda
@@ -7,6 +7,7 @@ Martin Escardo
 module TypeTopology.index where
 
 import TypeTopology.AbsolutenessOfCompactness
+import TypeTopology.AbsolutenessOfCompactnessExample
 import TypeTopology.ADecidableQuantificationOverTheNaturals
 import TypeTopology.CantorMinusPoint
 import TypeTopology.CantorSearch


### PR DESCRIPTION
Here is version 2 of the absoluteness of compactness. The main addition is using the open modality to derive another proof of prop-tychonoff. I had to do this as a separate file, since the modality is a module parameter to AbsolutenessOfCompactness, so in order to work with a specific modality (the open modality on a proposition P) it's necessary to pass it as a module parameter from a separate file.

I also added some explanation in the comments about an example from realizability of downwards absoluteness failing.