### PR TITLE
Step 1 of PR #217

### DIFF
--- a/source/DomainTheory/BasesAndContinuity/Bases.lagda
+++ b/source/DomainTheory/BasesAndContinuity/Bases.lagda
@@ -490,6 +490,10 @@ module _
                        → index-of-compact-basis 𝒷 → ⟨ 𝓓 ⟩
  family-of-basic-opens (_ , β , _) = β
 
+ small-compact-basis : (𝒷 : has-specified-small-compact-basis)
+                     → is-small-compact-basis 𝓓 (family-of-basic-opens 𝒷)
+ small-compact-basis (_ , _ , scb) = scb
+
  has-unspecified-small-compact-basis : 𝓥 ⁺ ⊔ 𝓤 ⊔ 𝓣 ̇
  has-unspecified-small-compact-basis = ∥ has-specified-small-compact-basis ∥
 

--- a/source/DomainTheory/BasesAndContinuity/Bases.lagda
+++ b/source/DomainTheory/BasesAndContinuity/Bases.lagda
@@ -486,12 +486,12 @@ module _
  index-of-compact-basis : has-specified-small-compact-basis → 𝓥  ̇
  index-of-compact-basis (B , _) = B
 
- family-of-basic-opens : (𝒷 : has-specified-small-compact-basis)
-                       → index-of-compact-basis 𝒷 → ⟨ 𝓓 ⟩
- family-of-basic-opens (_ , β , _) = β
+ family-of-compact-elements : (𝒷 : has-specified-small-compact-basis)
+                            → index-of-compact-basis 𝒷 → ⟨ 𝓓 ⟩
+ family-of-compact-elements (_ , β , _) = β
 
  small-compact-basis : (𝒷 : has-specified-small-compact-basis)
-                     → is-small-compact-basis 𝓓 (family-of-basic-opens 𝒷)
+                     → is-small-compact-basis 𝓓 (family-of-compact-elements 𝒷)
  small-compact-basis (_ , _ , scb) = scb
 
  has-unspecified-small-compact-basis : 𝓥 ⁺ ⊔ 𝓤 ⊔ 𝓣 ̇

--- a/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
+++ b/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
@@ -72,9 +72,9 @@ We denote by `_⊑_` the informating ordering of the dcpo `𝓓`.
 We also define a reformulation `has-supₚ` of `has-sup` from `Basics.Dcpo`. The
 reason for this reformulation is to have a version more suitable to use with
 notion of family that I (Ayberk) use, which is the one from `Slice.Family`.
-Moreover, it is also convenient have a version of this notion that is packaged
-up with the proof of its propositionality so that it can be defined directly as
-an `Ω`-valued function.
+Moreover, it is also convenient to have a version of this notion that is
+packaged up with the proof of its propositionality so that it can be defined
+directly as an `Ω`-valued function.
 
 \begin{code}
 

--- a/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
+++ b/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
@@ -1,0 +1,113 @@
+---
+title:       Scott domains
+author:      Ayberk Tosun
+start-date:  2023-10-26
+---
+
+Ayberk Tosun.
+
+Started on 26 October 2023.
+
+\begin{code}[hide]
+
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+open import MLTT.Spartan
+open import UF.FunExt
+open import UF.Logic
+open import UF.PropTrunc
+open import UF.SubtypeClassifier
+open import UF.Subsingletons
+
+module DomainTheory.BasesAndContinuity.ScottDomain
+        (pt : propositional-truncations-exist)
+        (fe : Fun-Ext)
+        (𝓥  : Universe)
+       where
+
+open import Slice.Family
+
+open import DomainTheory.Basics.Dcpo                   pt fe 𝓥
+open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
+open import DomainTheory.BasesAndContinuity.Bases      pt fe 𝓥
+
+open import Locales.Frame hiding (⟨_⟩)
+
+open Universal   fe
+open Implication fe
+open Existential pt
+open Conjunction
+
+open Locale
+
+open PropositionalTruncation pt
+
+\end{code}
+
+We first define the notion of a 𝓣-family having an upper bound.
+
+\begin{code}
+
+module DefinitionOfBoundedCompleteness (𝓓 : DCPO {𝓤} {𝓣}) where
+
+\end{code}
+
+We denote by `_⊑_` the informating ordering of the dcpo `𝓓`.
+
+\begin{code}
+
+ _⊑_ : ⟨ 𝓓 ⟩ → ⟨ 𝓓 ⟩ → 𝓣  ̇
+ x ⊑ y = x ⊑⟨ 𝓓 ⟩ y
+
+\end{code}
+
+\begin{code}
+
+ has-an-upper-bound : Fam 𝓣 ⟨ 𝓓 ⟩ → Ω (𝓤 ⊔ 𝓣)
+ has-an-upper-bound (_ , ι) =
+  Ǝ u ꞉ ⟨ 𝓓 ⟩ , is-upperbound (underlying-order 𝓓) u ι
+
+\end{code}
+
+We also define a reformulation `has-supₚ` of `has-sup` from `Basics.Dcpo`. The
+reason for this reformulation is to have a version more suitable to use with
+notion of family that I (Ayberk) use, which is the one from `Slice.Family`.
+Moreover, it is also convenient have a version of this notion that is packaged
+up with the proof of its propositionality so that it can be defined directly as
+an `Ω`-valued function.
+
+\begin{code}
+
+ has-supₚ : Fam 𝓣 ⟨ 𝓓 ⟩ → Ω (𝓤 ⊔ 𝓣)
+ has-supₚ (I , ι) = has-sup (underlying-order 𝓓) ι
+                  , having-sup-is-prop _⊑_ (pr₁ (axioms-of-dcpo 𝓓)) ι
+
+\end{code}
+
+Bounded completeness then says that any family that has an upper bound also has
+a least upper bound.
+
+\begin{code}
+
+ bounded-complete : Ω (𝓤 ⊔ 𝓣 ⁺)
+ bounded-complete = Ɐ S ꞉ Fam 𝓣 ⟨ 𝓓 ⟩ , has-an-upper-bound S ⇒ has-supₚ S
+
+\end{code}
+
+We now proceed to define the notion of a Scott domain.
+
+\begin{code}
+
+module DefinitionOfScottDomain (𝓓 : DCPO {𝓤} {𝓣}) where
+
+ open DefinitionOfBoundedCompleteness
+
+ has-unspecified-small-compact-basisₚ : Ω (𝓤 ⊔ 𝓥 ⁺ ⊔ 𝓣)
+ has-unspecified-small-compact-basisₚ = has-unspecified-small-compact-basis 𝓓
+                                      , ∃-is-prop
+
+ is-scott-domain : Ω (𝓤 ⊔ 𝓥 ⁺ ⊔ 𝓣 ⁺)
+ is-scott-domain =
+  has-unspecified-small-compact-basisₚ ∧ bounded-complete 𝓓
+
+\end{code}

--- a/source/DomainTheory/Lifting/LiftingSet.lagda
+++ b/source/DomainTheory/Lifting/LiftingSet.lagda
@@ -171,6 +171,54 @@ module _ {𝓤 : Universe}
 
 \end{code}
 
+Minor addition by Ayberk Tosun.
+
+\begin{code}
+
+ open import Lifting.UnivalentPrecategory 𝓣 X
+ open PosetAxioms
+
+ 𝓛-DCPO⁻ : DCPO {𝓣 ⁺ ⊔ 𝓤} {𝓣 ⊔ 𝓤}
+ 𝓛-DCPO⁻ = 𝓛 X , _⊑_ , †
+  where
+   γ : {x y : 𝓛 X} → (x ⊑ y) ≃ (x ⊑' y)
+   γ {x} {y} = logically-equivalent-props-are-equivalent
+                (⊑-prop-valued fe fe s x y)
+                (⊑'-prop-valued s)
+                ⊑-to-⊑' ⊑'-to-⊑
+
+   p : is-prop-valued _⊑_
+   p = ⊑-prop-valued fe fe s
+
+   a : is-antisymmetric _⊑_
+   a l m p q = ⊑'-is-antisymmetric (⊑-to-⊑' p) (⊑-to-⊑' q)
+
+   δ : is-directed-complete _⊑_
+   δ I ι (i , υ)  = lifting-sup ι δ′ , σ
+    where
+     δ′ : is-directed _⊑'_ ι
+     δ′ = i
+        , λ j k →
+           ∥∥-rec
+            ∃-is-prop
+            (λ { (i , p , q) → ∣ i , ⊑-to-⊑' p , ⊑-to-⊑' q ∣ })
+            (υ j k)
+
+     σ₁ : (j : I) → ι j ⊑ lifting-sup ι δ′
+     σ₁ j = ⊑'-to-⊑ (lifting-sup-is-upperbound ι δ′ j)
+
+     σ₂ : is-lowerbound-of-upperbounds _⊑_ (lifting-sup ι δ′) ι
+     σ₂ j φ = ⊑'-to-⊑
+               (lifting-sup-is-lowerbound-of-upperbounds δ′ j λ k → ⊑-to-⊑' (φ k))
+
+     σ : is-sup _⊑_ (lifting-sup ι δ′) ι
+     σ = σ₁ , σ₂
+
+   † : dcpo-axioms _⊑_
+   † = (lifting-of-set-is-set s , p , 𝓛-id , 𝓛-comp , a) , δ
+
+\end{code}
+
 Now that we have the lifting as a dcpo, we prove that the lifting functor and
 Kleisli extension yield continuous maps.
 

--- a/source/DomainTheory/Lifting/LiftingSet.lagda
+++ b/source/DomainTheory/Lifting/LiftingSet.lagda
@@ -173,6 +173,14 @@ module _ {𝓤 : Universe}
 
 Minor addition by Ayberk Tosun.
 
+The lifting of a set as a dcpo as defined above has an order that is essentially
+locally small. It is sometimes convenient, however, to repackage the lifting
+dcpo with the equivalent order that has small values.
+
+The development where this function is used can be updated as to work on a dcpo
+with an external proof of local smallness as to obviate the need for this
+repackaging. This is a refactoring to consider in the future.
+
 \begin{code}
 
  open import Lifting.UnivalentPrecategory 𝓣 X

--- a/source/DomainTheory/Topology/ScottTopology.lagda
+++ b/source/DomainTheory/Topology/ScottTopology.lagda
@@ -112,4 +112,14 @@ I find it convenient to define the type of directed families.
    where
     open 𝒪ₛᴿ
 
+ upward-closure : (𝔘 : 𝒪ₛ) →  is-upwards-closed (λ - → - ∈ₛ 𝔘) holds
+ upward-closure = 𝒪ₛᴿ.pred-is-upwards-closed ∘ to-𝒪ₛᴿ
+
+ scott-openness : (𝔘 : 𝒪ₛ) → is-scott-open (λ - → - ∈ₛ 𝔘) holds
+ scott-openness 𝔘 =
+  𝒪ₛᴿ.pred-is-upwards-closed 𝔘ᴿ , 𝒪ₛᴿ.pred-is-inaccessible-by-dir-joins 𝔘ᴿ
+   where
+    𝔘ᴿ : 𝒪ₛᴿ
+    𝔘ᴿ = to-𝒪ₛᴿ 𝔘
+
 \end{code}

--- a/source/DomainTheory/Topology/ScottTopologyProperties.lagda
+++ b/source/DomainTheory/Topology/ScottTopologyProperties.lagda
@@ -112,6 +112,8 @@ Notation for the principal Scott open.
 
 \end{code}
 
+We now prove some properties of the Scott topology on a dcpo that is algebraic.
+
 \begin{code}
 
 module PropertiesAlgebraic (𝓓 : DCPO {𝓤} {𝓥})
@@ -168,10 +170,6 @@ module PropertiesAlgebraic (𝓓 : DCPO {𝓤} {𝓥})
       → x ∈ₚ U holds
     † (c , _ , q , r) = υ c x q r
 
-\end{code}
-
-\begin{code}
-
  characterization-of-scott-opens
   : (U : 𝓟 {𝓥} ⟨ 𝓓 ⟩)
   → (is-scott-open U ⇒ (Ɐ x ꞉ ⟨ 𝓓 ⟩ , U x ⇔ join-of-compact-opens U x)) holds
@@ -179,10 +177,6 @@ module PropertiesAlgebraic (𝓓 : DCPO {𝓤} {𝓥})
   where
    ⦅⇒⦆ = characterization-of-scott-opens₁ U ς x
    ⦅⇐⦆ = characterization-of-scott-opens₂ U ς x
-
-\end{code}
-
-\begin{code}
 
  resize-join-of-compact-opens : (U : 𝓟 {𝓥} ⟨ 𝓓 ⟩) (x : ⟨ 𝓓 ⟩)
                               → is-scott-open U holds
@@ -199,6 +193,10 @@ module PropertiesAlgebraic (𝓓 : DCPO {𝓤} {𝓥})
 \end{code}
 
 Addition 2023-11-22.
+
+The principal filter on the bottom element is the top open of the Scott locale.
+We write this down in a different submodule as it requires the additional
+assumption of a bottom element in the algebraic dcpo in consideration.
 
 \begin{code}
 

--- a/source/DomainTheory/Topology/ScottTopologyProperties.lagda
+++ b/source/DomainTheory/Topology/ScottTopologyProperties.lagda
@@ -37,7 +37,6 @@ open import DomainTheory.Basics.Dcpo                   pt fe 𝓥
 open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
 open import DomainTheory.Basics.WayBelow               pt fe 𝓥
 
-
 \end{code}
 
 \begin{code}

--- a/source/DomainTheory/Topology/ScottTopologyProperties.lagda
+++ b/source/DomainTheory/Topology/ScottTopologyProperties.lagda
@@ -1,0 +1,224 @@
+---
+title:      Properties of the Scott topology
+author:     Ayberk Tosun
+start-date: 2023-10-30
+---
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+open import MLTT.Spartan
+open import UF.FunExt
+open import UF.PropTrunc
+open import UF.SubtypeClassifier
+
+module DomainTheory.Topology.ScottTopologyProperties
+        (pt : propositional-truncations-exist)
+        (fe : Fun-Ext)
+        (𝓥  : Universe) where
+
+open import UF.Logic
+open Existential pt
+open Implication fe
+open Universal   fe
+open Conjunction
+
+open import UF.Size
+open import UF.Equiv
+
+open import UF.Powerset-MultiUniverse
+open import Slice.Family
+
+open PropositionalTruncation pt
+
+open import DomainTheory.Topology.ScottTopology        pt fe 𝓥
+open import DomainTheory.Basics.Dcpo                   pt fe 𝓥
+open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
+open import DomainTheory.Basics.WayBelow               pt fe 𝓥
+
+
+\end{code}
+
+\begin{code}
+
+principal-filter : (𝓓 : DCPO {𝓤} {𝓥}) → ⟨ 𝓓 ⟩ → 𝓟 ⟨ 𝓓 ⟩
+principal-filter 𝓓 c x = c ⊑⟨ 𝓓 ⟩ x , prop-valuedness 𝓓 c x
+
+infix 45 principal-filter
+
+syntax principal-filter 𝓓 x = ↑[ 𝓓 ] x
+
+\end{code}
+
+Let `D` be a dcpo and consider a compact element `c : D` of it. The
+upwards-closure of `c` is then a Scott open.
+
+\begin{code}
+
+module Properties (𝓓 : DCPO {𝓤} {𝓥}) where
+
+ open DefnOfScottTopology 𝓓 𝓥
+
+ principal-filter-is-upwards-closed : (x : ⟨ 𝓓 ⟩)
+                                    → is-upwards-closed (↑[ 𝓓 ] x) holds
+ principal-filter-is-upwards-closed x y z p q =
+  x ⊑⟨ 𝓓 ⟩[ p ] y ⊑⟨ 𝓓 ⟩[ q ] z ∎⟨ 𝓓 ⟩
+
+ compact-implies-principal-filter-is-scott-open : (c : ⟨ 𝓓 ⟩)
+                                                → is-compact 𝓓 c
+                                                → is-scott-open (↑[ 𝓓 ] c) holds
+ compact-implies-principal-filter-is-scott-open c κ = Ⅰ , Ⅱ
+  where
+   Ⅰ : is-upwards-closed (↑[ 𝓓 ] c) holds
+   Ⅰ = principal-filter-is-upwards-closed c
+
+   Ⅱ : is-inaccessible-by-directed-joins (↑[ 𝓓 ] c) holds
+   Ⅱ (S , δ) = κ (index S) (S [_]) δ
+
+\end{code}
+
+Conversely, if the principal filter is Scott open then `c` is a compact element.
+
+\begin{code}
+
+ principal-filter-scott-open-implies-compact : (c : ⟨ 𝓓 ⟩)
+                                             → is-scott-open (↑[ 𝓓 ] c) holds
+                                             → is-compact 𝓓 c
+ principal-filter-scott-open-implies-compact c (υ , κ) I ι δ p =
+  κ ((I , ι) , δ) p
+
+\end{code}
+
+We can now record this as a logical equivalence.
+
+\begin{code}
+
+ principal-filter-scott-open-iff-compact :
+  (x : ⟨ 𝓓 ⟩) → is-scott-open (↑[ 𝓓 ] x) holds ↔ is-compact 𝓓 x
+ principal-filter-scott-open-iff-compact x = Ⅰ , Ⅱ
+  where
+   Ⅰ = principal-filter-scott-open-implies-compact x
+   Ⅱ = compact-implies-principal-filter-is-scott-open x
+
+\end{code}
+
+Notation for the principal Scott open.
+
+\begin{code}
+
+ ↑ˢ[_] : (Σ c ꞉ ⟨ 𝓓 ⟩ , is-compact 𝓓 c) → Σ S ꞉ 𝓟 {𝓥} ⟨ 𝓓 ⟩ , is-scott-open S holds
+ ↑ˢ[ (c , κ) ] =
+  principal-filter 𝓓 c , compact-implies-principal-filter-is-scott-open c κ
+
+\end{code}
+
+\begin{code}
+
+module PropertiesAlgebraic (𝓓 : DCPO {𝓤} {𝓥})
+                           (𝕒 : structurally-algebraic 𝓓) where
+
+ open DefnOfScottTopology 𝓓 𝓥
+
+ open structurally-algebraic
+
+ is-compactₚ : ⟨ 𝓓 ⟩ → Ω (𝓤 ⊔ 𝓥 ⁺)
+ is-compactₚ x = is-compact 𝓓 x , being-compact-is-prop 𝓓 x
+
+ join-of-compact-opens : 𝓟 {𝓥} ⟨ 𝓓 ⟩ → 𝓟 {𝓤 ⊔ 𝓥 ⁺} ⟨ 𝓓 ⟩
+ join-of-compact-opens U x =
+  Ǝ c ꞉ ⟨ 𝓓 ⟩ , (is-compactₚ c ∧ c ∈ₚ U ∧ x ∈ₚ (↑[ 𝓓 ] c)) holds
+
+ characterization-of-scott-opens₁ : (U : 𝓟 ⟨ 𝓓 ⟩)
+                                  → is-scott-open U holds
+                                  → U ⊆ join-of-compact-opens U
+ characterization-of-scott-opens₁ U (υ , ξ) x p = †
+  where
+   S : Fam 𝓥 ⟨ 𝓓 ⟩
+   S = index-of-compact-family 𝕒 x , compact-family 𝕒 x
+
+   S↑ : Fam↑
+   S↑ = S , compact-family-is-directed 𝕒 x
+
+   q : x ＝ ⋁ S↑
+   q = compact-family-∐-＝ 𝕒 x ⁻¹
+
+   κ : (i : index S) → is-compactₚ (S [ i ]) holds
+   κ = compact-family-is-compact 𝕒 x
+
+   ψ : is-upperbound (underlying-order 𝓓) x (S [_])
+   ψ i = transport (λ - → (S [ i ]) ⊑⟨ 𝓓 ⟩ -) (q ⁻¹) (⋁-is-upperbound S↑ i)
+
+   φ : (⋁ S↑) ∈ U
+   φ = transport (λ - → - ∈ U) q p
+
+   ‡ : Σ i ꞉ index S , (S [ i ]) ∈ U
+     → ∃ c₀ ꞉ ⟨ 𝓓 ⟩ , (is-compactₚ c₀ ∧ c₀ ∈ₚ U ∧ x ∈ₚ ↑[ 𝓓 ] c₀) holds
+   ‡ (i , μ) = ∣ S [ i ] , κ i , μ , ψ i ∣
+
+   † : ∃ c₀ ꞉ ⟨ 𝓓 ⟩ , (is-compactₚ c₀ ∧ c₀ ∈ₚ U ∧ x ∈ₚ ↑[ 𝓓 ] c₀) holds
+   † = ∥∥-rec ∃-is-prop ‡ (ξ S↑ φ)
+
+ characterization-of-scott-opens₂ : (U : 𝓟 ⟨ 𝓓 ⟩)
+                                  → is-scott-open U holds
+                                  → join-of-compact-opens U ⊆ U
+ characterization-of-scott-opens₂ U (υ , _) x p =
+  ∥∥-rec (holds-is-prop (x ∈ₚ U)) † p
+   where
+    † : Σ c ꞉ ⟨ 𝓓 ⟩ , (is-compactₚ c ∧ c ∈ₚ U ∧ principal-filter 𝓓 c x) holds
+      → x ∈ₚ U holds
+    † (c , _ , q , r) = υ c x q r
+
+\end{code}
+
+\begin{code}
+
+ characterization-of-scott-opens
+  : (U : 𝓟 {𝓥} ⟨ 𝓓 ⟩)
+  → (is-scott-open U ⇒ (Ɐ x ꞉ ⟨ 𝓓 ⟩ , U x ⇔ join-of-compact-opens U x)) holds
+ characterization-of-scott-opens U ς x = ⦅⇒⦆ , ⦅⇐⦆
+  where
+   ⦅⇒⦆ = characterization-of-scott-opens₁ U ς x
+   ⦅⇐⦆ = characterization-of-scott-opens₂ U ς x
+
+\end{code}
+
+\begin{code}
+
+ resize-join-of-compact-opens : (U : 𝓟 {𝓥} ⟨ 𝓓 ⟩) (x : ⟨ 𝓓 ⟩)
+                              → is-scott-open U holds
+                              → (join-of-compact-opens U x holds) is 𝓥 small
+ resize-join-of-compact-opens U x ς = x ∈ U , ε
+  where
+   ε : (x ∈ U) ≃ join-of-compact-opens U x holds
+   ε = logically-equivalent-props-are-equivalent
+        (holds-is-prop (U x))
+        ∃-is-prop
+        (characterization-of-scott-opens₁ U ς x)
+        (characterization-of-scott-opens₂ U ς x)
+
+\end{code}
+
+Addition 2023-11-22.
+
+\begin{code}
+
+module BottomLemma (𝓓  : DCPO {𝓤} {𝓥})
+                   (𝕒  : structurally-algebraic 𝓓)
+                   (hl : has-least (underlying-order 𝓓)) where
+
+ ⊥ᴰ : ⟨ 𝓓 ⟩
+ ⊥ᴰ = pr₁ hl
+
+ ⊥ᴰ-is-least : is-least (underlying-order 𝓓) ⊥ᴰ
+ ⊥ᴰ-is-least = pr₂ hl
+
+ open Properties 𝓓
+
+ open DefnOfScottTopology 𝓓 𝓥
+ open PropertiesAlgebraic 𝓓 𝕒
+
+ bottom-principal-filter-is-top : (𝔘 : 𝒪ₛ) → 𝔘 .pr₁ ⊆ ↑[ 𝓓 ] ⊥ᴰ
+ bottom-principal-filter-is-top 𝔘 x _ = ⊥ᴰ-is-least x
+
+\end{code}

--- a/source/DomainTheory/index.lagda
+++ b/source/DomainTheory/index.lagda
@@ -64,6 +64,7 @@ import DomainTheory.Basics.WayBelow        -- (7)
    continuous dcpos
 7. Using step functions we show that sup-complete dcpos with small compact
    bases are closed under exponentials
+8. Definition of the notion of a Scott domain
 -}
 
 import DomainTheory.BasesAndContinuity.Bases                   -- (1)
@@ -73,6 +74,7 @@ import DomainTheory.BasesAndContinuity.ContinuityDiscussion    -- (4)
 import DomainTheory.BasesAndContinuity.ContinuityImpredicative -- (5)
 import DomainTheory.BasesAndContinuity.IndCompletion           -- (6)
 import DomainTheory.BasesAndContinuity.StepFunctions           -- (7)
+import DomainTheory.BasesAndContinuity.ScottDomain             -- (8)
 
 {- Bilimits
 
@@ -137,10 +139,12 @@ import DomainTheory.ScottModelOfPCF.ScottModelOfPCF -- (2)
 {- Topology (by Ayberk Tosun)
 
 0. The definition of the Scott topology of a dcpo
+1. Some properties of the Scott topology of a dcpo
 
 -}
 
-import DomainTheory.Topology.ScottTopology          -- (0)
+import DomainTheory.Topology.ScottTopology           -- (0)
+import DomainTheory.Topology.ScottTopologyProperties -- (1)
 
 \end{code}
 

--- a/source/DomainTheory/index.lagda
+++ b/source/DomainTheory/index.lagda
@@ -1,6 +1,8 @@
 Tom de Jong, 4 June 2019
 Updated 23 December 2021
 Updated 12 and 14 June 2022
+Updated 30 October 2023 (by Ayberk Tosun)
+Updated 6 November 2023 (by Ayberk Tosun)
 
 Index for the formalization of domain theory, briefly describing the contents of
 each directory, ordered almost¹ alphabetically by directory name.

--- a/source/DomainTheory/index.lagda
+++ b/source/DomainTheory/index.lagda
@@ -64,7 +64,7 @@ import DomainTheory.Basics.WayBelow        -- (7)
    continuous dcpos
 7. Using step functions we show that sup-complete dcpos with small compact
    bases are closed under exponentials
-8. Definition of the notion of a Scott domain
+8. Definition of the notion of a Scott domain (by Ayberk Tosun)
 -}
 
 import DomainTheory.BasesAndContinuity.Bases                   -- (1)

--- a/source/Locales/ScottLocale/ScottLocalesOfAlgebraicDcpos.lagda
+++ b/source/Locales/ScottLocale/ScottLocalesOfAlgebraicDcpos.lagda
@@ -100,8 +100,8 @@ function.
 
 \begin{code}
 
- I = index-of-compact-basis 𝓓 hscb
- β = family-of-basic-opens  𝓓 hscb
+ I = index-of-compact-basis     𝓓 hscb
+ β = family-of-compact-elements 𝓓 hscb
 
 \end{code}
 


### PR DESCRIPTION
@tomdjong requested that I break PR #217 into smaller PRs — which is quite reasonable given how large that PR had gotten. This is the first in a series of PRs breaking up PR #217.

It adds three things:

  1. The definition of the notion of [Scott domain](https://ayberkt.github.io/mathematical-forest/axt-000J.xml).
  2. A version of `𝓛-DCPO` that gives an intrinsically locally small dcpo. This is kind of a hack, but it’s very conventient for me at the moment.
  3. A module, called `Topology.ScottTopologyProperties`, in which some properties of the Scott topology of a dcpo is proved.

There are also a bunch of other minor additions.

By the way, let me also note that there is a well-principled way of breaking up a large PR into smaller PRs: one can create a new branch and then automatically cherry-pick the commits that touch a certain file or directory. However, to be able to do this, one has to adhere to the principle of keeping commits small, and not mixing a bunch of changes to multiple files into the same commit. When I was developing this PR, I have sinned and did not stick to this principle, as a result of which I have not been able to do this. I have therefore re-comitted the relevant changes manually in this PR.