### PR TITLE
Fix commented code and minor issues from thesis-pr

### DIFF
--- a/source/TWA/Thesis/AndrewSneap/DyadicRationals.lagda
+++ b/source/TWA/Thesis/AndrewSneap/DyadicRationals.lagda
@@ -1,5 +1,7 @@
 Andrew Sneap, April 2023
 
+Note that this file is incomplete.
+
 \begin{code}
 {-# OPTIONS --without-K --safe #-}
             

--- a/source/TWA/Thesis/AndrewSneap/DyadicReals.lagda
+++ b/source/TWA/Thesis/AndrewSneap/DyadicReals.lagda
@@ -1,5 +1,7 @@
 Andrew Sneap, April 2023
 
+Note that this file is incomplete.
+
 \begin{code}
 {-# OPTIONS --without-K --safe  #-}
 

--- a/source/TWA/Thesis/Chapter3/ClosenessSpaces-Examples.lagda
+++ b/source/TWA/Thesis/Chapter3/ClosenessSpaces-Examples.lagda
@@ -66,7 +66,7 @@ discrete-clofun''-e : {X : 𝓤 ̇ } (x y : X)
                     → discrete-clofun'' x y d ＝ ∞ → x ＝ y
 discrete-clofun''-e x y (inl e) cxy＝∞ = e
 discrete-clofun''-e x y (inr f) cxy＝∞
- = 𝟘-elim (zero-is-not-one (ap (λ - → pr₁ - 0) cxy＝∞))
+ = 𝟘-elim (zero-is-not-one (ap (λ - → ℕ∞-to-ℕ→𝟚 - 0) cxy＝∞))
 
 discrete-clofun''-i : {X : 𝓤 ̇ } (x : X)
                     → (d : is-decidable (x ＝ x))
@@ -126,7 +126,7 @@ finite-totally-bounded {𝓤} {X} f d x (succ ε)
  = X , (id , id , η) , f
  where
   η : (x : X) → C (D-ClosenessSpace d) (succ ε) x x
-  η x n _ = ap (λ - → pr₁ - n) (i⟨ D-ClosenessSpace d ⟩ x)
+  η x n _ = ap (λ - → ℕ∞-to-ℕ→𝟚 - n) (i⟨ D-ClosenessSpace d ⟩ x)
 
 discrete-apart-implies-closeness-0
  : {X : 𝓤 ̇ }
@@ -151,7 +151,7 @@ discrete-closeness-succ-implies-equal d x y n Csnxy
  = γ (d x y) (Csnxy n (<-gives-⊏ n (succ n) (<-succ n)))
  where
   γ : (dxy : is-decidable (x ＝ y))
-    → pr₁ (discrete-clofun'' x y dxy) n ＝ ₁
+    → ℕ∞-to-ℕ→𝟚 (discrete-clofun'' x y dxy) n ＝ ₁
     → x ＝ y
   γ (inl e) _ = e
   γ (inr f) cxyₙ=₁ = 𝟘-elim (zero-is-not-one cxyₙ=₁)
@@ -174,9 +174,9 @@ discrete-closeness-succ-implies-equal d x y n Csnxy
 +-clofun'-e X Y (inr y₁) (inr y₂) q
  = ap inr (e⟨ Y ⟩ y₁ y₂ q)
 +-clofun'-e X Y (inl x₁) (inr y₂) f
- = 𝟘-elim (zero-is-not-one (ap (λ - → pr₁ - 0) f))
+ = 𝟘-elim (zero-is-not-one (ap (λ - → ℕ∞-to-ℕ→𝟚 - 0) f))
 +-clofun'-e X Y (inr y₁) (inl x₂) f
- = 𝟘-elim (zero-is-not-one (ap (λ - → pr₁ - 0) f))
+ = 𝟘-elim (zero-is-not-one (ap (λ - → ℕ∞-to-ℕ→𝟚 - 0) f))
 
 +-clofun'-i : (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
             → self-indistinguishable (+-clofun' X Y)
@@ -269,13 +269,13 @@ min-∞-l : (u v : ℕ∞) → min u v ＝ ∞ → u ＝ ∞
 min-∞-l u v min＝∞
  = to-subtype-＝ (being-decreasing-is-prop (fe _ _))
      (dfunext (fe _ _)
-       (λ i → Lemma[min𝟚ab＝₁→a＝₁] (ap (λ - → pr₁ - i) min＝∞)))
+       (λ i → Lemma[min𝟚ab＝₁→a＝₁] (ap (λ - → ℕ∞-to-ℕ→𝟚 - i) min＝∞)))
 
 min-∞-r : (u v : ℕ∞) → min u v ＝ ∞ → v ＝ ∞
 min-∞-r u v min＝∞
  = to-subtype-＝ (being-decreasing-is-prop (fe _ _))
      (dfunext (fe _ _)
-       (λ i → Lemma[min𝟚ab＝₁→b＝₁] (ap (λ - → pr₁ - i) min＝∞)))
+       (λ i → Lemma[min𝟚ab＝₁→b＝₁] (ap (λ - → ℕ∞-to-ℕ→𝟚 - i) min＝∞)))
 
 ×-clofun'-e : (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
             → indistinguishable-are-equal (×-clofun' X Y)
@@ -318,9 +318,11 @@ minℕ∞-abcdef : (a b c d e f : ℕ∞)
 minℕ∞-abcdef a b c d e f mab≼e mcd≼f n minabcd＝₁
  = Lemma[a＝₁→b＝₁→min𝟚ab＝₁]
      (mab≼e n (min𝟚-abcd-ac
-       (pr₁ a n) (pr₁ c n) (pr₁ b n) (pr₁ d n) minabcd＝₁))
+       (ℕ∞-to-ℕ→𝟚 a n) (ℕ∞-to-ℕ→𝟚 c n) (ℕ∞-to-ℕ→𝟚 b n) (ℕ∞-to-ℕ→𝟚 d n)
+       minabcd＝₁))
      (mcd≼f n (min𝟚-abcd-bd
-       (pr₁ a n) (pr₁ c n) (pr₁ b n) (pr₁ d n) minabcd＝₁))
+       (ℕ∞-to-ℕ→𝟚 a n) (ℕ∞-to-ℕ→𝟚 c n) (ℕ∞-to-ℕ→𝟚 b n) (ℕ∞-to-ℕ→𝟚 d n)
+       minabcd＝₁))
 
 ×-clofun'-u : (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
             → is-ultra (×-clofun' X Y)
@@ -713,7 +715,7 @@ discrete-seq-clofun-e
  → (d : (i : ℕ) → is-discrete (X i))
  → indistinguishable-are-equal (discrete-seq-clofun d)
 discrete-seq-clofun-e d α β cαβ=∞
- = discrete-seq-clofun'-e d α β (λ n → ap (λ - → pr₁ - n) cαβ=∞)
+ = discrete-seq-clofun'-e d α β (λ n → ap (λ - → ℕ∞-to-ℕ→𝟚 - n) cαβ=∞)
 
 discrete-seq-clofun-i : {X : ℕ → 𝓤 ̇ }
                       → (d : (i : ℕ) → is-discrete (X i))
@@ -819,9 +821,9 @@ C-to-∼ⁿ d = C-to-∼ⁿ' (λ _ → d)
 \begin{code}
 Π-clofun' : (T : ℕ → ClosenessSpace 𝓤)
           → Π (⟨_⟩ ∘ T) → Π (⟨_⟩ ∘ T) → (ℕ → 𝟚)
-Π-clofun' T x y zero = pr₁ (c⟨ T 0 ⟩ (x 0) (y 0)) 0
+Π-clofun' T x y zero = ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (x 0) (y 0)) 0
 Π-clofun' T x y (succ n)
- = min𝟚 (pr₁ (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
+ = min𝟚 (ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
      (Π-clofun' (T ∘ succ) (x ∘ succ) (y ∘ succ) n)
 
 Π-clofun'-d : (T : ℕ → ClosenessSpace 𝓤)
@@ -836,7 +838,8 @@ C-to-∼ⁿ d = C-to-∼ⁿ' (λ _ → d)
 Π-clofun'-all : (T : ℕ → ClosenessSpace 𝓤)
               → (x y : Π (⟨_⟩ ∘ T))
               → Π-clofun' T x y ∼ (λ i → ₁)
-              → (n : ℕ) → (pr₁ (c⟨ T n ⟩ (x n) (y n))) ∼ (λ i → ₁)
+              → (n : ℕ)
+              → (ℕ∞-to-ℕ→𝟚 (c⟨ T n ⟩ (x n) (y n))) ∼ (λ i → ₁)
 Π-clofun'-all T x y cxy∼∞ 0 zero = cxy∼∞ 0
 Π-clofun'-all T x y cxy∼∞ 0 (succ i)
  = Lemma[min𝟚ab＝₁→a＝₁] (cxy∼∞ (succ i))
@@ -849,43 +852,28 @@ C-to-∼ⁿ d = C-to-∼ⁿ' (λ _ → d)
             → Π-clofun' T x y ∼ (λ i → ₁) → x ＝ y
 Π-clofun'-e T x y f
  = dfunext (fe _ _)
-     (λ i → e i (x i) (y i)
+     (λ i → e⟨ T i ⟩ (x i) (y i)
        (to-subtype-＝ (being-decreasing-is-prop (fe _ _))
          (dfunext (fe _ _) (Π-clofun'-all T x y f i))))
- where
-  e : (n : ℕ) → indistinguishable-are-equal c⟨ T n ⟩
-  e n = pr₁ (pr₂ (pr₂ (T n)))
 
 Π-clofun'-i : (T : ℕ → ClosenessSpace 𝓤)
             → (x : Π (⟨_⟩ ∘ T)) → Π-clofun' T x x ∼ (λ i → ₁)
-Π-clofun'-i T x 0 = ap (λ - → pr₁ - 0) (i 0 (x 0))
- where
-  i : (n : ℕ) → self-indistinguishable c⟨ T n ⟩
-  i n = pr₁ (pr₂ (pr₂ (pr₂ (T n))))
+Π-clofun'-i T x 0 = ap (λ - → ℕ∞-to-ℕ→𝟚 - 0) (i⟨ T 0 ⟩ (x 0))
 Π-clofun'-i T x (succ n)
  = Lemma[a＝₁→b＝₁→min𝟚ab＝₁]
-     (ap (λ - → pr₁ - (succ n)) (i 0 (x 0)))
+     (ap (λ - → ℕ∞-to-ℕ→𝟚 - (succ n)) (i⟨ T 0 ⟩ (x 0)))
      (Π-clofun'-i (T ∘ succ) (x ∘ succ) n)
- where
-  i : (n : ℕ) → self-indistinguishable c⟨ T n ⟩
-  i n = pr₁ (pr₂ (pr₂ (pr₂ (T n))))
 
 Π-clofun'-s : (T : ℕ → ClosenessSpace 𝓤)
             → (x y : Π (⟨_⟩ ∘ T))
             → Π-clofun' T x y ∼ Π-clofun' T y x
 Π-clofun'-s T x y zero
- = ap (λ - → pr₁ - 0) (s 0 (x 0) (y 0))
- where
-  s : (n : ℕ) → is-symmetric c⟨ T n ⟩
-  s n = pr₁ (pr₂ (pr₂ (pr₂ (pr₂ (T n)))))
+ = ap (λ - → ℕ∞-to-ℕ→𝟚 - 0) (s⟨ T 0 ⟩ (x 0) (y 0))
 Π-clofun'-s T x y (succ n)
  = ap (λ - → min𝟚 - (Π-clofun' (T ∘ succ) (x ∘ succ) (y ∘ succ) n))
-     (ap (λ - → pr₁ - (succ n)) (s 0 (x 0) (y 0)))
+     (ap (λ - → pr₁ - (succ n)) (s⟨ T 0 ⟩ (x 0) (y 0)))
  ∙ ap (λ - → min𝟚 (pr₁ (c⟨ T 0 ⟩ (y 0) (x 0)) (succ n)) -)
      (Π-clofun'-s (T ∘ succ) (x ∘ succ) (y ∘ succ) n)
- where
-  s : (n : ℕ) → is-symmetric c⟨ T n ⟩
-  s n = pr₁ (pr₂ (pr₂ (pr₂ (pr₂ (T n)))))
 
 Lemma[min𝟚abcd＝₁→min𝟚ac＝₁] : (a b c d : 𝟚)
                             → min𝟚 (min𝟚 a b) (min𝟚 c d) ＝ ₁
@@ -903,29 +891,23 @@ Lemma[min𝟚abcd＝₁→min𝟚bd＝₁] ₁ ₁ ₁ ₁ e = refl
             → min𝟚 (Π-clofun' T x y n) (Π-clofun' T y z n) ＝ ₁
             → Π-clofun' T x z n ＝ ₁
 Π-clofun'-u T x y z 0 η
- = u 0 (x 0) (y 0) (z 0) 0 η
- where
-  u : (n : ℕ) → is-ultra c⟨ T n ⟩
-  u n = pr₂ (pr₂ (pr₂ (pr₂ (pr₂ (T n)))))
+ = u⟨ T 0 ⟩ (x 0) (y 0) (z 0) 0 η
 Π-clofun'-u T x y z (succ n) η
  = Lemma[a＝₁→b＝₁→min𝟚ab＝₁]
-     (u 0 (x 0) (y 0) (z 0) (succ n)
+     (u⟨ T 0 ⟩ (x 0) (y 0) (z 0) (succ n)
        (Lemma[min𝟚abcd＝₁→min𝟚ac＝₁]
-         (pr₁ (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
+         (ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
          (Π-clofun' (T ∘ succ) (x ∘ succ) (y ∘ succ) n)
-         (pr₁ (c⟨ T 0 ⟩ (y 0) (z 0)) (succ n))
+         (ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (y 0) (z 0)) (succ n))
          (Π-clofun' (T ∘ succ) (y ∘ succ) (z ∘ succ) n)
          η))
      (Π-clofun'-u (T ∘ succ) (x ∘ succ) (y ∘ succ) (z ∘ succ) n
        (Lemma[min𝟚abcd＝₁→min𝟚bd＝₁]
-         (pr₁ (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
+         (ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (x 0) (y 0)) (succ n))
          (Π-clofun' (T ∘ succ) (x ∘ succ) (y ∘ succ) n)
-         (pr₁ (c⟨ T 0 ⟩ (y 0) (z 0)) (succ n))
+         (ℕ∞-to-ℕ→𝟚 (c⟨ T 0 ⟩ (y 0) (z 0)) (succ n))
          (Π-clofun' (T ∘ succ) (y ∘ succ) (z ∘ succ) n)
          η))
- where
-  u : (n : ℕ) → is-ultra c⟨ T n ⟩
-  u n = pr₂ (pr₂ (pr₂ (pr₂ (pr₂ (T n)))))
 
 Π-clofun : (T : ℕ → ClosenessSpace 𝓤)
          → Π (⟨_⟩ ∘ T) → Π (⟨_⟩ ∘ T) → ℕ∞

--- a/source/TWA/Thesis/Chapter3/ClosenessSpaces.lagda
+++ b/source/TWA/Thesis/Chapter3/ClosenessSpaces.lagda
@@ -30,18 +30,22 @@ module TWA.Thesis.Chapter3.ClosenessSpaces (fe : FunExt) where
 open import TWA.Closeness fe hiding (is-ultra; is-closeness)
 
 is-decreasing'
- : (v : ℕ∞) (n : ℕ) → (i : ℕ) → i ≤ n → pr₁ v n ＝ ₁ → pr₁ v i ＝ ₁
+ : (v : ℕ∞) (n i : ℕ)
+ → i ≤ n
+ → ℕ∞-to-ℕ→𝟚 v n ＝ ₁
+ → ℕ∞-to-ℕ→𝟚 v i ＝ ₁
 is-decreasing' v
- = regress (λ z → pr₁ v z ＝ ₁) (λ n → ≤₂-criterion-converse (pr₂ v n))
+ = regress (λ z → ℕ∞-to-ℕ→𝟚 v z ＝ ₁)
+     (λ n → ≤₂-criterion-converse (pr₂ v n))
 
-positive-below-n : (i n : ℕ) → pr₁ (Succ (n ↑)) i ＝ ₁ → i ≤ n
+positive-below-n : (i n : ℕ) → ℕ∞-to-ℕ→𝟚 (Succ (n ↑)) i ＝ ₁ → i ≤ n
 positive-below-n zero n snᵢ=1 = ⋆
 positive-below-n (succ i) (succ n) snᵢ=1 = positive-below-n i n snᵢ=1
 
 ≼-left-decidable : (n : ℕ) (v : ℕ∞) → is-decidable ((n ↑) ≼ v)
 ≼-left-decidable zero v = inl (zero-minimal v)
 ≼-left-decidable (succ n) v
- = Cases (𝟚-is-discrete (pr₁ v n) ₁)
+ = Cases (𝟚-is-discrete (ℕ∞-to-ℕ→𝟚 v n) ₁)
      (λ  vₙ=1 → inl (λ i snᵢ=1 → is-decreasing' v n i
                                    (positive-below-n i n snᵢ=1) vₙ=1))
      (λ ¬vₙ=1 → inr (λ sn≼v → ¬vₙ=1 (sn≼v n (ℕ-to-ℕ∞-diagonal₁ n))))
@@ -208,7 +212,7 @@ closeness-∞-implies-ϵ-close : (X : ClosenessSpace 𝓤)
                             → c⟨ X ⟩ x y ＝ ∞
                             → (ϵ : ℕ) → C X ϵ x y
 closeness-∞-implies-ϵ-close X x y cxy＝∞ ϵ n _
- = ap (λ - → pr₁ - n) cxy＝∞
+ = ap (λ - → ℕ∞-to-ℕ→𝟚 - n) cxy＝∞
 
 C-id : (X : ClosenessSpace 𝓤)
      → (n : ℕ)

--- a/source/TWA/Thesis/Chapter3/SearchableTypes-Examples.lagda
+++ b/source/TWA/Thesis/Chapter3/SearchableTypes-Examples.lagda
@@ -29,7 +29,7 @@ open import TWA.Thesis.Chapter3.PredicateEquality fe pe
 
 ## Finite uniformly continuously searchable spaces
 
-\end{code}
+\begin{code}
 finite-csearchable
  : (X : ClosenessSpace 𝓤)
  → (f : finite-linear-order ⟨ X ⟩)
@@ -41,7 +41,7 @@ finite-csearchable X f x
 
 ## Disjoint union of uniformly continuously searchable spaces
 
-\end{code}
+\begin{code}
 +-csearchable : (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
               → csearchable 𝓦 X
               → csearchable 𝓦 Y
@@ -74,7 +74,7 @@ finite-csearchable X f x
 
 ## Binary product of uniformly continuously searchable spaces
 
-\end{code}
+\begin{code}
 ×-pred-left : (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
             → decidable-uc-predicate 𝓦 (×-ClosenessSpace X Y)
             → ⟨ Y ⟩ → decidable-uc-predicate 𝓦 X
@@ -140,7 +140,7 @@ finite-csearchable X f x
 
 ## Equivalent uniformly continuously searchable spaces
 
-\end{code}
+\begin{code}
 ≃-csearchable : {X : 𝓤 ̇} (Y : ClosenessSpace 𝓥)
               → (e : X ≃ ⟨ Y ⟩)
               → csearchable 𝓦 Y
@@ -172,7 +172,7 @@ finite-csearchable X f x
 
 ## Finite-sequence uniformly continuously searchable spaces
 
-\end{code}
+\begin{code}
 tail-predicate
  : {X : ℕ → 𝓤 ̇ }
  → (f : (n : ℕ) → finite-linear-order (X n))
@@ -275,7 +275,7 @@ discrete-finite-seq-csearchable x₀ f ds
 
 ## Tychonoff theorem
 
-\end{code}
+\begin{code}
 tail-predicate-tych
  : (T : ℕ → ClosenessSpace 𝓤)
  → (δ : ℕ)

--- a/source/TWA/Thesis/Chapter4/ApproxOrder-Examples.lagda
+++ b/source/TWA/Thesis/Chapter4/ApproxOrder-Examples.lagda
@@ -41,7 +41,7 @@ open import TWA.Thesis.Chapter4.ApproxOrder fe
 
 ## Subtype orders
 
-\end{code}
+\begin{code}
 inclusion-order
  : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } → (f : X → Y) (_≤_ : Y → Y → 𝓦 ̇) → X → X → 𝓦 ̇
 inclusion-order f _≤_ x₁ x₂ = f x₁ ≤ f x₂
@@ -175,7 +175,7 @@ module ΣOrder-Relates (pt : propositional-truncations-exist) where
 
 ## Finite orders
 
-\end{code}
+\begin{code}
 _≤Fin_ : {n : ℕ} → Fin n → Fin n → 𝓤₀  ̇
 _≤Fin_ {succ n} 𝟎 y = 𝟙
 _≤Fin_ {succ n} (suc x) 𝟎 = 𝟘
@@ -249,7 +249,7 @@ finite-order-is-linear-order (n , (g , i))
 
 ## Discrete-sequence orders
 
-\end{code}
+\begin{code}
 discrete-lexicorder : {D : 𝓤 ̇ }
                     → is-discrete D
                     → (_≤_ : D → D → 𝓥 ̇ )
@@ -531,7 +531,7 @@ module LexicographicOrder-Relates
 
 ## Specific example orders
 
-\end{code}
+\begin{code}
 ℕ→𝟚-lexicorder : (ℕ → 𝟚) → (ℕ → 𝟚) → 𝓤₀ ̇
 ℕ→𝟚-lexicorder
  = discrete-lexicorder 𝟚-is-discrete (finite-order 𝟚-is-finite)

--- a/source/TWA/Thesis/Chapter4/ApproxOrder.lagda
+++ b/source/TWA/Thesis/Chapter4/ApproxOrder.lagda
@@ -22,7 +22,7 @@ open import TWA.Thesis.Chapter3.ClosenessSpaces fe
 
 ## Traditional orders
 
-\end{code}
+\begin{code}
 is-preorder : {X : 𝓤  ̇ } → (X → X → 𝓦  ̇ ) → 𝓤 ⊔ 𝓦  ̇ 
 is-preorder _≤_ = reflexive _≤_
                 × transitive _≤_
@@ -62,7 +62,7 @@ discrete-reflexive-antisym-linear-order-is-decidable
 
 ## Approximate orders
 
-\end{code}
+\begin{code}
 is-approx-order : (X : ClosenessSpace 𝓤)
                 → (_≤ⁿ_ : ⟨ X ⟩ → ⟨ X ⟩ → ℕ → 𝓦'  ̇ )
                 → 𝓤 ⊔ 𝓦'  ̇
@@ -187,7 +187,7 @@ module ApproxOrder-Relates (pt : propositional-truncations-exist) where
 
 ## Predicates from approximate orders
 
-\end{code}
+\begin{code}
 approx-order-ucontinuous-l
  : (X : ClosenessSpace 𝓤)
  → {_≤ⁿ_ : ⟨ X ⟩ → ⟨ X ⟩ → ℕ → 𝓦'  ̇ }
@@ -212,7 +212,6 @@ approx-order-ucontinuous-r X a ε y
             x₁≤ⁿy
             (≤ⁿ-close X a ε x₁ x₂ Cx₁x₂))
 
--- LINK: approx-order-uc-predicate
 approx-order-uc-predicate-l : (X : ClosenessSpace 𝓤)
                             → (_≤ⁿ_ : ⟨ X ⟩ → ⟨ X ⟩ → ℕ → 𝓦 ̇ )
                             → is-approx-order X _≤ⁿ_

--- a/source/TWA/Thesis/Chapter4/GlobalOptimisation.lagda
+++ b/source/TWA/Thesis/Chapter4/GlobalOptimisation.lagda
@@ -20,7 +20,7 @@ open import TWA.Thesis.Chapter4.ApproxOrder fe
 
 ## Absolute global optimisation
 
-\end{code}
+\begin{code}
 is-global-minimal : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (_≤_ : Y → Y → 𝓦 ̇ )
                   → (X → Y) → X → 𝓤 ⊔ 𝓦  ̇
 is-global-minimal {𝓤} {𝓥} {𝓦'} {X} _≤_ f x₀ = (x : X) → f x₀ ≤ f x
@@ -75,7 +75,7 @@ finite-global-minimal x (n , e@(g , _ , (h , μ))) _≤_ l f
 
 ## Approximate global optimisation
 
-\end{code}
+\begin{code}
 is_global-minimal : ℕ → {𝓤 𝓥 : Universe}
                   → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                   → (_≤ⁿ_ : Y → Y → ℕ → 𝓦 ̇ )
@@ -102,7 +102,7 @@ F-ϵ-global-minimal Y x l _≤ⁿ_ a ϵ
 
 ## Global optimisation theorem
 
-\end{code}
+\begin{code}
 cover-continuity-lemma
  : (X : ClosenessSpace 𝓤) {X' : 𝓤' ̇ } (Y : ClosenessSpace 𝓥)
  → (_≤ⁿ_ : ⟨ Y ⟩ → ⟨ Y ⟩ → ℕ → 𝓦'  ̇ )

--- a/source/TWA/Thesis/Chapter4/ParametricRegression.lagda
+++ b/source/TWA/Thesis/Chapter4/ParametricRegression.lagda
@@ -37,7 +37,7 @@ open import TWA.Closeness fe hiding (is-ultra;is-closeness)
 
 ## Regression as maximisation
 
-\end{code}
+\begin{code}
 invert-rel : {X : 𝓤 ̇ } → (X → X → 𝓥 ̇ ) → (X → X → 𝓥 ̇ )
 invert-rel R x y = R y x
 
@@ -112,10 +112,10 @@ oracle-closeness' : (Y : PseudoClosenessSpace 𝓥)
                   → C' (ι ℕ∞-ClosenessSpace) ϵ (c 𝓞 y₁) (c 𝓞 y₂)
 oracle-closeness' (_ , c , _ , c-sym , c-ult) 𝓞 ϵ y₁ y₂ Cϵy₁y₂ n n⊏ϵ
  = decidable-𝟚₁ (∼ⁿ-decidable (λ _ → 𝟚-is-discrete) _ _ (succ n))
-       (λ k k<sn → C𝓞-eq k
-                     (<-≤-trans k (succ n) ϵ k<sn (⊏-gives-< n ϵ n⊏ϵ))
-                     (𝟚-possibilities (pr₁ (c 𝓞 y₁) k))
-                     (𝟚-possibilities (pr₁ (c 𝓞 y₂) k)))
+    (λ k k<sn
+     → C𝓞-eq k (<-≤-trans k (succ n) ϵ k<sn (⊏-gives-< n ϵ n⊏ϵ))
+        (𝟚-possibilities (pr₁ (c 𝓞 y₁) k))
+        (𝟚-possibilities (pr₁ (c 𝓞 y₂) k)))
    where
     C𝓞-eq : (n : ℕ) → n < ϵ
           → let c𝓞y₁n = pr₁ (c 𝓞 y₁) n in
@@ -126,16 +126,16 @@ oracle-closeness' (_ , c , _ , c-sym , c-ult) 𝓞 ϵ y₁ y₂ Cϵy₁y₂ n n�
     C𝓞-eq n n<ϵ (inl c𝓞y₁＝₀) (inl c𝓞y₂＝₀) = c𝓞y₁＝₀ ∙ c𝓞y₂＝₀ ⁻¹
     C𝓞-eq n n<ϵ (inl c𝓞y₁＝₀) (inr c𝓞y₂＝₁)
      = 𝟘-elim (zero-is-not-one
-         (c𝓞y₁＝₀ ⁻¹
+        (c𝓞y₁＝₀ ⁻¹
          ∙ c-ult 𝓞 y₂ y₁ n
-           (Lemma[a＝₁→b＝₁→min𝟚ab＝₁] c𝓞y₂＝₁
+            (Lemma[a＝₁→b＝₁→min𝟚ab＝₁] c𝓞y₂＝₁
              (ap (λ - → pr₁ - n) (c-sym y₂ y₁)
-             ∙ Cϵy₁y₂ n (<-gives-⊏ n ϵ n<ϵ)))))
+              ∙ Cϵy₁y₂ n (<-gives-⊏ n ϵ n<ϵ)))))
     C𝓞-eq n n<ϵ (inr c𝓞y₁＝₁) (inl c𝓞y₂＝₀)
      = 𝟘-elim (zero-is-not-one
-         (c𝓞y₂＝₀ ⁻¹
+        (c𝓞y₂＝₀ ⁻¹
          ∙ c-ult 𝓞 y₁ y₂ n
-           (Lemma[a＝₁→b＝₁→min𝟚ab＝₁] c𝓞y₁＝₁
+            (Lemma[a＝₁→b＝₁→min𝟚ab＝₁] c𝓞y₁＝₁
              (Cϵy₁y₂ n (<-gives-⊏ n ϵ n<ϵ)))))
     C𝓞-eq n n<ϵ (inr c𝓞y₁＝₁) (inr c𝓞y₂＝₁) = c𝓞y₁＝₁ ∙ c𝓞y₂＝₁ ⁻¹
 
@@ -155,9 +155,10 @@ optimisation-convergence
        → (has ϵ global-maximal) ℕ∞-approx-lexicorder (λ x → c 𝓞 (M x))
 optimisation-convergence X Y x₀ t M 𝓞 ϕᴹ
  = global-max-ℕ∞ X x₀ t (c 𝓞 ∘ M)
-     (λ ϵ → pr₁ (ϕᴹ ϵ)
-          , λ x₁ x₂ Cδᶜx₁x₂ → oracle-closeness' Y 𝓞 ϵ (M x₁) (M x₂)
-                                (pr₂ (ϕᴹ ϵ) x₁ x₂ Cδᶜx₁x₂))
+    (λ ϵ → pr₁ (ϕᴹ ϵ)
+    , λ x₁ x₂ Cδᶜx₁x₂
+      → oracle-closeness' Y 𝓞 ϵ (M x₁) (M x₂)
+         (pr₂ (ϕᴹ ϵ) x₁ x₂ Cδᶜx₁x₂))
  where
   c : ⟪ Y ⟫ → ⟪ Y ⟫ → ℕ∞
   c = pr₁ (pr₂ Y)
@@ -191,14 +192,14 @@ s-imperfect-convergence
        → (M : ⟨ X ⟩ → ⟪ Y ⟫) (ϕᴹ : f-ucontinuous' (ι X) Y M)
        → (Ψ : ⟪ Y ⟫ → ⟪ Y ⟫) (k : ⟨ X ⟩)
        → let
-           𝓞 = M k
-           Ψ𝓞 = Ψ 𝓞
-           reg = p-regressor X Y S ε
-           ω = M (reg M ϕᴹ Ψ𝓞)
+          𝓞 = M k
+          Ψ𝓞 = Ψ 𝓞
+          reg = p-regressor X Y S ε
+          ω = M (reg M ϕᴹ Ψ𝓞)
          in (C' Y ε 𝓞 Ψ𝓞) → (C' Y ε 𝓞 ω)
 s-imperfect-convergence X Y S ε M ϕᴹ Ψ k Cε𝓞Ψ𝓞
  = C'-trans Y ε 𝓞 Ψ𝓞 ω Cε𝓞Ψ𝓞
-     (pr₂ (S ((p , d) , ϕ)) (k , C'-sym Y ε 𝓞 Ψ𝓞 Cε𝓞Ψ𝓞))
+    (pr₂ (S ((p , d) , ϕ)) (k , C'-sym Y ε 𝓞 Ψ𝓞 Cε𝓞Ψ𝓞))
  where
   𝓞 = M k
   Ψ𝓞 = Ψ 𝓞
@@ -215,8 +216,7 @@ s-imperfect-convergence X Y S ε M ϕᴹ Ψ k Cε𝓞Ψ𝓞
     δ = pr₁ (ϕᴹ ε)
     γ : (x₁ x₂ : ⟨ X ⟩) → C X δ x₁ x₂ → p x₁ holds → p x₂ holds
     γ x₁ x₂ Cδx₁x₂ CεΨ𝓞Mx₂
-     = C'-trans Y ε Ψ𝓞 (M x₁) (M x₂) CεΨ𝓞Mx₂
-         (pr₂ (ϕᴹ ε) x₁ x₂ Cδx₁x₂)
+     = C'-trans Y ε Ψ𝓞 (M x₁) (M x₂) CεΨ𝓞Mx₂ (pr₂ (ϕᴹ ε) x₁ x₂ Cδx₁x₂)
 
 perfect-convergence
        : (X : ClosenessSpace 𝓤) (Y : PseudoClosenessSpace 𝓥)
@@ -225,9 +225,9 @@ perfect-convergence
        → (M : ⟨ X ⟩ → ⟪ Y ⟫) (ϕᴹ : f-ucontinuous' (ι X) Y M)
        → (k : ⟨ X ⟩)
        → let
-           𝓞 = M k
-           reg = p-regressor X Y S ε
-           ω = M (reg M ϕᴹ 𝓞)
+          𝓞 = M k
+          reg = p-regressor X Y S ε
+          ω = M (reg M ϕᴹ 𝓞)
          in C' Y ε 𝓞 ω
 perfect-convergence X Y S ε M ϕᴹ k
  = s-imperfect-convergence X Y S ε M ϕᴹ id k (C'-refl Y ε 𝓞)

--- a/source/TWA/Thesis/Chapter5/BoehmStructure.lagda
+++ b/source/TWA/Thesis/Chapter5/BoehmStructure.lagda
@@ -14,7 +14,7 @@ open import Naturals.Addition renaming (_+_ to _ℕ+_)
 
 open import TWA.Thesis.Chapter5.Integers
 
-module TWA.Thesis.Chapter5.BelowAndAbove where
+module TWA.Thesis.Chapter5.BoehmStructure where
 \end{code}
 
 ## downLeft, downMid and downRight

--- a/source/TWA/Thesis/Chapter5/BoehmVerification.lagda
+++ b/source/TWA/Thesis/Chapter5/BoehmVerification.lagda
@@ -19,7 +19,7 @@ open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
-open import TWA.Thesis.Chapter5.BelowAndAbove
+open import TWA.Thesis.Chapter5.BoehmStructure
  hiding (downLeft; downMid; downRight; upRight; upLeft; _below_)
 open import TWA.Thesis.AndrewSneap.DyadicRationals
  renaming (normalise to ι)
@@ -45,7 +45,7 @@ open import TWA.Thesis.Chapter3.ClosenessSpaces-Examples fe
 
 ## Structural operations and properties
 
-\end{code}
+\begin{code}
 downLeft downMid downRight : ℤ → ℤ
 downLeft  k = (k ℤ+ k)
 downMid   k = (k ℤ+ k) +pos 1
@@ -111,7 +111,7 @@ nested-implies-fully-nested ζ ρ n m (k , refl)
 
 ## Verification of the structure of ternary Boehm encodings
 
-\end{code}
+\begin{code}
 -- By Andrew Sneap
 ⦅_⦆ : (χ : ℤ → ℤ[1/2]ᴵ) → nested χ → positioned χ → ℝ-d
 ⦅_⦆ χ τ π = (L , R)
@@ -479,7 +479,7 @@ ternary-normalised≃𝕋
 
 ## Representing compact intervals
 
-\end{code} 
+\begin{code} 
 CompactInterval : ℤ × ℤ → 𝓤₀ ̇
 CompactInterval (k , δ) = Σ (x , _) ꞉ 𝕋 , x(δ) ＝ k
 

--- a/source/TWA/Thesis/Chapter5/IntervalObject.lagda
+++ b/source/TWA/Thesis/Chapter5/IntervalObject.lagda
@@ -1,5 +1,12 @@
 Todd Waugh Ambridge, January 2024
 
+M.H. Escardo and A. Simpson. A universal characterization of the
+closed Euclidean interval (extended abstract). Proceedings of the 16th
+Annual IEEE Symposium on Logic in Computer Science,
+pp.115--125. Boston, Massachusetts, June 16-19, 2001.
+
+https://doi.org/10.1109/LICS.2001.932488
+
 # Formalisation of the Escardo-Simpson interval object
 
 \begin{code}

--- a/source/TWA/Thesis/Chapter5/SignedDigitIntervalObject.lagda
+++ b/source/TWA/Thesis/Chapter5/SignedDigitIntervalObject.lagda
@@ -25,7 +25,7 @@ open basic-interval-object-development fe io hiding (−1 ; O ; +1)
 
 ## Representation map
 
-\end{code}
+\begin{code}
 ⟨_⟩ : 𝟛 → 𝕀
 ⟨ −1 ⟩ = u
 ⟨  O ⟩ = u ⊕ v
@@ -78,7 +78,7 @@ map-realiser² f f' f→ f⊕ α β
 
 ## Negation
 
-\end{code}
+\begin{code}
 flip-realiser : flip pw-realises¹ −_
 flip-realiser −1 = −1-inverse
 flip-realiser  O =  O-inverse
@@ -91,7 +91,7 @@ neg-realiser
 
 ## Binary midpoint
 
-\end{code}
+\begin{code}
 half : 𝟝 → 𝕀
 half −2 = u
 half −1 = u /2
@@ -176,7 +176,7 @@ mid-realiser α β = div2-realiser (add2 α β)
 
 ## Infinitary midpoint
 
-\end{code}
+\begin{code}
 quarter : 𝟡 → 𝕀
 quarter −4 = u
 quarter −3 = u ⊕ (u ⊕ (u ⊕ v))
@@ -634,7 +634,7 @@ M-realiser δs = fg-approx-holds (map ⟪_⟫) (map quarter ∘ bigMid')
 
 ## Multiplication
 
-\end{code}
+\begin{code}
 digitMul-realiser : digitMul realises' _*_
 digitMul-realiser −1 α
  = neg-realiser α ⁻¹ ∙ *-gives-negation-r ⟪ α ⟫ ⁻¹

--- a/source/TWA/Thesis/Chapter6/SignedDigitContinuity.lagda
+++ b/source/TWA/Thesis/Chapter6/SignedDigitContinuity.lagda
@@ -29,7 +29,7 @@ open import TWA.Thesis.Chapter6.SequenceContinuity fe
 
 ## Negation
 
-\end{code}
+\begin{code}
 neg-ucontinuous' : seq-f-ucontinuous¹ neg
 neg-ucontinuous' = map-ucontinuous' flip
 
@@ -37,16 +37,17 @@ neg-ucontinuous
  : f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace neg
 neg-ucontinuous
  = seq-f-ucontinuous¹-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete
-     neg neg-ucontinuous'
+    𝟛-is-discrete 𝟛-is-discrete
+    neg neg-ucontinuous'
 \end{code}
 
 ## Binary midpoint
 
-\end{code}
+\begin{code}
 div2-ucontinuous' : seq-f-ucontinuous¹ div2
 div2-ucontinuous' zero = 0 , λ α β _ k ()
-div2-ucontinuous' (succ ε) = succ (succ ε) , γ ε where
+div2-ucontinuous' (succ ε) = succ (succ ε) , γ ε
+ where
   γ : (ε : ℕ) → (α β : ℕ → 𝟝) → (α ∼ⁿ β) (succ (succ ε))
     →  (div2 α ∼ⁿ div2 β) (succ ε)
   γ ε α β α∼ⁿβ 0 ⋆ = ap (λ - → pr₁ (div2-aux - (α 1))) (α∼ⁿβ 0 ⋆)
@@ -57,46 +58,47 @@ div2-ucontinuous' (succ ε) = succ (succ ε) , γ ε where
     β' = pr₂ (div2-aux (β 0) (β 1)) ∷ (tail (tail β))
     α∼ⁿβ' : (α' ∼ⁿ β') (succ (succ ε))
     α∼ⁿβ' 0 ⋆ = ap (λ - → pr₂ (div2-aux - (α 1))) (α∼ⁿβ 0 ⋆)
-             ∙ ap (λ - → pr₂ (div2-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
+              ∙ ap (λ - → pr₂ (div2-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
     α∼ⁿβ' (succ j) = α∼ⁿβ (succ (succ j))
 
 mid-ucontinuous' : seq-f-ucontinuous² mid
 mid-ucontinuous' = seq-f-ucontinuous¹²-comp div2 add2
-                   div2-ucontinuous' (zipWith-ucontinuous' _+𝟛_)
+                    div2-ucontinuous' (zipWith-ucontinuous' _+𝟛_)
 
 mid-ucontinuous
  : f-ucontinuous
-     (×-ClosenessSpace 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace)
-     𝟛ᴺ-ClosenessSpace (uncurry mid)
+    (×-ClosenessSpace 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace)
+    𝟛ᴺ-ClosenessSpace (uncurry mid)
 mid-ucontinuous
  = seq-f-ucontinuous²-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
-     mid mid-ucontinuous'
+    𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
+    mid mid-ucontinuous'
 
 mid-l-ucontinuous
  : (y : 𝟛ᴺ)
  → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace (λ x → mid x y)
 mid-l-ucontinuous y
  = seq-f-ucontinuous¹-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete
-     (λ x → mid x y)
-     (seq-f-ucontinuous²-left mid mid-ucontinuous' y)
+    𝟛-is-discrete 𝟛-is-discrete
+    (λ x → mid x y)
+    (seq-f-ucontinuous²-left mid mid-ucontinuous' y)
 
 mid-r-ucontinuous
  : (x : 𝟛ᴺ)
  → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace (λ y → mid x y)
 mid-r-ucontinuous x
  = seq-f-ucontinuous¹-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete
-     (λ y → mid x y)
-     (seq-f-ucontinuous²-right mid mid-ucontinuous' x)
+    𝟛-is-discrete 𝟛-is-discrete
+    (λ y → mid x y)
+    (seq-f-ucontinuous²-right mid mid-ucontinuous' x)
 \end{code}
 
 ## Infinitary midpoint
 
-\end{code}
+\begin{code}
 bigMid'-ucontinuous' : seq-f-ucontinuousᴺ bigMid'
-bigMid'-ucontinuous' ε = dδ ε , d≤δ ε , γ ε where
+bigMid'-ucontinuous' ε = dδ ε , d≤δ ε , γ ε
+ where
   d : ℕ → ℕ
   d 0 = 0
   d (succ ε) = succ (succ ε)
@@ -110,9 +112,9 @@ bigMid'-ucontinuous' ε = dδ ε , d≤δ ε , γ ε where
   d≤δ 1 = ⋆
   d≤δ (succ (succ n))
    = ≤-trans n (succ (δ n)) (succ (succ (succ (δ n))))
-       (d≤δ (succ n))
-       (≤-trans (δ n) (succ (δ n)) (succ (succ (δ n)))
-         (≤-succ (δ n)) (≤-succ (succ (δ n))))
+      (d≤δ (succ n))
+      (≤-trans (δ n) (succ (δ n)) (succ (succ (δ n)))
+       (≤-succ (δ n)) (≤-succ (succ (δ n))))
   pr₁δs< : (n : ℕ) → d n < d (succ n)
   pr₁δs< zero = ⋆
   pr₁δs< (succ n) = ≤-refl n
@@ -132,35 +134,37 @@ bigMid'-ucontinuous' ε = dδ ε , d≤δ ε , γ ε where
             → (αs' n ∼ⁿ βs' n) (δ (succ ε))
     αs∼ⁿβs' zero n<d i i<d
      = pr₂ (mid-ucontinuous' (δ (succ ε)))
-       (tail (tail (αs 0))) (tail (tail (βs 0)))
-       (tail       (αs 1) ) (tail       (βs 1) )
-       (λ i → αs∼ⁿβs zero ⋆ (succ (succ i)))
-       (λ i i≤δϵ → αs∼ⁿβs 1 ⋆ (succ i)
-         (≤-trans i _ _ i≤δϵ (≤-succ (δ ε)))) i i<d
+        (tail (tail (αs 0))) (tail (tail (βs 0)))
+        (tail       (αs 1) ) (tail       (βs 1) )
+        (λ i → αs∼ⁿβs zero ⋆ (succ (succ i)))
+        (λ i i≤δϵ → αs∼ⁿβs 1 ⋆ (succ i)
+        (≤-trans i _ _ i≤δϵ (≤-succ (δ ε)))) i i<d
     αs∼ⁿβs' (succ n) n<d i i≤δϵ
      = αs∼ⁿβs (succ (succ n)) n<d i
-         (≤-trans i (succ (succ (δ ε)))
-                    (succ (succ (succ (succ (succ (δ ε))))))
-           i≤δϵ (≤-+ (δ ε) 3))
+        (≤-trans i (succ (succ (δ ε)))
+                   (succ (succ (succ (succ (succ (δ ε))))))
+          i≤δϵ (≤-+ (δ ε) 3))
 
 div4-ucontinuous' : seq-f-ucontinuous¹ div4
 div4-ucontinuous' zero = 0 , λ α β _ k ()
-div4-ucontinuous' (succ ε) = succ (succ ε) , γ ε where
+div4-ucontinuous' (succ ε) = succ (succ ε) , γ ε
+ where
   γ : (ε : ℕ) → (α β : ℕ → 𝟡) → (α ∼ⁿ β) (succ (succ ε))
     →  (div4 α ∼ⁿ div4 β) (succ ε)
   γ ε α β α∼ⁿβ 0 ⋆ = ap (λ - → pr₁ (div4-aux - (α 1))) (α∼ⁿβ 0 ⋆)
-                  ∙ ap (λ - → pr₁ (div4-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
+                   ∙ ap (λ - → pr₁ (div4-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
   γ (succ ε) α β α∼ⁿβ (succ k) = γ ε α' β' α∼ⁿβ' k
    where
     α' = pr₂ (div4-aux (α 0) (α 1)) ∷ (tail (tail α))
     β' = pr₂ (div4-aux (β 0) (β 1)) ∷ (tail (tail β))
     α∼ⁿβ' : (α' ∼ⁿ β') (succ (succ ε))
     α∼ⁿβ' 0 ⋆ = ap (λ - → pr₂ (div4-aux - (α 1))) (α∼ⁿβ 0 ⋆)
-             ∙ ap (λ - → pr₂ (div4-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
+              ∙ ap (λ - → pr₂ (div4-aux (β 0) -)) (α∼ⁿβ 1 ⋆)
     α∼ⁿβ' (succ j) = α∼ⁿβ (succ (succ j))
 
 bigMid-ucontinuous' : seq-f-ucontinuousᴺ bigMid
-bigMid-ucontinuous' ε = dδ , d≤δ , ϕ where
+bigMid-ucontinuous' ε = dδ , d≤δ , ϕ
+ where
   γ = bigMid'-ucontinuous' (pr₁ (div4-ucontinuous' ε))
   dδ : ℕ × ℕ
   dδ = pr₁ γ
@@ -171,13 +175,13 @@ bigMid-ucontinuous' ε = dδ , d≤δ , ϕ where
     → (bigMid x₁ ∼ⁿ bigMid x₂) ε
   ϕ αs βs αs∼ⁿβs
    = pr₂ (div4-ucontinuous' ε)
-       (bigMid' αs) (bigMid' βs)
-       (pr₂ (pr₂ γ) αs βs αs∼ⁿβs)
+      (bigMid' αs) (bigMid' βs)
+      (pr₂ (pr₂ γ) αs βs αs∼ⁿβs)
 \end{code}
 
 ## Multiplication
 
-\end{code}
+\begin{code}
 mul-ucontinuous' : seq-f-ucontinuous² mul
 mul-ucontinuous' ε = δ ε , γ ε where
   δ : ℕ → ℕ × ℕ
@@ -187,10 +191,10 @@ mul-ucontinuous' ε = δ ε , γ ε where
     → (mul α₁ β₁ ∼ⁿ mul α₂ β₂) ε
   γ ε α₁ α₂ β₁ β₂ α∼ β∼
    = pr₂ (pr₂ (bigMid-ucontinuous' ε))
-       (zipWith digitMul α₁ (λ _ → β₁))
-       (zipWith digitMul α₂ (λ _ → β₂))
-       (λ n n<d k k<δ → ap (_*𝟛 β₁ k) (α∼ n n<d)
-                      ∙ ap (α₂ n *𝟛_) (β∼ k k<δ))
+      (zipWith digitMul α₁ (λ _ → β₁))
+      (zipWith digitMul α₂ (λ _ → β₂))
+      (λ n n<d k k<δ → ap (_*𝟛 β₁ k) (α∼ n n<d)
+                     ∙ ap (α₂ n *𝟛_) (β∼ k k<δ))
 
 mul-ucontinuous
  : f-ucontinuous
@@ -198,23 +202,23 @@ mul-ucontinuous
      𝟛ᴺ-ClosenessSpace (uncurry mul)
 mul-ucontinuous
  = seq-f-ucontinuous²-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
-     mul mul-ucontinuous'
+    𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
+    mul mul-ucontinuous'
 
 mul-l-ucontinuous
  : (y : 𝟛ᴺ)
  → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace (λ x → mul x y)
 mul-l-ucontinuous y
  = seq-f-ucontinuous¹-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete
-     (λ x → mul x y)
-     (seq-f-ucontinuous²-left mul mul-ucontinuous' y)
+    𝟛-is-discrete 𝟛-is-discrete
+    (λ x → mul x y)
+    (seq-f-ucontinuous²-left mul mul-ucontinuous' y)
 
 mul-b-ucontinuous
  : f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace (λ x → mul x x)
 mul-b-ucontinuous
  = seq-f-ucontinuous¹-to-closeness
-     𝟛-is-discrete 𝟛-is-discrete
-     (λ x → mul x x)
-     (seq-f-ucontinuous²-both mul mul-ucontinuous')
+    𝟛-is-discrete 𝟛-is-discrete
+    (λ x → mul x x)
+    (seq-f-ucontinuous²-both mul mul-ucontinuous')
 \end{code}

--- a/source/TWA/Thesis/Chapter6/SignedDigitExamples.lagda
+++ b/source/TWA/Thesis/Chapter6/SignedDigitExamples.lagda
@@ -30,7 +30,7 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
 
 ## Representations we will use
 
-\end{code}
+\begin{code}
 -1𝟚ᴺ -1/2𝟚ᴺ O𝟚ᴺ 1/4𝟚ᴺ 1/3𝟚ᴺ 1/2𝟚ᴺ 1𝟚ᴺ : 𝟚ᴺ
 -1𝟚ᴺ   = repeat ₀
 -1/2𝟚ᴺ = ₀ ∷ (₀ ∷ repeat ₁)
@@ -58,7 +58,7 @@ x /4 = (x /2) /2 /2
 
 ## Search examples
 
-\end{code}
+\begin{code}
 module Search-Example1 where
 
  predicate : ℕ → decidable-uc-predicate 𝓤₀ 𝟛ᴺ-ClosenessSpace
@@ -127,7 +127,7 @@ module Search-Example3 where
 
 ## Optimisation examples
 
-\end{code}
+\begin{code}
 module Optimisation-Example1 where
 
  opt-test : ℕ → 𝟛ᴺ
@@ -166,7 +166,7 @@ module Optimisation-Example2 where
 
 ## Regression examples
 
-\end{code}
+\begin{code}
 module Regression-Example
  (X : ClosenessSpace 𝓤) (Y : ClosenessSpace 𝓥)
  (g : ⟨ Y ⟩ → ⟨ X ⟩)
@@ -219,7 +219,7 @@ module Regression-ExampleDistortionProne
  where
 
  open Regression-Example X X id (id-ucontinuous X) tb S M (Ψ 𝓞)
-        observations ϕᴹ
+  observations ϕᴹ
           
  regΨ𝓞 optΨ𝓞 : ℕ → ⟨ X ⟩
  regΨ𝓞 = reg𝓞
@@ -236,15 +236,16 @@ module Regression-Example1a where
  observations : Vec 𝟛ᴺ 3
  observations = -1𝟛ᴺ :: (O𝟛ᴺ :: [ 1𝟛ᴺ ])
 
- ϕᴹ : (y : 𝟛ᴺ) → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-                   (λ x → mid (neg x) y)
+ ϕᴹ : (y : 𝟛ᴺ)
+    → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
+       (λ x → mid (neg x) y)
  ϕᴹ y = f-ucontinuous-comp 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-              𝟛ᴺ-ClosenessSpace neg (λ x → mid x y)
-              neg-ucontinuous
-              (seq-f-ucontinuous¹-to-closeness
-                𝟛-is-discrete 𝟛-is-discrete
-                (λ x → mid x y)
-                (seq-f-ucontinuous²-left mid mid-ucontinuous' y))
+         𝟛ᴺ-ClosenessSpace neg (λ x → mid x y)
+         neg-ucontinuous
+         (seq-f-ucontinuous¹-to-closeness
+         𝟛-is-discrete 𝟛-is-discrete
+         (λ x → mid x y)
+         (seq-f-ucontinuous²-left mid mid-ucontinuous' y))
  
  open Regression-Example
    𝟛ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
@@ -272,10 +273,10 @@ module Regression-Example1b where
  ϕᴹ : (x : 𝟛ᴺ) → f-ucontinuous 𝟛ᴺ×𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
                    (λ (p₁ , p₂) → mid p₁ (mid p₂ x))
  ϕᴹ x = seq-f-ucontinuous²-to-closeness
-          𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
-          (λ p₁ p₂ → mid p₁ (mid p₂ x))
-          (seq-f-ucontinuous²-comp mid mid
-            mid-ucontinuous' mid-ucontinuous' x)
+         𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
+         (λ p₁ p₂ → mid p₁ (mid p₂ x))
+         (seq-f-ucontinuous²-comp mid mid
+         mid-ucontinuous' mid-ucontinuous' x)
 
  open Regression-Example1a using (𝓞;observations;Ψ)
  
@@ -306,13 +307,13 @@ module Regression-Example2 where
 
  ϕᴹ : (y : 𝟛ᴺ)
     → f-ucontinuous
-        (×-ClosenessSpace 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace)
-        𝟛ᴺ-ClosenessSpace (λ x → M x y)
+       (×-ClosenessSpace 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace)
+       𝟛ᴺ-ClosenessSpace (λ x → M x y)
  ϕᴹ y = seq-f-ucontinuous²-to-closeness
-           𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
-           (λ α β → M (α , β) y)
-           (seq-f-ucontinuous²-comp mid mul
-             mid-ucontinuous' mul-ucontinuous' y)
+         𝟛-is-discrete 𝟛-is-discrete 𝟛-is-discrete
+         (λ α β → M (α , β) y)
+         (seq-f-ucontinuous²-comp mid mul
+           mid-ucontinuous' mul-ucontinuous' y)
 
  open Regression-Example
    𝟛ᴺ×𝟛ᴺ-ClosenessSpace 𝟚ᴺ×𝟚ᴺ-ClosenessSpace

--- a/source/TWA/Thesis/Chapter6/SignedDigitOrder.lagda
+++ b/source/TWA/Thesis/Chapter6/SignedDigitOrder.lagda
@@ -16,7 +16,7 @@ open import Integers.Order
 
 open import TWA.Thesis.Chapter2.Sequences
 open import TWA.Thesis.Chapter5.SignedDigit
-open import TWA.Thesis.Chapter5.BelowAndAbove
+open import TWA.Thesis.Chapter5.BoehmStructure
 open import TWA.Thesis.Chapter5.Integers
 
 module TWA.Thesis.Chapter6.SignedDigitOrder
@@ -29,7 +29,7 @@ open import TWA.Thesis.Chapter4.ApproxOrder fe
 
 ## Integer approx (originally defined in BoehmVerification)
 
-\end{code}
+\begin{code}
 𝟛-to-down : (a : 𝟛) → (ℤ → ℤ)
 𝟛-to-down −1 = downLeft
 𝟛-to-down  O = downMid
@@ -56,7 +56,7 @@ ternary-to-ℤ² α = ternary-to-ℤ²' (α 0) (α ∘ succ) (negsucc 0)
 
 ## Real preserving preorder
 
-\end{code}
+\begin{code}
 
 module RealPresOrder (pt : propositional-truncations-exist) where
 
@@ -96,7 +96,7 @@ module RealPresOrder (pt : propositional-truncations-exist) where
 
 ## Real-preserving approximate order
 
-\end{code}
+\begin{code}
 _≤ⁿ𝟛ᴺ_ : 𝟛ᴺ → 𝟛ᴺ → ℕ → 𝓤₀ ̇
 (x ≤ⁿ𝟛ᴺ y) n = integer-approx x n ≤ integer-approx y n
 

--- a/source/TWA/Thesis/Chapter6/SignedDigitSearch.lagda
+++ b/source/TWA/Thesis/Chapter6/SignedDigitSearch.lagda
@@ -32,36 +32,36 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
 
 ## Totally bounded
 
-\end{code}
+\begin{code}
 𝟛ᴺ-totally-bounded : totally-bounded 𝟛ᴺ-ClosenessSpace 𝓤₀
 𝟛ᴺ-totally-bounded = ℕ→F-totally-bounded 𝟛-is-discrete 𝟛-is-finite O
 
 𝟛ᴺ×𝟛ᴺ-totally-bounded : totally-bounded 𝟛ᴺ×𝟛ᴺ-ClosenessSpace 𝓤₀
 𝟛ᴺ×𝟛ᴺ-totally-bounded
  = ×-totally-bounded
-     𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     𝟛ᴺ-totally-bounded 𝟛ᴺ-totally-bounded
+    𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
+    𝟛ᴺ-totally-bounded 𝟛ᴺ-totally-bounded
 \end{code}
 
 ## Global optimisation
 
-\end{code}
+\begin{code}
 𝟛ᴺ→𝟛ᴺ-global-opt : (f : 𝟛ᴺ → 𝟛ᴺ)
                  → f-ucontinuous 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace f
                  → (ϵ : ℕ)
                  → (has ϵ global-minimal) _≤ⁿ𝟛ᴺ_ f
 𝟛ᴺ→𝟛ᴺ-global-opt f ϕ ϵ
  = global-opt 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     (repeat O)
-     _≤ⁿ𝟛ᴺ_
-     ≤ⁿ𝟛ᴺ-is-approx-order
-     ϵ f ϕ
-     𝟛ᴺ-totally-bounded
+    (repeat O)
+    _≤ⁿ𝟛ᴺ_
+    ≤ⁿ𝟛ᴺ-is-approx-order
+    ϵ f ϕ
+    𝟛ᴺ-totally-bounded
 \end{code}
 
 ## Uniformly continuously searchable
 
-\end{code}
+\begin{code}
 𝟛ᴺ-csearchable-tb 𝟛ᴺ-csearchable
  : {𝓦 : Universe} → csearchable 𝓦 𝟛ᴺ-ClosenessSpace
 𝟛ᴺ-csearchable-tb
@@ -74,15 +74,15 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
  : {𝓦 : Universe} → csearchable 𝓦 𝟛ᴺ×𝟛ᴺ-ClosenessSpace
 𝟛ᴺ×𝟛ᴺ-csearchable-tb
  = totally-bounded-csearchable
-     𝟛ᴺ×𝟛ᴺ-ClosenessSpace (repeat O , repeat O) 𝟛ᴺ×𝟛ᴺ-totally-bounded
+    𝟛ᴺ×𝟛ᴺ-ClosenessSpace (repeat O , repeat O) 𝟛ᴺ×𝟛ᴺ-totally-bounded
 𝟛ᴺ×𝟛ᴺ-csearchable
  = ×-csearchable 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     𝟛ᴺ-csearchable 𝟛ᴺ-csearchable
+    𝟛ᴺ-csearchable 𝟛ᴺ-csearchable
 \end{code}
 
 ## Cantor space search and optimisation
 
-\end{code}
+\begin{code}
 ≤₂-is-preorder : is-preorder _≤₂_
 ≤₂-is-preorder
  = (λ _ → ≤₂-refl) , ≤₂-trans , λ _ _ → ≤₂-is-prop-valued
@@ -102,13 +102,12 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
 𝟚ᴺ = ℕ → 𝟚
 
 𝟚ᴺ-lexicorder : 𝟚ᴺ → 𝟚ᴺ → 𝓤₀ ̇
-𝟚ᴺ-lexicorder
- = discrete-lexicorder 𝟚-is-discrete _≤₂_
+𝟚ᴺ-lexicorder = discrete-lexicorder 𝟚-is-discrete _≤₂_
 
 𝟚ᴺ-lexicorder-is-preorder : is-preorder 𝟚ᴺ-lexicorder
 𝟚ᴺ-lexicorder-is-preorder
  = discrete-lexicorder-is-preorder
-     𝟚-is-discrete _≤₂_ ≤₂-is-antisym-preorder
+    𝟚-is-discrete _≤₂_ ≤₂-is-antisym-preorder
 
 𝟚ᴺ-approx-lexicorder : 𝟚ᴺ → 𝟚ᴺ → ℕ → 𝓤₀ ̇ 
 𝟚ᴺ-approx-lexicorder = discrete-approx-lexicorder 𝟚-is-discrete _≤₂_
@@ -117,8 +116,8 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
  : is-approx-order 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-approx-lexicorder
 𝟚ᴺ-approx-lexicorder-is-approx-order
  = discrete-approx-lexicorder-is-approx-order
-       𝟚-is-discrete _≤₂_
-       ≤₂-is-antisym-linear-preorder 
+    𝟚-is-discrete _≤₂_
+    ≤₂-is-antisym-linear-preorder 
 
 𝟚ᴺ-approx-lexicorder' : 𝟚ᴺ → 𝟚ᴺ → ℕ → Ω 𝓤₀
 𝟚ᴺ-approx-lexicorder' α β n
@@ -131,8 +130,8 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
 𝟚ᴺ×𝟚ᴺ-totally-bounded : totally-bounded 𝟚ᴺ×𝟚ᴺ-ClosenessSpace 𝓤₀
 𝟚ᴺ×𝟚ᴺ-totally-bounded
  = ×-totally-bounded
-     𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
-     𝟚ᴺ-totally-bounded 𝟚ᴺ-totally-bounded
+    𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
+    𝟚ᴺ-totally-bounded 𝟚ᴺ-totally-bounded
 
 𝟚ᴺ→𝟛ᴺ-global-opt : (f : 𝟚ᴺ → 𝟛ᴺ)
                  → f-ucontinuous 𝟚ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace f
@@ -140,17 +139,17 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
                  → (has ϵ global-minimal) _≤ⁿ𝟛ᴺ_ f
 𝟚ᴺ→𝟛ᴺ-global-opt f ϕ ϵ
  = global-opt 𝟚ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     (repeat ₀)
-     _≤ⁿ𝟛ᴺ_
-     ≤ⁿ𝟛ᴺ-is-approx-order
-     ϵ f ϕ
-     𝟚ᴺ-totally-bounded
+    (repeat ₀)
+    _≤ⁿ𝟛ᴺ_
+    ≤ⁿ𝟛ᴺ-is-approx-order
+    ϵ f ϕ
+    𝟚ᴺ-totally-bounded
 
 𝟚ᴺ-csearchable-tb 𝟚ᴺ-csearchable
  : {𝓦 : Universe} → csearchable 𝓦 𝟚ᴺ-ClosenessSpace
 𝟚ᴺ-csearchable-tb
  = totally-bounded-csearchable
-     𝟚ᴺ-ClosenessSpace (repeat ₀) 𝟚ᴺ-totally-bounded
+    𝟚ᴺ-ClosenessSpace (repeat ₀) 𝟚ᴺ-totally-bounded
 𝟚ᴺ-csearchable
  = discrete-finite-seq-csearchable ₀ 𝟚-is-finite 𝟚-is-discrete
 
@@ -158,16 +157,15 @@ open import TWA.Thesis.Chapter6.SignedDigitOrder fe
  : {𝓦 : Universe} → csearchable 𝓦 𝟚ᴺ×𝟚ᴺ-ClosenessSpace
 𝟚ᴺ×𝟚ᴺ-csearchable-tb
  = totally-bounded-csearchable
-     𝟚ᴺ×𝟚ᴺ-ClosenessSpace (repeat ₀ , repeat ₀) 𝟚ᴺ×𝟚ᴺ-totally-bounded
+    𝟚ᴺ×𝟚ᴺ-ClosenessSpace (repeat ₀ , repeat ₀) 𝟚ᴺ×𝟚ᴺ-totally-bounded
 𝟚ᴺ×𝟚ᴺ-csearchable
  = ×-csearchable 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
-     𝟚ᴺ-csearchable 𝟚ᴺ-csearchable
+    𝟚ᴺ-csearchable 𝟚ᴺ-csearchable
 \end{code}
 
 ## Conversion from Cantor sequence to ternary signed-digit encoding
 
-\end{code}
-
+\begin{code}
 𝟚→𝟛 : 𝟚 → 𝟛
 𝟚→𝟛 ₀ = −1
 𝟚→𝟛 ₁ = +1
@@ -181,8 +179,8 @@ _⤊ (α , β) = α ↑ , β ↑
 ↑-ucontinuous : f-ucontinuous 𝟚ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace _↑
 ↑-ucontinuous
  = seq-f-ucontinuous¹-to-closeness
-     𝟚-is-discrete 𝟛-is-discrete
-     _↑ (map-ucontinuous' 𝟚→𝟛)
+    𝟚-is-discrete 𝟛-is-discrete
+    _↑ (map-ucontinuous' 𝟚→𝟛)
 
 ⤊-ucontinuous
  : f-ucontinuous 𝟚ᴺ×𝟚ᴺ-ClosenessSpace 𝟛ᴺ×𝟛ᴺ-ClosenessSpace _⤊
@@ -190,31 +188,31 @@ _⤊ (α , β) = α ↑ , β ↑
  = ϵ
  , (λ x₁ x₂ Cx₁x₂
  → ×-C-combine 𝟛ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     (pr₁ (x₁ ⤊)) (pr₁ (x₂ ⤊))
-     (pr₂ (x₁ ⤊)) (pr₂ (x₂ ⤊))
-     ϵ
-     (pr₂ (↑-ucontinuous ϵ) (pr₁ x₁) (pr₁ x₂)
-       (×-C-left 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
-         (pr₁ x₁) (pr₁ x₂)
-         (pr₂ x₁) (pr₂ x₂)
-         ϵ Cx₁x₂))
+    (pr₁ (x₁ ⤊)) (pr₁ (x₂ ⤊))
+    (pr₂ (x₁ ⤊)) (pr₂ (x₂ ⤊))
+    ϵ
+    (pr₂ (↑-ucontinuous ϵ) (pr₁ x₁) (pr₁ x₂)
+     (×-C-left 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
+      (pr₁ x₁) (pr₁ x₂)
+      (pr₂ x₁) (pr₂ x₂)
+      ϵ Cx₁x₂))
      (pr₂ (↑-ucontinuous ϵ) (pr₂ x₁) (pr₂ x₂)
-       (×-C-right 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
-         (pr₁ x₁) (pr₁ x₂)
-         (pr₂ x₁) (pr₂ x₂)
-         ϵ Cx₁x₂)))
+      (×-C-right 𝟚ᴺ-ClosenessSpace 𝟚ᴺ-ClosenessSpace
+       (pr₁ x₁) (pr₁ x₂)
+       (pr₂ x₁) (pr₂ x₂)
+       ϵ Cx₁x₂)))
 
 ↑-pred : decidable-uc-predicate 𝓦 𝟛ᴺ-ClosenessSpace
        → decidable-uc-predicate 𝓦 𝟚ᴺ-ClosenessSpace
 ↑-pred ((p , d) , ϕ)
  = (p ∘ _↑ , d ∘ _↑)
  , p-ucontinuous-comp 𝟚ᴺ-ClosenessSpace 𝟛ᴺ-ClosenessSpace
-     _↑ ↑-ucontinuous p ϕ
+    _↑ ↑-ucontinuous p ϕ
 
 ⤊-pred : decidable-uc-predicate 𝓦 𝟛ᴺ×𝟛ᴺ-ClosenessSpace
-                 → decidable-uc-predicate 𝓦 𝟚ᴺ×𝟚ᴺ-ClosenessSpace
+        → decidable-uc-predicate 𝓦 𝟚ᴺ×𝟚ᴺ-ClosenessSpace
 ⤊-pred ((p , d) , ϕ)
  = (p ∘ _⤊ , d ∘ _⤊)
  , p-ucontinuous-comp 𝟚ᴺ×𝟚ᴺ-ClosenessSpace 𝟛ᴺ×𝟛ᴺ-ClosenessSpace
-     _⤊ ⤊-ucontinuous p ϕ
+    _⤊ ⤊-ucontinuous p ϕ
 \end{code}

--- a/source/TWA/Thesis/index.lagda
+++ b/source/TWA/Thesis/index.lagda
@@ -145,8 +145,8 @@ open import TWA.Thesis.Chapter5.IntervalObject
 open import TWA.Thesis.Chapter5.IntervalObjectApproximation
 open import TWA.Thesis.Chapter5.SignedDigit
 open import TWA.Thesis.Chapter5.SignedDigitIntervalObject
+open import TWA.Thesis.Chapter5.BoehmStructure
 open import TWA.Thesis.Chapter5.BoehmVerification
-open import TWA.Thesis.Chapter5.BelowAndAbove
 open import TWA.Thesis.Chapter5.Integers
 \end{code}
 


### PR DESCRIPTION
A sizable portion of code was accidentally commented out, something I only noticed today! I also fixed most of the issues from https://github.com/martinescardo/TypeTopology/pull/172. 

I still need to:
- Use projections less throughout, for the sake of readability
- Use variations of Π-is-prop that apply it multiple times, in order to get more concise and readable proofs
- Remove any code that already exists in TypeTopology, and use the version that already exists (this is most true in the files Escardo-Simpson-LICS2001 and Chapter5/IntervalObject that are almost the same