### PR TITLE
Prove that the sharp elements of a Scott domain coincide with the spectral points of its Scott locale

### DIFF
--- a/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
@@ -208,6 +208,29 @@ For convenience, we also define some direct projections on the Σ-based type.
   in
    h-preserves-joins
 
+\end{code}
+
+Added on 2024-05-22.
+
+\begin{code}
+
+ preserves-joins′ : (⟨ F ⟩ → ⟨ G ⟩) → Ω (𝓤 ⊔ 𝓤' ⊔ 𝓦 ⁺)
+ preserves-joins′ h =
+  Ɐ S ꞉ Fam 𝓦 ⟨ F ⟩ , h (⋁[ F ] S) ＝[ σ ]＝ ⋁[ G ] ⁅ h x ∣ x ε S ⁆
+
+\end{code}
+
+\begin{code}
+
+ -- preserves-joins-implies-preserves-joins′ : (h : ⟨ F ⟩ → ⟨ G ⟩)
+ --                                          → (preserves-joins′ h
+ --                                          ⇒  preserves-joins  h) holds
+ -- preserves-joins-implies-preserves-joins′ h φ S = {!!}
+
+\end{code}
+
+\begin{code}
+
  frame-homomorphisms-preserve-all-joins′
   : (h : _─f→_)
   → (S : Fam 𝓦 ⟨ F ⟩)

--- a/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
@@ -208,10 +208,6 @@ For convenience, we also define some direct projections on the Σ-based type.
   in
    h-preserves-joins
 
-\end{code}
-
-\begin{code}
-
  frame-homomorphisms-preserve-all-joins′
   : (h : _─f→_)
   → (S : Fam 𝓦 ⟨ F ⟩)

--- a/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
@@ -210,25 +210,6 @@ For convenience, we also define some direct projections on the Σ-based type.
 
 \end{code}
 
-Added on 2024-05-22.
-
-\begin{code}
-
- preserves-joins′ : (⟨ F ⟩ → ⟨ G ⟩) → Ω (𝓤 ⊔ 𝓤' ⊔ 𝓦 ⁺)
- preserves-joins′ h =
-  Ɐ S ꞉ Fam 𝓦 ⟨ F ⟩ , h (⋁[ F ] S) ＝[ σ ]＝ ⋁[ G ] ⁅ h x ∣ x ε S ⁆
-
-\end{code}
-
-\begin{code}
-
- -- preserves-joins-implies-preserves-joins′ : (h : ⟨ F ⟩ → ⟨ G ⟩)
- --                                          → (preserves-joins′ h
- --                                          ⇒  preserves-joins  h) holds
- -- preserves-joins-implies-preserves-joins′ h φ S = {!!}
-
-\end{code}
-
 \begin{code}
 
  frame-homomorphisms-preserve-all-joins′

--- a/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
+++ b/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
@@ -464,3 +464,11 @@ We now have everything required to record the proof that the family
                           , 𝒦-in-point-is-semidirected ℱ
 
 \end{code}
+
+Added on 2024-05-23.
+
+\begin{code}
+
+
+
+\end{code}

--- a/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
+++ b/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
@@ -469,6 +469,7 @@ Added on 2024-05-23.
 
 \begin{code}
 
-
+ 𝒦-in-point↑ : (ℱ : Point) → Fam↑
+ 𝒦-in-point↑ ℱ = 𝒦-in-point ℱ , 𝒦-in-point-is-directed ℱ
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -368,9 +368,6 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- open PropertiesAlgebraic 𝓓 𝕒
- open Properties 𝓓
-
  pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) pt[ 𝓍 ] holds
  pt-is-spectral 𝓍@(x , 𝓈𝒽) 𝒦@(K , σ) 𝕜 = decidable-implies-compact pe (x ∈ₛ 𝒦) †
   where
@@ -390,5 +387,15 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 \end{code}
 
 \begin{code}
+
+ lemma-6 : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+         → c ⊑⟨ 𝓓 ⟩ {!⋁ (𝒦-in-point ℱ , δ) !} → F ↑ˢ[ c , 𝕜 ] holds
+ lemma-6 F c 𝕜 p = {!!}
+
+ sharp₀-gives-sharp-elements : (F : Point σ⦅𝓓⦆) → is-sharp (sharp₀ F) holds
+ sharp₀-gives-sharp-elements F c 𝕜 = {!!}
+
+ sharp : Point σ⦅𝓓⦆ → ♯𝓓
+ sharp F = sharp₀ F , sharp₀-gives-sharp-elements F
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -408,13 +408,8 @@ that it satisfies some property.
  pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
   where
    ‡ : preserves-joins (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   ‡ S = (⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆) , goal
-    where
-     open Joins _⇒_
-
-     goal : ((u , _) : upper-bound ⁅ pt₀[ x ] y ∣ y ε S ⁆)
-          → (pt₀[ x ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ⇒ u) holds
-     goal (u , a) p = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆ (u , a) p
+   ‡ S = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆
+       , ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆
 
    † : is-a-frame-homomorphism (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
    † = refl , (λ _ _ → refl) , ‡

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -675,7 +675,7 @@ The fact that `sharp` is a retraction `𝓅𝓉[_]` follows easily from the lemm
 
 \end{code}
 
-It is also the case that `𝓅𝓉[_]` is a retraction of `sharp`.
+The map `𝓅𝓉[_]` is a retraction of the map `sharp`.
 
 \begin{code}
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -3,6 +3,7 @@ title:          Equivalence of sharp elements with spectral points
 author:         Ayberk Tosun
 date-started:   2024-05-22
 date-completed: 2024-05-28
+dates-updated:  [2024-06-03]
 ---
 
 This module contains the proof of equivalence between the sharp elements of a
@@ -432,7 +433,7 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \end{code}
 
-We package `pt[_]` up with this proof spectrality to obtain the following:
+We package `pt[_]` up with this proof of spectrality and denote it `𝓅𝓉[_]`.
 
 \begin{code}
 
@@ -470,16 +471,16 @@ The following lemma says if `sharp(ℱ) ∈ 𝔘` then `U ∈ ℱ`.
    open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
 
    † : (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
-   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ γ
+   † p = ∥∥-rec (holds-is-prop (F 𝔘)) ‡ γ
     where
-     †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
+     ‡ : Σ (i , _) ꞉ index (𝒦-in-point ℱ) , ((B𝓓 [ i ]) ∈ₛ 𝔘) holds
        → F 𝔘 holds
-     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) q b
+     ‡ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) q b
       where
        q : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
        q x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
 
-     γ : ∥ Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds ∥
+     γ : ∥ Σ (i , _) ꞉ index (𝒦-in-point ℱ) , ((B𝓓 [ i ]) ∈ₛ 𝔘) holds ∥
      γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
 
 \end{code}
@@ -500,34 +501,8 @@ which we record explicitly.
 
 \end{code}
 
-The converse of this special case is true as well.
-
-\begin{code}
-
- in-point-implies-below-sharp
-  : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
-  → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
- in-point-implies-below-sharp ℱ@(F , ψ) c 𝕜 χ =
-  ∥∥-rec (prop-valuedness 𝓓 c (⋁ 𝒦-in-point↑ ℱ)) † γ
-   where
-    γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
-    γ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c 𝕜
-
-    † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → c ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
-    † (i , p) = transport (λ - → - ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)) p ‡
-     where
-      q : ↑ˢ[ βₖ i ] ＝ ↑ˢ[ c , 𝕜 ]
-      q = ap ↑ˢ[_] (to-subtype-＝ (holds-is-prop ∘ is-compactₚ 𝓓) p)
-
-      μ : F ↑ˢ[ βₖ i ] holds
-      μ = transport (λ - → F - holds) (q ⁻¹) χ
-
-      ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
-      ‡ = ⋁-is-upperbound (𝒦-in-point↑ ℱ) (i , μ)
-
-\end{code}
-
-In fact, it can be generalized to finite joins of compact elements
+In fact, it can be generalized to finite joins of compact element i.e. compact
+Scott opens.
 
 \begin{code}
 
@@ -565,6 +540,35 @@ In fact, it can be generalized to finite joins of compact elements
 
 \end{code}
 
+The converse of this special case is true as well.
+
+\begin{code}
+
+ in-point-implies-below-sharp
+  : (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+  → (K : ⟨ σ⦅𝓓⦆ ⟩)
+  → (𝕜 : is-compact-open Scott⦅𝓓⦆ K holds)
+  → (F K ⇒ sharp₀ ℱ ∈ₛ K) holds
+ in-point-implies-below-sharp ℱ@(F , ψ) K 𝕜 χ =
+  ∥∥-rec (holds-is-prop (sharp₀ ℱ ∈ₛ K)) † γ
+   where
+    ℬ↑ : directed-basisᴰ (𝒪 Scott⦅𝓓⦆)
+    ℬ↑ = spectralᴰ-implies-directed-basisᴰ Scott⦅𝓓⦆ σᴰ
+
+    γ : is-basic Scott⦅𝓓⦆ K (spectralᴰ-implies-directed-basisᴰ Scott⦅𝓓⦆ σᴰ) holds
+    γ = compact-opens-are-basic Scott⦅𝓓⦆ ℬ↑ K 𝕜
+
+    † : Σ i ꞉ Bσ , βσ i ＝ K → (sharp₀ ℱ ∈ₛ K) holds
+    † (i , p) = transport (λ - → (sharp₀ ℱ ∈ₛ -) holds) p ‡
+     where
+      μ : F (𝜸 i) holds
+      μ = transport (λ - → F - holds) (p ⁻¹) χ
+
+      ‡ : (sharp₀ (F , ψ) ∈ₛ βσ i) holds
+      ‡ = in-point-implies-below-sharp⋆ i ℱ μ
+
+\end{code}
+
 The map `sharp₀` always gives sharp elements.
 
 \begin{code}
@@ -580,8 +584,11 @@ The map `sharp₀` always gives sharp elements.
    γ : is-decidableₚ (F ↑ˢ[ c , 𝕜 ]) holds
    γ = compact-implies-boolean pe (F ↑ˢ[ c , 𝕜 ]) χ
 
+   κ : is-compact-open Scott⦅𝓓⦆ ↑ˢ[ c , 𝕜 ] holds
+   κ = principal-filter-is-compact₀ c 𝕜
+
    case₁ : F ↑ˢ[ c , 𝕜 ] holds → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
-   case₁ = inl ∘ in-point-implies-below-sharp ℱ c 𝕜
+   case₁ = inl ∘ in-point-implies-below-sharp ℱ ↑ˢ[ (c , 𝕜) ] κ
 
    case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
    case₂ χ = inr (χ ∘ below-sharp-implies-in-point ℱ c 𝕜)
@@ -589,7 +596,7 @@ The map `sharp₀` always gives sharp elements.
 \end{code}
 
 We denote by `sharp` the version of `sharp₀` that is packaged up with the proof
-that it always gives sharp elements and denote it by `sharp`.
+that it always gives sharp elements.
 
 \begin{code}
 
@@ -603,7 +610,8 @@ that it always gives sharp elements and denote it by `sharp`.
 
 \subsection{Some lemmas}
 
-We now prove some useful lemmas that we use in the equivalence proof.
+We now prove some useful lemmas that we use in showing that these two maps
+form an equivalence.
 
 Given a sharp element `𝓍`, the element `sharp (pt 𝓍)` is exactly the join of
 the compact approximants of `𝓍`.
@@ -619,8 +627,8 @@ the compact approximants of `𝓍`.
     γ : ((i , _) : ↓ᴮₛ x) → (sharp₀ pt[ x , 𝕤 ] ∈ₛ ↑ˢ[ βₖ i ]) holds
     γ (i , q) = in-point-implies-below-sharp
                  pt[ x , 𝕤 ]
-                 (B𝓓 [ i ])
-                 (basis-is-compact i)
+                 ↑ˢ[ βₖ i ]
+                 (principal-filter-is-compact i)
                  (⊑ᴮₛ-to-⊑ᴮ q)
 
     δ : is-upperbound

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -756,6 +756,6 @@ formalized in this module.
   domains*.
 
   Mathematical Structures in Computer Science, vol. 33, no. 7,
-  pp 573-604, August 2023.
+  pp 573-604, August 2023. doi:10.1017/S0960129523000282
 
   https://doi.org/10.1017/S0960129523000282

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -586,9 +586,6 @@ type of spectral points.
  final-lemma (k ∷ ks) ℱ@(F , _) p =
   ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ †
    where
-    IH : (sharp₀ ℱ ∈ₛ 𝜸 ks) holds
-    IH = final-lemma ks ℱ {!!}
-
     foo : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
     foo = F (𝜸 (k ∷ ks))                     ＝⟨ ap F (𝜸-equal-to-𝜸₁ (k ∷ ks)) ⟩
           F (𝜸₁ (k ∷ ks))                    ＝⟨ frame-homomorphisms-preserve-binary-joins ℱ _ _  ⟩
@@ -625,7 +622,7 @@ type of spectral points.
       nts₁ k = ∣ k , another-lemma (S [ k ]) ℱ₀ ∣
 
       nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
-      nts₂ (ks , p) = {!final-lemma!}
+      nts₂ (ks , p) = ∣ (ks , p) , final-lemma ks ℱ₀ ∣
 
       nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)
       nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -245,6 +245,20 @@ We now define the type `♯𝓓` of sharp elements of the Scott domain `𝓓`.
  ♯𝓓 : 𝓤 ⁺  ̇
  ♯𝓓 = Σ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x holds
 
+\end{code}
+
+We usually pattern match on the inhabitants of `♯𝓓` to refer to the first
+component.
+
+\begin{code}
+
+ ⦅_⦆ : ♯𝓓 → ⟨ 𝓓 ⟩∙
+ ⦅_⦆ (x , _) = x
+
+\end{code}
+
+\begin{code}
+
  abstract
   to-sharp-＝ : (𝓍 𝓎 : ♯𝓓) → pr₁ 𝓍 ＝ pr₁ 𝓎 → 𝓍 ＝ 𝓎
   to-sharp-＝ 𝓍 𝓎 = to-subtype-＝ (holds-is-prop ∘ is-sharp)
@@ -510,6 +524,12 @@ We now define the map `sharp` going in the opposite direction.
       ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
       ‡ = ⋁-is-upperbound (𝒦-in-point↑ ℱ) (i , μ)
 
+\end{code}
+
+The map `sharp₀` always gives sharp elements.
+
+\begin{code}
+
  sharp₀-gives-sharp-elements : (F : Point scott[𝓓])
                              → is-spectral-map scott[𝓓] (𝟏Loc pe) F holds
                              → is-sharp (sharp₀ F) holds
@@ -529,6 +549,9 @@ We now define the map `sharp` going in the opposite direction.
 
 \end{code}
 
+We package up `sharp₀` with the proof that it always gives sharp elements
+and denote it by `sharp`.
+
 \begin{code}
 
  sharp : Spectral-Point scott[𝓓] → ♯𝓓
@@ -536,13 +559,6 @@ We now define the map `sharp` going in the opposite direction.
   where
    open Spectral-Point scott[𝓓] ℱ
     renaming (point-fn to F; point to F·; point-preserves-compactness to σ)
-
-\end{code}
-
-\begin{code}
-
- ⦅_⦆ : ♯𝓓 → ⟨ 𝓓 ⟩∙
- ⦅_⦆ (x , _) = x
 
 \end{code}
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -540,7 +540,9 @@ Scott opens.
 
 \end{code}
 
-The converse of this special case is true as well.
+We can reformulate this more concisely to say the same thing for any compact
+Scott open `K` since a Scott open is compact iff it is a finite join of
+principal filters on compact opens.
 
 \begin{code}
 
@@ -569,7 +571,7 @@ The converse of this special case is true as well.
 
 \end{code}
 
-The map `sharp₀` always gives sharp elements.
+We now prove that the map `sharp₀` always gives sharp elements.
 
 \begin{code}
 
@@ -608,7 +610,7 @@ that it always gives sharp elements.
 
 \end{code}
 
-\subsection{Some lemmas}
+\subsection{A useful lemma}
 
 We now prove some useful lemmas that we use in showing that these two maps
 form an equivalence.
@@ -672,6 +674,8 @@ The fact that `sharp` is a retraction `𝓅𝓉[_]` follows easily from the lemm
          Ⅱ = ↓ᴮₛ-∐-＝ ⦅ 𝓍 ⦆
 
 \end{code}
+
+It is also the case that `𝓅𝓉[_]` is a retraction of `sharp`.
 
 \begin{code}
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -8,7 +8,7 @@ The formalization of a proof.
 
 \begin{code}
 
-{--# OPTIONS --safe --without-K --lossy-unification #--}
+{-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
 open import MLTT.List hiding ([_])
@@ -60,6 +60,7 @@ open import Locales.TerminalLocale.Properties pt fe sr
 open import NotionsOfDecidability.Decidable
 open import NotionsOfDecidability.SemiDecidable fe pe pt
 open import Slice.Family
+open import UF.Equiv
 open import UF.Logic
 open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties
@@ -189,6 +190,14 @@ algebraic dcpo, however, we could define a small version.
 
  ♯𝓓 : 𝓤 ⁺  ̇
  ♯𝓓 = Σ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x holds
+
+\end{code}
+
+\begin{code}
+
+ abstract
+  to-sharp-＝ : (𝓍 𝓎 : ♯𝓓) → pr₁ 𝓍 ＝ pr₁ 𝓎 → 𝓍 ＝ 𝓎
+  to-sharp-＝ 𝓍 𝓎 = to-subtype-＝ (holds-is-prop ∘ is-sharp)
 
 \end{code}
 
@@ -375,15 +384,20 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
    † : is-decidableₚ (x ∈ₛ (K , σ)) holds
    † = sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽 𝒦 𝕜
 
+ open Notion-Of-Spectral-Point pe
+
+ 𝓅𝓉[_] : ♯𝓓 → Spectral-Point σ⦅𝓓⦆
+ 𝓅𝓉[_] 𝓍 = to-spectral-point σ⦅𝓓⦆ ℱ
+  where
+   ℱ : Spectral-Map (𝟏Loc pe) σ⦅𝓓⦆
+   ℱ = pt[ 𝓍 ] , pt-is-spectral 𝓍
+
 \end{code}
 
 \begin{code}
 
  sharp₀ : Point σ⦅𝓓⦆ → ⟨ 𝓓 ⟩∙
- sharp₀ F = ⋁ (𝒦-in-point F , δ)
-  where
-   δ : is-Directed 𝓓 (𝒦-in-point F [_])
-   δ = 𝒦-in-point-is-directed F
+ sharp₀ ℱ = ∐ 𝓓 (𝒦-in-point-is-directed ℱ)
 
  lemma-6-⇒ : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
          → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ → F ↑ˢ[ c , 𝕜 ] holds
@@ -445,12 +459,139 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- open Notion-Of-Spectral-Point pe
-
  sharp : Spectral-Point σ⦅𝓓⦆ → ♯𝓓
  sharp ℱ = sharp₀ F· , sharp₀-gives-sharp-elements F· σ
   where
    open Spectral-Point σ⦅𝓓⦆ ℱ
     renaming (point-fn to F; point to F·; point-preserves-compactness to σ)
+
+\end{code}
+
+\begin{code}
+
+ ⦅_⦆ : ♯𝓓 → ⟨ 𝓓 ⟩∙
+ ⦅_⦆ (x , _) = x
+
+\end{code}
+
+We now proceed to prove that the type of sharp elements is equivalent to the
+type of spectral points.
+
+\begin{code}
+
+ abstract
+  lemma₁ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds) (c : ⟨ 𝓓 ⟩∙)
+         → is-compact 𝓓 c
+         → c ⊑⟨ 𝓓 ⟩ x
+         → c ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
+  lemma₁ x 𝕤 c κ p = ∥∥-rec (prop-valuedness 𝓓 c (sharp₀ pt[ x , 𝕤 ])) † γ
+   where
+    † : (Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c) → c ⊑⟨ 𝓓 ⟩ sharp₀ pt[ x , 𝕤 ]
+    † (i , q) = transport (λ - → underlying-order 𝓓 - (sharp₀ pt[ x , 𝕤 ])) q ‡
+     where
+      r : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ x
+      r = transport (λ - → - ⊑⟨ 𝓓 ⟩ x) (q ⁻¹) p
+
+      ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ sharp₀ pt[ x , 𝕤 ]
+      ‡ = sup-is-upperbound (underlying-order 𝓓)
+           (⋁-is-sup (𝒦-in-point↑ pt[ x , 𝕤 ])) (i , r)
+
+    γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
+    γ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c κ
+
+ lemma₃ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds) (c : ⟨ 𝓓 ⟩∙)
+        → is-compact 𝓓 c
+        → ∃ i ꞉ (index (𝒦-in-point pt[ (x , 𝕤) ])) , c ＝ 𝒦-in-point pt[ (x , 𝕤) ] [ i ]
+        → c ⊑⟨ 𝓓 ⟩ x
+ lemma₃ x 𝕤 c κ = ∥∥-rec (prop-valuedness 𝓓 c x) †
+  where
+   † : Σ i ꞉ (index (𝒦-in-point pt[ (x , 𝕤) ])) , c ＝ 𝒦-in-point pt[ x , 𝕤 ] [ i ]
+     → c ⊑⟨ 𝓓 ⟩ x
+   † ((i , foo) , r) = transport (λ - → - ⊑⟨ 𝓓 ⟩ x) (r ⁻¹) foo
+
+ abstract
+  lemma₄ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds)
+         → ∐ 𝓓 (↓ᴮₛ-is-directed x) ＝ ∐ 𝓓 (𝒦-in-point-is-directed pt[ (x , 𝕤) ])
+  lemma₄ x 𝕤 =
+   antisymmetry 𝓓 (∐ 𝓓 (↓ᴮₛ-is-directed x)) (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) † ‡
+    where
+     abstract
+      † : (∐ 𝓓 (↓ᴮₛ-is-directed x)) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
+      † = ∐-is-lowerbound-of-upperbounds
+           𝓓
+           (↓ᴮₛ-is-directed x)
+           (⋁ 𝒦-in-point↑ pt[ x , 𝕤 ])
+           goal
+            where
+             goal : (i : ↓ᴮₛ x) →
+                     underlying-order 𝓓 (↓-inclusionₛ x i) (⋁ 𝒦-in-point↑ pt[ x , 𝕤 ])
+             goal (i , q) = lemma₁ x 𝕤 (B𝓓 [ i ]) (pr₂ (βₖ i)) (⊑ᴮₛ-to-⊑ᴮ q)
+
+      ‡ : ((⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) ⊑⟨ 𝓓 ⟩ ∐ 𝓓 (↓ᴮₛ-is-directed x))
+      ‡ = sup-is-lowerbound-of-upperbounds
+           (underlying-order 𝓓)
+           (⋁-is-sup (𝒦-in-point↑ pt[ (x , 𝕤) ]))
+           (∐ 𝓓 (↓ᴮₛ-is-directed x))
+           goal
+            where
+             goal : is-upperbound
+                     (underlying-order 𝓓)
+                     (∐ 𝓓 (↓ᴮₛ-is-directed x))
+                     (𝒦-in-point pt[ x , 𝕤 ] [_])
+             goal (i , q) = ∐-is-upperbound 𝓓 (↓ᴮₛ-is-directed x) (i , ⊑ᴮ-to-⊑ᴮₛ q)
+
+ sharp-cancels-pt : (𝓍 : ♯𝓓) → sharp 𝓅𝓉[ 𝓍 ] ＝ 𝓍
+ sharp-cancels-pt 𝓍@(x , 𝕤) = to-sharp-＝ (sharp 𝓅𝓉[ 𝓍 ]) 𝓍 †
+  where
+   † : ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆ ＝ x
+   † = ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆        ＝⟨ Ⅰ ⟩
+       ∐ 𝓓 (↓ᴮₛ-is-directed x)  ＝⟨ Ⅱ ⟩
+       ⦅ 𝓍 ⦆                    ∎
+        where
+         Ⅰ = lemma₄ x 𝕤 ⁻¹
+         Ⅱ = ↓ᴮₛ-∐-＝ ⦅ 𝓍 ⦆
+
+ open PropertiesAlgebraic 𝓓 𝕒
+
+ pt-cancels-sharp : (ℱ : Spectral-Point σ⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
+ pt-cancels-sharp ℱ =
+  to-spectral-point-＝ σ⦅𝓓⦆ 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
+   where
+    open Spectral-Point σ⦅𝓓⦆ ℱ renaming (point-fn to F; point to ℱ₀)
+
+    †₁ : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+    †₁ 𝔘@(U , s) μ = {!lemma-6-⇐ ℱ₀ !}
+
+    †₂ : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (F 𝔘 ⇒ sharp₀ ℱ₀ ∈ₛ 𝔘) holds
+    †₂ 𝔘@(U , s) μ = {!!}
+     where
+      foo : {!!}
+      foo = {!pr₁ (characterization-of-scott-opens U s ?)!}
+
+    † : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
+    † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) nts
+     where
+      S : Fam 𝓤 ⟨ 𝒪 σ⦅𝓓⦆ ⟩
+      S = covering-familyₛ σ⦅𝓓⦆ σᴰ 𝔘
+
+      q : 𝔘 ＝ ⋁[ 𝒪 σ⦅𝓓⦆ ] S
+      q = basisₛ-covers-do-cover-eq σ⦅𝓓⦆ σᴰ 𝔘
+
+      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)
+      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩
+            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 σ⦅𝓓⦆ ] S)              ＝⟨ Ⅰ ⟩
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ {!!} ⟩
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ ⟩
+            F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                              ∎
+             where
+              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
+              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
+
+ ♯𝓓-equivalent-to-spectral-points-of-σ⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point σ⦅𝓓⦆
+ ♯𝓓-equivalent-to-spectral-points-of-σ⦅𝓓⦆ = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
+  where
+   † : qinv 𝓅𝓉[_]
+   † = sharp , sharp-cancels-pt , pt-cancels-sharp
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -384,18 +384,63 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
    δ : is-Directed 𝓓 (𝒦-in-point F [_])
    δ = 𝒦-in-point-is-directed F
 
-\end{code}
+ lemma-6-⇒ : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+         → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ → F ↑ˢ[ c , 𝕜 ] holds
+ lemma-6-⇒ ℱ@(F , 𝒽) c 𝕜 p =
+  ∥∥-rec (holds-is-prop (F ↑ˢ[ c , 𝕜 ])) † γ
+   where
+    open 𝒪ₛᴿ (to-𝒪ₛᴿ ↑ˢ[ c , 𝕜 ])
 
-\begin{code}
+    γ : ∃ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
+    γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
 
- lemma-6 : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
-         → c ⊑⟨ 𝓓 ⟩ {!⋁ (𝒦-in-point ℱ , δ) !} → F ↑ˢ[ c , 𝕜 ] holds
- lemma-6 F c 𝕜 p = {!!}
+    † : Σ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
+      → F ↑ˢ[ c , 𝕜 ] holds
+    † ((i , p) , φ) =
+     frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ c , 𝕜 ]) ‡ p
+      where
+       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 σ⦅𝓓⦆) ] ↑ˢ[ c , 𝕜 ]) holds
+       ‡ =
+        principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
 
- sharp₀-gives-sharp-elements : (F : Point σ⦅𝓓⦆) → is-sharp (sharp₀ F) holds
- sharp₀-gives-sharp-elements F c 𝕜 = {!!}
+ lemma-6-⇐ : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+           → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
+ lemma-6-⇐ ℱ@(F , ψ) c 𝕜 χ =
+  ∥∥-rec (prop-valuedness 𝓓 c (⋁ 𝒦-in-point↑ ℱ)) † γ
+   where
+    γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
+    γ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c 𝕜
 
- sharp : Point σ⦅𝓓⦆ → ♯𝓓
- sharp F = sharp₀ F , sharp₀-gives-sharp-elements F
+    † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → c ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
+    † (i , p) = transport (λ - → - ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)) p ‡
+     where
+      q : ↑ˢ[ βₖ i ] ＝ ↑ˢ[ c , 𝕜 ]
+      q = ap ↑ˢ[_] (to-subtype-＝ (holds-is-prop ∘ is-compactₚ 𝓓) p)
+
+      μ : F ↑ˢ[ βₖ i ] holds
+      μ = transport (λ - → F - holds) (q ⁻¹) χ
+
+      ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
+      ‡ = ⋁-is-upperbound (𝒦-in-point↑ ℱ) (i , μ)
+
+ sharp₀-gives-sharp-elements : (F : Point σ⦅𝓓⦆)
+                             → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
+                             → is-sharp (sharp₀ F) holds
+ sharp₀-gives-sharp-elements ℱ@(F , _) σ c 𝕜 = cases case₁ case₂ γ
+  where
+   φ : is-compact-open (𝟏Loc pe) (F ↑ˢ[ c , 𝕜 ]) holds
+   φ = σ ↑ˢ[ c , 𝕜 ] (principal-filter-is-compact₀ c 𝕜 )
+
+   γ : is-decidableₚ (F ↑ˢ[ c , 𝕜 ]) holds
+   γ = compact-implies-boolean pe (F ↑ˢ[ c , 𝕜 ]) φ
+
+   case₁ : F ↑ˢ[ c , 𝕜 ] holds → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
+   case₁ = inl ∘ lemma-6-⇐ ℱ c 𝕜
+
+   case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
+   case₂ χ = inr λ q → χ (lemma-6-⇒ ℱ c 𝕜 q)
+
+ sharp : (ℱ : Point σ⦅𝓓⦆) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds → ♯𝓓
+ sharp ℱ@(F , _) σ = sharp₀ ℱ , sharp₀-gives-sharp-elements ℱ σ
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -752,5 +752,10 @@ formalized in this module.
 
 \section{References}
 
-[1]: de Jong, Tom. "Apartness, sharp elements, and the Scott topology of
-     domains." Mathematical Structures in Computer Science 33.7 (2023): 573-604.
+- [1]: Tom de Jong. *Apartness, sharp elements, and the Scott topology of
+  domains*.
+
+  Mathematical Structures in Computer Science, vol. 33, no. 7,
+  pp 573-604, August 2023.
+
+  https://doi.org/10.1017/S0960129523000282

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -355,11 +355,11 @@ down regardless as it is a potentially useful observation.
  admits-decidable-membership-in-scott-clopens x =
   Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-clopen (𝒪 Scott⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
- admits-decidable-membership-in-scott-clopens-implies-is-sharp
+ sharp-implies-admits-decidable-membership-in-scott-clopens
   : (x : ⟨ 𝓓 ⟩∙)
   → is-sharp x holds
   → admits-decidable-membership-in-scott-clopens x holds
- admits-decidable-membership-in-scott-clopens-implies-is-sharp x 𝓈𝒽 K χ =
+ sharp-implies-admits-decidable-membership-in-scott-clopens x 𝓈𝒽 K χ =
   ψ K κ
    where
     ψ : admits-decidable-membership-in-compact-scott-opens x holds

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -41,14 +41,14 @@ open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
 open import DomainTheory.Basics.WayBelow pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
-open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.Clopen pt fe sr
+open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
+open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
-open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -2,16 +2,23 @@
 title:          Equivalence of sharp elements with spectral points
 author:         Ayberk Tosun
 date-started:   2024-05-22
+date-completed: 2024-05-28
 ---
 
-The formalization of a proof.
+This module contains the proof of equivalence between the sharp elements of a
+Scott domain and the “spectral points” of its Scott locale. This equivalence
+conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15, in the
+context of our work on the patch topology in univalent foundations (j.w.w. Igor
+Arrieta)
+
+The formalization was completed on 2024-05-28
 
 \begin{code}
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.Spartan
 open import MLTT.List hiding ([_])
+open import MLTT.Spartan
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Size

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -49,6 +49,7 @@ open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.Point.SpectralPoint-Definition pt fe
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
@@ -444,7 +445,12 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- sharp : (ℱ : Point σ⦅𝓓⦆) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds → ♯𝓓
- sharp ℱ@(F , _) σ = sharp₀ ℱ , sharp₀-gives-sharp-elements ℱ σ
+ open Notion-Of-Spectral-Point pe
+
+ sharp : Spectral-Point σ⦅𝓓⦆ → ♯𝓓
+ sharp ℱ = sharp₀ F· , sharp₀-gives-sharp-elements F· σ
+  where
+   open Spectral-Point σ⦅𝓓⦆ ℱ
+    renaming (point-fn to F; point to F·; point-preserves-compactness to σ)
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -662,7 +662,7 @@ the compact approximants of `𝓍`.
 
 \subsection{The equivalence proof}
 
-The fact that `sharp` is a retraction `𝓅𝓉[_]` follows easily from the lemma
+The fact that `sharp` is a retraction of `𝓅𝓉[_]` follows easily from the lemma
 `sharp-equal-to-join-of-covering-family` above.
 
 \begin{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -7,7 +7,7 @@ date-completed: 2024-05-28
 
 This module contains the proof of equivalence between the sharp elements of a
 Scott domain and the “spectral points” of its Scott locale. This equivalence
-conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
+was conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
 
 The formalization of the proof was completed on 2024-05-28
 
@@ -107,8 +107,8 @@ is-decidableₚ P =
 We work in a module parameterized by
 
  - a large and locally small Scott domain `𝓓`,
- - assumed to satisfy `decidability-condition` which says that upper boundedness
-   of its compact elements is a decidable property.
+ - assumed to satisfy the `decidability-condition` which says that upper
+   boundedness of its compact elements is a decidable property.
 
 \begin{code}
 
@@ -135,43 +135,43 @@ and self-containment.
 
 \end{code}
 
-We denote by `scott[𝓓]` the Scott locale of domain `𝓓`.
+We denote by `Scott⦅𝓓⦆` the Scott locale of domain `𝓓`.
 
 \begin{code}
 
- open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe renaming (σ⦅𝓓⦆ to scott[𝓓])
+ open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe renaming (σ⦅𝓓⦆ to Scott⦅𝓓⦆)
 
 \end{code}
 
-For the frame of opens of the Scott locale `scott[𝓓]`, we reserve the notation
+For the frame of opens of the Scott locale `Scott⦅𝓓⦆`, we reserve the notation
 `σ[𝓓]`. This notation differs from other uses in TypeTopology, but it should be
 the standard one and the notation elsewhere should be updated to use this one.
 
 \begin{code}
 
  σ[𝓓] : Frame (𝓤 ⁺) 𝓤 𝓤
- σ[𝓓] = 𝒪 scott[𝓓]
+ σ[𝓓] = 𝒪 Scott⦅𝓓⦆
 
  open SpectralScottLocaleConstruction  𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
 
- open ScottLocaleProperties 𝓓 hl hscb pe renaming (⊤-is-compact to scott[𝓓]-is-compact)
+ open ScottLocaleProperties 𝓓 hl hscb pe renaming (⊤-is-compact to Scott⦅𝓓⦆-is-compact)
  open is-small-compact-basis scb
  open structurally-algebraic
 
- σᴰ : spectralᴰ scott[𝓓]
+ σᴰ : spectralᴰ Scott⦅𝓓⦆
  σᴰ = scott-locale-spectralᴰ
 
- basis : Fam 𝓤 ⟨ 𝒪 scott[𝓓] ⟩
- basis = basisₛ scott[𝓓] σᴰ
+ basis : Fam 𝓤 ⟨ 𝒪 Scott⦅𝓓⦆ ⟩
+ basis = basisₛ Scott⦅𝓓⦆ σᴰ
 
  Bσ : 𝓤  ̇
  Bσ = index basis
 
- βσ : Bσ → ⟨ 𝒪 scott[𝓓] ⟩
+ βσ : Bσ → ⟨ 𝒪 Scott⦅𝓓⦆ ⟩
  βσ = basis [_]
 
- κσ : (i : Bσ) → is-compact-open scott[𝓓] (βσ i) holds
- κσ = basisₛ-consists-of-compact-opens scott[𝓓] σᴰ
+ κσ : (i : Bσ) → is-compact-open Scott⦅𝓓⦆ (βσ i) holds
+ κσ = basisₛ-consists-of-compact-opens Scott⦅𝓓⦆ σᴰ
 
 \end{code}
 
@@ -277,11 +277,11 @@ membership in compact Scott opens.
 
  admits-decidable-membership-in-compact-scott-opens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
  admits-decidable-membership-in-compact-scott-opens x =
-  Ɐ 𝒦 ꞉ ⟨ 𝒪 scott[𝓓] ⟩ , is-compact-open scott[𝓓] 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-compact-open Scott⦅𝓓⦆ 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
  admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
  admits-decidable-membership-in-scott-clopens x =
-  Ɐ 𝒦 ꞉ ⟨ 𝒪 scott[𝓓] ⟩ , is-clopen (𝒪 scott[𝓓]) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-clopen (𝒪 Scott⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
 \end{code}
 
@@ -319,10 +319,10 @@ in compact Scott opens.
  sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽 𝒦 𝕜 =
   ∥∥-rec (holds-is-prop (is-decidableₚ (x ∈ₛ 𝒦))) (uncurry ‡) ♢
    where
-    ♢ : is-basic scott[𝓓] 𝒦 (spectralᴰ-implies-directed-basisᴰ scott[𝓓] σᴰ) holds
+    ♢ : is-basic Scott⦅𝓓⦆ 𝒦 (spectralᴰ-implies-directed-basisᴰ Scott⦅𝓓⦆ σᴰ) holds
     ♢ = compact-opens-are-basic
-         scott[𝓓]
-         (spectralᴰ-implies-directed-basisᴰ scott[𝓓] σᴰ)
+         Scott⦅𝓓⦆
+         (spectralᴰ-implies-directed-basisᴰ Scott⦅𝓓⦆ σᴰ)
          𝒦
          𝕜
 
@@ -382,10 +382,10 @@ What can be said about the converse? That is something to keep thinking about.
     ψ : admits-decidable-membership-in-compact-scott-opens x holds
     ψ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽
 
-    κ : is-compact-open scott[𝓓] K holds
+    κ : is-compact-open Scott⦅𝓓⦆ K holds
     κ = clopens-are-compact-in-compact-frames
-         (𝒪 scott[𝓓])
-         scott[𝓓]-is-compact
+         (𝒪 Scott⦅𝓓⦆)
+         Scott⦅𝓓⦆-is-compact
          K
          χ
 
@@ -395,13 +395,13 @@ What can be said about the converse? That is something to keep thinking about.
 
 \section{The equivalence}
 
-We now start constructing an equivalence between the type `Spectral-Point scott[𝓓]`
+We now start constructing an equivalence between the type `Spectral-Point Scott⦅𝓓⦆`
 and the type `♯𝓓`.
 
 This equivalence consists of the maps:
 
-  1. `𝓅𝓉[_] : ♯𝓓 → Spectral-Point scott[𝓓]`, and
-  2. `sharp : Spectral-Point scott[𝓓] → ♯𝓓`.
+  1. `𝓅𝓉[_] : ♯𝓓 → Spectral-Point Scott⦅𝓓⦆`, and
+  2. `sharp : Spectral-Point Scott⦅𝓓⦆ → ♯𝓓`.
 
 We now construct these maps in this order.
 
@@ -412,25 +412,25 @@ version of the construction of interest, which is then packaged up with a proof.
 
 \begin{code}
 
- pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 scott[𝓓] ⟩ → Ω 𝓤
+ pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ → Ω 𝓤
  pt₀[_] x U = x ∈ₛ U
 
  open FrameHomomorphisms
- open FrameHomomorphismProperties (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe)
+ open FrameHomomorphismProperties (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe)
 
- pt[_] : ♯𝓓 → Point scott[𝓓]
+ pt[_] : ♯𝓓 → Point Scott⦅𝓓⦆
  pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
   where
-   ‡ : preserves-joins (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   ‡ : preserves-joins (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
    ‡ S = (⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆) , goal
     where
      open Joins _⇒_
 
      goal : ((u , _) : upper-bound ⁅ pt₀[ x ] y ∣ y ε S ⁆)
-          → (pt₀[ x ] (⋁[ 𝒪 scott[𝓓] ] S) ⇒ u) holds
+          → (pt₀[ x ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ⇒ u) holds
      goal (u , a) p = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆ (u , a) p
 
-   † : is-a-frame-homomorphism (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   † : is-a-frame-homomorphism (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
    † = refl , (λ _ _ → refl) , ‡
 
 \end{code}
@@ -448,7 +448,7 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map scott[𝓓] (𝟏Loc pe) pt[ 𝓍 ] holds
+ pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) pt[ 𝓍 ] holds
  pt-is-spectral 𝓍@(x , 𝓈𝒽) 𝒦@(K , σ) 𝕜 = decidable-implies-compact pe (x ∈ₛ 𝒦) †
   where
    † : is-decidableₚ (x ∈ₛ (K , σ)) holds
@@ -462,10 +462,10 @@ We package `pt[_]` up with this proof spectrality to obtain the following:
 
 \begin{code}
 
- 𝓅𝓉[_] : ♯𝓓 → Spectral-Point scott[𝓓]
- 𝓅𝓉[_] 𝓍 = to-spectral-point scott[𝓓] ℱ
+ 𝓅𝓉[_] : ♯𝓓 → Spectral-Point Scott⦅𝓓⦆
+ 𝓅𝓉[_] 𝓍 = to-spectral-point Scott⦅𝓓⦆ ℱ
   where
-   ℱ : Spectral-Map (𝟏Loc pe) scott[𝓓]
+   ℱ : Spectral-Map (𝟏Loc pe) Scott⦅𝓓⦆
    ℱ = pt[ 𝓍 ] , pt-is-spectral 𝓍
 
 \end{code}
@@ -476,10 +476,10 @@ We now define the map `sharp` going in the opposite direction.
 
 \begin{code}
 
- sharp₀ : Point scott[𝓓] → ⟨ 𝓓 ⟩∙
+ sharp₀ : Point Scott⦅𝓓⦆ → ⟨ 𝓓 ⟩∙
  sharp₀ ℱ = ∐ 𝓓 (𝒦-in-point-is-directed ℱ)
 
- lemma-6-⇒ : (ℱ@(F , _) : Point scott[𝓓]) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+ lemma-6-⇒ : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
          → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ → F ↑ˢ[ c , 𝕜 ] holds
  lemma-6-⇒ ℱ@(F , 𝒽) c 𝕜 p =
   ∥∥-rec (holds-is-prop (F ↑ˢ[ c , 𝕜 ])) † γ
@@ -494,11 +494,11 @@ We now define the map `sharp` going in the opposite direction.
     † ((i , p) , φ) =
      frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ c , 𝕜 ]) ‡ p
       where
-       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 scott[𝓓]) ] ↑ˢ[ c , 𝕜 ]) holds
+       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] ↑ˢ[ c , 𝕜 ]) holds
        ‡ =
         principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
 
- lemma-6-⇐ : (ℱ@(F , _) : Point scott[𝓓]) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+ lemma-6-⇐ : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
            → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
  lemma-6-⇐ ℱ@(F , ψ) c 𝕜 χ =
   ∥∥-rec (prop-valuedness 𝓓 c (⋁ 𝒦-in-point↑ ℱ)) † γ
@@ -524,8 +524,8 @@ The map `sharp₀` always gives sharp elements.
 
 \begin{code}
 
- sharp₀-gives-sharp-elements : (F : Point scott[𝓓])
-                             → is-spectral-map scott[𝓓] (𝟏Loc pe) F holds
+ sharp₀-gives-sharp-elements : (F : Point Scott⦅𝓓⦆)
+                             → is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) F holds
                              → is-sharp (sharp₀ F) holds
  sharp₀-gives-sharp-elements ℱ@(F , _) σ c 𝕜 = cases case₁ case₂ γ
   where
@@ -548,10 +548,10 @@ and denote it by `sharp`.
 
 \begin{code}
 
- sharp : Spectral-Point scott[𝓓] → ♯𝓓
+ sharp : Spectral-Point Scott⦅𝓓⦆ → ♯𝓓
  sharp ℱ = sharp₀ F· , sharp₀-gives-sharp-elements F· σ
   where
-   open Spectral-Point scott[𝓓] ℱ
+   open Spectral-Point Scott⦅𝓓⦆ ℱ
     renaming (point-fn to F; point to F·; point-preserves-compactness to σ)
 
 \end{code}
@@ -635,7 +635,7 @@ type of spectral points.
 
  open PropertiesAlgebraic 𝓓 𝕒
 
- another-lemma : (𝔘 : ⟨ 𝒪 scott[𝓓] ⟩) (ℱ@(F , _) : Point scott[𝓓])
+ another-lemma : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
                → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
  another-lemma 𝔘 ℱ@(F , 𝒽) = †
   where
@@ -648,14 +648,14 @@ type of spectral points.
        → F 𝔘 holds
      †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) foo b
       where
-       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 scott[𝓓]) ] 𝔘) holds
+       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
        foo x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
 
- final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point scott[𝓓])
+ final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
              → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
  final-lemma []       ℱ@(F , _) p = 𝟘-elim quux
   where
-   φ : F 𝟎[ 𝒪 scott[𝓓] ] holds
+   φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
 
    baz : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
@@ -684,20 +684,20 @@ type of spectral points.
     ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
     ‡ (inr q) = ∣ inr (final-lemma ks ℱ q) ∣
 
- pt-cancels-sharp : (ℱ : Spectral-Point scott[𝓓]) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
+ pt-cancels-sharp : (ℱ : Spectral-Point Scott⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
  pt-cancels-sharp ℱ =
-  to-spectral-point-＝ scott[𝓓] 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
+  to-spectral-point-＝ Scott⦅𝓓⦆ 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
    where
-    open Spectral-Point scott[𝓓] ℱ renaming (point-fn to F; point to ℱ₀)
+    open Spectral-Point Scott⦅𝓓⦆ ℱ renaming (point-fn to F; point to ℱ₀)
 
-    † : (𝔘 : ⟨ 𝒪 scott[𝓓] ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
+    † : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
     † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) nts
      where
-      S : Fam 𝓤 ⟨ 𝒪 scott[𝓓] ⟩
-      S = covering-familyₛ scott[𝓓] σᴰ 𝔘
+      S : Fam 𝓤 ⟨ 𝒪 Scott⦅𝓓⦆ ⟩
+      S = covering-familyₛ Scott⦅𝓓⦆ σᴰ 𝔘
 
-      q : 𝔘 ＝ ⋁[ 𝒪 scott[𝓓] ] S
-      q = basisₛ-covers-do-cover-eq scott[𝓓] σᴰ 𝔘
+      q : 𝔘 ＝ ⋁[ 𝒪 Scott⦅𝓓⦆ ] S
+      q = basisₛ-covers-do-cover-eq Scott⦅𝓓⦆ σᴰ 𝔘
 
       nts₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
       nts₁ k = ∣ k , another-lemma (S [ k ]) ℱ₀ ∣
@@ -705,19 +705,19 @@ type of spectral points.
       nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
       nts₂ (ks , p) = ∣ (ks , p) , final-lemma ks ℱ₀ ∣
 
-      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 scott[𝓓] ] S) ＝ F (⋁[ 𝒪 scott[𝓓] ] S)
-      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 scott[𝓓] ] S)                  ＝⟨ refl ⟩
-            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 scott[𝓓] ] S)              ＝⟨ Ⅰ ⟩
+      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
+      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩
+            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)              ＝⟨ Ⅰ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ ⟩
-            F (⋁[ 𝒪 scott[𝓓] ] S)                              ∎
+            F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                              ∎
              where
-              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
-              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
+              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
+              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
 
- ♯𝓓-equivalent-to-spectral-points-of-scott[𝓓] : ♯𝓓 ≃ Spectral-Point scott[𝓓]
- ♯𝓓-equivalent-to-spectral-points-of-scott[𝓓] = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
+ ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point Scott⦅𝓓⦆
+ ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
   where
    † : qinv 𝓅𝓉[_]
    † = sharp , sharp-cancels-pt , pt-cancels-sharp

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -641,9 +641,9 @@ type of spectral points.
 
  open PropertiesAlgebraic 𝓓 𝕒
 
- another-lemma : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
-               → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
- another-lemma 𝔘 ℱ@(F , 𝒽) = †
+ lemma₅ : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+        → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+ lemma₅ 𝔘 ℱ@(F , 𝒽) = †
   where
    open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
 
@@ -652,14 +652,14 @@ type of spectral points.
     where
      †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
        → F 𝔘 holds
-     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) foo b
+     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) q b
       where
-       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
-       foo x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
+       q : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
+       q x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
 
- final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
-             → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
- final-lemma []       ℱ@(F , _) p = 𝟘-elim quux
+ lemma₆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+        → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
+ lemma₆ []       ℱ@(F , _) p = 𝟘-elim quux
   where
    φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
@@ -670,25 +670,22 @@ type of spectral points.
    quux : ⊥ₚ holds
    quux = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) baz
 
- final-lemma (k ∷ ks) ℱ@(F , _) p =
-  ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ †
+ lemma₆ (k ∷ ks) ℱ@(F , _) p =
+  ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ (transport _holds ♠ p)
    where
-    foo : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
-    foo = F (𝜸 (k ∷ ks))                     ＝⟨ ap F (𝜸-equal-to-𝜸₁ (k ∷ ks)) ⟩
-          F (𝜸₁ (k ∷ ks))                    ＝⟨ frame-homomorphisms-preserve-binary-joins ℱ _ _  ⟩
-          F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
-          F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
-          F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
-           where
-            Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
-            Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
-
-    † : (F ↑ᵏ[ k ] ∨ F (𝜸 ks)) holds
-    † = transport _holds foo p
+    ♠ : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
+    ♠ = F (𝜸 (k ∷ ks))                     ＝⟨ ap F (𝜸-equal-to-𝜸₁ (k ∷ ks)) ⟩
+        F (𝜸₁ (k ∷ ks))                    ＝⟨ frame-homomorphisms-preserve-binary-joins ℱ _ _  ⟩
+        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
+        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
+        F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
+         where
+          Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
+          Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
 
     ‡ : F ↑ᵏ[ k ] holds + F (𝜸 ks) holds → (sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)) holds
     ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
-    ‡ (inr q) = ∣ inr (final-lemma ks ℱ q) ∣
+    ‡ (inr q) = ∣ inr (lemma₆ ks ℱ q) ∣
 
  pt-cancels-sharp : (ℱ : Spectral-Point Scott⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
  pt-cancels-sharp ℱ =
@@ -706,20 +703,21 @@ type of spectral points.
       q = basisₛ-covers-do-cover-eq Scott⦅𝓓⦆ σᴰ 𝔘
 
       nts₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
-      nts₁ k = ∣ k , another-lemma (S [ k ]) ℱ₀ ∣
+      nts₁ k = ∣ k , lemma₅ (S [ k ]) ℱ₀ ∣
 
       nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
-      nts₂ (ks , p) = ∣ (ks , p) , final-lemma ks ℱ₀ ∣
+      nts₂ (ks , p) = ∣ (ks , p) , lemma₆ ks ℱ₀ ∣
 
       nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
-      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩
-            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)              ＝⟨ Ⅰ ⟩
+      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)               ＝⟨ refl ⟩
+            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)           ＝⟨ Ⅰ    ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂ ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ ⟩
-            F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                              ∎
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ Ⅳ    ⟩
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ    ⟩
+            F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                          ∎
              where
               Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
+              Ⅳ = bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂
               Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
 
  ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point Scott⦅𝓓⦆

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -7,11 +7,9 @@ date-completed: 2024-05-28
 
 This module contains the proof of equivalence between the sharp elements of a
 Scott domain and the “spectral points” of its Scott locale. This equivalence
-conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15, in the
-context of our work on the patch topology in univalent foundations (j.w.w. Igor
-Arrieta)
+conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
 
-The formalization was completed on 2024-05-28
+The formalization of the proof was completed on 2024-05-28
 
 \begin{code}[hide]
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -8,7 +8,10 @@ The formalization of a proof.
 
 \begin{code}
 
+{--# OPTIONS --safe --without-K #--}
+
 open import MLTT.Spartan
+open import MLTT.List hiding ([_])
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Size
@@ -38,17 +41,22 @@ open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
 open import DomainTheory.Basics.WayBelow pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
+open import Locales.Compactness pt fe hiding (is-compact)
+open import Locales.Clopen pt fe sr
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
+open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
+open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralMap pt fe
-open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.TerminalLocale.Properties pt fe sr
+open import NotionsOfDecidability.Decidable
 open import NotionsOfDecidability.SemiDecidable fe pe pt
 open import Slice.Family
 open import UF.Logic
@@ -58,7 +66,7 @@ open import UF.SubtypeClassifier
 
 open AllCombinators pt fe
 open DefinitionOfScottDomain
-open PropositionalTruncation pt
+open PropositionalTruncation pt hiding (_∨_)
 
 \end{code}
 
@@ -107,24 +115,28 @@ is proposition-valued.
  𝒷₀ : has-unspecified-small-compact-basis 𝓓
  𝒷₀ = pr₁ sd
 
- bc : DefinitionOfBoundedCompleteness.bounded-complete 𝓓 holds
- bc = pr₂ sd
+ open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe
+ open SpectralScottLocaleConstruction 𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
+ open ScottLocaleProperties 𝓓 hl hscb pe renaming (⊤-is-compact to σ⦅𝓓⦆-is-compact)
 
- hscb : has-specified-small-compact-basis 𝓓
- hscb = specified-small-compact-basis-has-split-support ua sr 𝓓 𝒷₀
-
- 𝕒 : structurally-algebraic 𝓓
- 𝕒 = structurally-algebraic-if-specified-small-compact-basis 𝓓 hscb
-
- open SpectralScottLocaleConstruction 𝓓 hl hscb dc bc pe hiding (scb)
  open structurally-algebraic
  open is-small-compact-basis scb
+ open Locale
 
- κ : (b : B) → is-compact 𝓓 (β b)
- κ = basis-is-compact
+ σᴰ : spectralᴰ σ⦅𝓓⦆
+ σᴰ = scott-locale-spectralᴰ
 
- σ⦅𝓓⦆ : Locale (𝓤 ⁺) 𝓤 𝓤
- σ⦅𝓓⦆ = Σ[𝓓]
+ basis : Fam 𝓤 ⟨ 𝒪 σ⦅𝓓⦆ ⟩
+ basis = basisₛ σ⦅𝓓⦆ σᴰ
+
+ Bσ : 𝓤  ̇
+ Bσ = index basis
+
+ βσ : Bσ → ⟨ 𝒪 σ⦅𝓓⦆ ⟩
+ βσ = basis [_]
+
+ κσ : (i : Bσ) → is-compact-open σ⦅𝓓⦆ (βσ i) holds
+ κσ = basisₛ-consists-of-compact-opens σ⦅𝓓⦆ σᴰ
 
  _⊑_ : ⟨ 𝓓 ⟩∙ → ⟨ 𝓓 ⟩∙ → Ω 𝓤
  x ⊑ y = (x ⊑⟨ 𝓓 ⟩ y) , prop-valuedness 𝓓 x y
@@ -147,14 +159,14 @@ algebraic dcpo, however, we could define a small version.
 \begin{code}
 
  is-sharp⁻ : ⟨ 𝓓 ⟩∙ → Ω 𝓤
- is-sharp⁻ x = Ɐ i ꞉ B , is-decidableₚ (β i ⊑ x)
+ is-sharp⁻ x = Ɐ i ꞉ index B𝓓 , is-decidableₚ ((B𝓓 [ i ]) ⊑ x)
 
 \end{code}
 
 \begin{code}
 
  sharp-implies-sharp⁻ : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x ⇒ is-sharp⁻ x) holds
- sharp-implies-sharp⁻ x 𝕤 i = 𝕤 (β i) (κ i)
+ sharp-implies-sharp⁻ x 𝕤 i = 𝕤 (B𝓓 [ i ]) (basis-is-compact i)
 
 \end{code}
 
@@ -164,10 +176,10 @@ algebraic dcpo, however, we could define a small version.
  sharp⁻-implies-sharp x 𝕤 c χ =
   ∥∥-rec (holds-is-prop (is-decidableₚ (c ⊑ x))) † μ
    where
-    μ : ∃ i ꞉ B , β i ＝ c
-    μ = small-compact-basis-contains-all-compact-elements 𝓓 β scb c χ
+    μ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
+    μ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c χ
 
-    † : Σ i ꞉ B , β i ＝ c → is-decidableₚ (c ⊑ x) holds
+    † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → is-decidableₚ (c ⊑ x) holds
     † (i , p) = transport (λ - → is-decidableₚ (- ⊑ x) holds) p (𝕤 i)
 
 \end{code}
@@ -205,21 +217,150 @@ algebraic dcpo, however, we could define a small version.
 \begin{code}
 
  open FrameHomomorphisms
+ open FrameHomomorphismProperties (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe)
 
  pt[_] : ♯𝓓 → Point σ⦅𝓓⦆
  pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
   where
-   †₂ : preserves-binary-meets (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   †₂ x y = refl
+   ‡ : preserves-joins (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   ‡ S = (⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆) , goal
+    where
+     open Joins _⇒_
 
-   †₃ : preserves-joins (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   †₃ = {!!}
-
-   foo : preserves-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   foo S = refl
+     goal : ((u , _) : upper-bound ⁅ pt₀[ x ] y ∣ y ε S ⁆)
+          → (pt₀[ x ] (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ⇒ u) holds
+     goal (u , a) p = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆ (u , a) p
 
    † : is-a-frame-homomorphism (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   † = refl , (λ _ _ → refl) , †₃
+   † = refl , (λ _ _ → refl) , ‡
+
+\end{code}
+
+\begin{code}
+
+ -- TODO: has this been written down somewhere?
+
+ ∨-preserves-decidability : (P Q : Ω 𝓤)
+                          → is-decidableₚ P holds
+                          → is-decidableₚ Q holds
+                          → is-decidableₚ (P ∨ Q) holds
+ ∨-preserves-decidability P Q φ ψ =
+  cases case₁ case₂ (+-preserves-decidability φ ψ)
+   where
+    case₁ : (P holds) + (Q holds) → is-decidableₚ (P ∨ Q) holds
+    case₁ (inl p) = inl ∣ inl p ∣
+    case₁ (inr q) = inl ∣ inr q ∣
+
+    case₂ : ¬ (P holds + Q holds) → is-decidableₚ (P ∨ Q) holds
+    case₂ = inr ∘ ∥∥-rec 𝟘-is-prop
+
+\end{code}
+
+For any sharp element `𝓍` and any compact Scott open `𝒦`, `𝓍 ∈ 𝒦` is a decidable
+proposition.
+
+\begin{code}
+
+ open BottomLemma 𝓓 𝕒 hl
+ open Properties 𝓓
+
+\end{code}
+
+We define the following predicate expressing that an element `x` has decidable
+membership in compact Scott opens.
+
+\begin{code}
+
+ admits-decidable-membership-in-compact-scott-opens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ admits-decidable-membership-in-compact-scott-opens x =
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 σ⦅𝓓⦆ ⟩ , is-compact-open σ⦅𝓓⦆ 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
+
+ admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ admits-decidable-membership-in-scott-clopens x =
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 σ⦅𝓓⦆ ⟩ , is-clopen (𝒪 σ⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
+
+\end{code}
+
+Every sharp element satisfies this property.
+
+\begin{code}
+
+ sharp-implies-admits-decidable-membership-in-compact-scott-opens
+  : (x : ⟨ 𝓓 ⟩∙)
+  → (is-sharp x ⇒ admits-decidable-membership-in-compact-scott-opens x) holds
+ sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽 𝒦 𝕜 =
+  ∥∥-rec (holds-is-prop (is-decidableₚ (x ∈ₛ 𝒦))) † ♢
+   where
+    ♢ : is-basic σ⦅𝓓⦆ 𝒦 (spectralᴰ-implies-directed-basisᴰ σ⦅𝓓⦆ σᴰ) holds
+    ♢ = compact-opens-are-basic
+         σ⦅𝓓⦆
+         (spectralᴰ-implies-directed-basisᴰ σ⦅𝓓⦆ σᴰ)
+         𝒦
+         𝕜
+
+    quux : βσ [] ＝ 𝟎[ 𝒪 σ⦅𝓓⦆ ]
+    quux = 𝜸-equal-to-𝜸₁ []
+
+    lemma : (xs : List (index B𝓓)) → is-decidableₚ (x ∈ₛ βσ xs) holds
+    lemma []       = inr 𝟘-elim
+    lemma (i ∷ is) = ∨-preserves-decidability (x ∈ₛ ↑ˢ[ βₖ i ]) (x ∈ₛ 𝜸 is) †₁ †₂
+     where
+      †₁ : is-decidableₚ (x ∈ₛ ↑ˢ[ βₖ i ]) holds
+      †₁ = 𝓈𝒽 (β i) (basis-is-compact i)
+
+      †₂ : is-decidableₚ (x ∈ₛ 𝜸 is) holds
+      †₂ = lemma is
+
+    ‡ : (xs : List (index B𝓓)) → βσ xs ＝ 𝒦 → is-decidableₚ (x ∈ₛ 𝒦) holds
+    ‡ xs p = transport (λ - → is-decidableₚ (x ∈ₛ -) holds) p (lemma xs)
+
+    † : Σ xs ꞉ List (index B𝓓) , βσ xs ＝ 𝒦 → is-decidableₚ (x ∈ₛ 𝒦) holds
+    † (xs , q) = ‡ xs q
+
+\end{code}
+
+\begin{code}
+
+ admits-decidable-membership-in-compact-scott-opens-implies-is-sharp
+  : (x : ⟨ 𝓓 ⟩∙)
+  → admits-decidable-membership-in-compact-scott-opens x holds
+  → is-sharp x holds
+ admits-decidable-membership-in-compact-scott-opens-implies-is-sharp x φ c 𝕜 =
+  φ ↑ˢ[ (c , 𝕜) ] (principal-filter-is-compact₀ c 𝕜)
+
+\end{code}
+
+\begin{code}
+
+ admits-decidable-membership-in-scott-clopens-implies-is-sharp
+  : (x : ⟨ 𝓓 ⟩∙)
+  → is-sharp x holds
+  → admits-decidable-membership-in-scott-clopens x holds
+ admits-decidable-membership-in-scott-clopens-implies-is-sharp x 𝓈𝒽 K χ =
+  ψ K κ
+   where
+    ψ : admits-decidable-membership-in-compact-scott-opens x holds
+    ψ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽
+
+    κ : is-compact-open σ⦅𝓓⦆ K holds
+    κ = clopens-are-compact-in-compact-frames
+         (𝒪 σ⦅𝓓⦆)
+         σ⦅𝓓⦆-is-compact
+         K
+         χ
+
+
+\end{code}
+
+\begin{code}
+
+ characterization-of-sharp-elements
+  : (x : ⟨ 𝓓 ⟩∙)
+  → (admits-decidable-membership-in-compact-scott-opens x ⇔ is-sharp x) holds
+ characterization-of-sharp-elements x = † , ‡
+  where
+   † = admits-decidable-membership-in-compact-scott-opens-implies-is-sharp x
+   ‡ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x
 
 \end{code}
 
@@ -231,36 +372,10 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
  open Properties 𝓓
 
  pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) pt[ 𝓍 ] holds
- pt-is-spectral 𝓍@(x , _) (K , σ) 𝕜 = decidable-implies-compact pe P {!!}
+ pt-is-spectral 𝓍@(x , 𝓈𝒽) 𝒦@(K , σ) 𝕜 = decidable-implies-compact pe (x ∈ₛ 𝒦) †
   where
-   P : Ω 𝓤
-   P = pt₀[ x ] (K , σ)
-
-   foo : pt₀[ x ] (⋁[ 𝒪 σ⦅𝓓⦆ ] ⁅ ↑ˢ[ β i , κ i ] ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆)
-       ＝ ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅  pt₀[ x ] ↑ˢ[ β i , κ i ]  ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆
-   foo = refl
-
-   goal : is-compact-open (𝟏Loc pe) (Ǝₚ (i , _) ꞉ (Σ i ꞉ B , K (β i) holds) , pt₀[ x ] ↑ˢ[ β i , κ i ]) holds
-   goal S δ p = {!!}
-    where
-     baz : {!!} → ∃ i ꞉ index S , (S [ i ]) holds
-     baz = p
-    -- frame-homomorphisms-preserve-all-joins′
-    --  (𝒪 σ⦅𝓓⦆)
-    --  (𝟎-𝔽𝕣𝕞 pe)
-    --  pt[ 𝓍 ]
-    --  ⁅ ↑ˢ[ β i , κ i ] ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆
-  -- ∥∥-rec ∃-is-prop goal (bar (♠ {!!}))
-  --  where
-  --   ♠ : join-of-compact-opens K x holds → K x holds
-  --   ♠ = characterization-of-scott-opens₂ K σ x
-
-  --   bar : K x holds → ∃ i ꞉ index S , (S [ i ]) holds
-  --   bar = p
-
-  --   goal : (Σ i ꞉ index S , (S [ i ]) holds)
-  --        → ∃ i ꞉ index S , (K x ⇒ S [ i ]) holds
-  --   goal (i , p) = ∣ i , (λ _ → p) ∣
+   † : is-decidableₚ (x ∈ₛ (K , σ)) holds
+   † = sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽 𝒦 𝕜
 
 \end{code}
 
@@ -271,5 +386,9 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
   where
    δ : is-Directed 𝓓 (𝒦-in-point F [_])
    δ = 𝒦-in-point-is-directed F
+
+\end{code}
+
+\begin{code}
 
 \end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -1,14 +1,14 @@
---------------------------------------------------------------------------------
+---
 title:          Equivalence of sharp elements with spectral points
 author:         Ayberk Tosun
 date-started:   2024-05-22
---------------------------------------------------------------------------------
+---
 
 The formalization of a proof.
 
 \begin{code}
 
-{--# OPTIONS --safe --without-K #--}
+{--# OPTIONS --safe --without-K --lossy-unification #--}
 
 open import MLTT.Spartan
 open import MLTT.List hiding ([_])

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -1,0 +1,275 @@
+--------------------------------------------------------------------------------
+title:          Equivalence of sharp elements with spectral points
+author:         Ayberk Tosun
+date-started:   2024-05-22
+--------------------------------------------------------------------------------
+
+The formalization of a proof.
+
+\begin{code}
+
+open import MLTT.Spartan
+open import UF.FunExt
+open import UF.PropTrunc
+open import UF.Size
+open import UF.Subsingletons
+open import UF.UA-FunExt
+open import UF.Univalence
+
+module Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints
+        (𝓤  : Universe)
+        (ua : Univalence)
+        (pt : propositional-truncations-exist)
+        (sr : Set-Replacement pt)
+       where
+
+private
+ fe : Fun-Ext
+ fe {𝓤} {𝓥} = univalence-gives-funext' 𝓤 𝓥 (ua 𝓤) (ua (𝓤 ⊔ 𝓥))
+
+ pe : Prop-Ext
+ pe {𝓤} = univalence-gives-propext (ua 𝓤)
+
+open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.CompactBasis pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.ScottDomain pt fe 𝓤
+open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
+open import DomainTheory.Basics.WayBelow pt fe 𝓤
+open import DomainTheory.Topology.ScottTopology pt fe 𝓤
+open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
+open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
+open import Locales.Frame pt fe
+open import Locales.InitialFrame pt fe hiding (_⊑_)
+open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.ScottLocale.Definition pt fe 𝓤
+open import Locales.ScottLocale.Properties pt fe 𝓤
+open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
+open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
+open import Locales.Spectrality.SpectralMap pt fe
+open import Locales.Compactness pt fe hiding (is-compact)
+open import Locales.TerminalLocale.Properties pt fe sr
+open import NotionsOfDecidability.SemiDecidable fe pe pt
+open import Slice.Family
+open import UF.Logic
+open import UF.Subsingletons-FunExt
+open import UF.Subsingletons-Properties
+open import UF.SubtypeClassifier
+
+open AllCombinators pt fe
+open DefinitionOfScottDomain
+open PropositionalTruncation pt
+
+\end{code}
+
+\section{Preliminaries}
+
+We define a version of the predicate `is-compact` that is packaged up with the
+proof that it is a proposition.
+
+\begin{code}
+
+is-compactₚ : (𝓓 : DCPO {𝓤 ⁺} {𝓤}) → ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+is-compactₚ 𝓓 x = is-compact 𝓓 x , being-compact-is-prop 𝓓 x
+
+\end{code}
+
+Similarly, we define a version of the predicate `is-decidable` that is packaged
+up with the proof that it is a proposition.
+
+\begin{code}
+
+is-decidableₚ : (P : Ω 𝓤) → Ω 𝓤
+is-decidableₚ P =
+ is-decidable (P holds) , decidability-of-prop-is-prop fe (holds-is-prop P)
+
+\end{code}
+
+\begin{code}
+
+module ResultOnSharpElements
+        (𝓓    : DCPO {𝓤 ⁺} {𝓤})
+        (hl   : has-least (underlying-order 𝓓))
+        (sd   : is-scott-domain 𝓓 holds)
+        (dc   : decidability-condition 𝓓)
+       where
+
+ open Construction 𝓓 ua hl sd dc
+ open DefinitionOfBoundedCompleteness hiding (_⊑_)
+
+\end{code}
+
+We define a version of the order `_⊑_` packaged up with the proof that it
+is proposition-valued.
+
+\begin{code}
+
+ 𝒷₀ : has-unspecified-small-compact-basis 𝓓
+ 𝒷₀ = pr₁ sd
+
+ bc : DefinitionOfBoundedCompleteness.bounded-complete 𝓓 holds
+ bc = pr₂ sd
+
+ hscb : has-specified-small-compact-basis 𝓓
+ hscb = specified-small-compact-basis-has-split-support ua sr 𝓓 𝒷₀
+
+ 𝕒 : structurally-algebraic 𝓓
+ 𝕒 = structurally-algebraic-if-specified-small-compact-basis 𝓓 hscb
+
+ open SpectralScottLocaleConstruction 𝓓 hl hscb dc bc pe hiding (scb)
+ open structurally-algebraic
+ open is-small-compact-basis scb
+
+ κ : (b : B) → is-compact 𝓓 (β b)
+ κ = basis-is-compact
+
+ σ⦅𝓓⦆ : Locale (𝓤 ⁺) 𝓤 𝓤
+ σ⦅𝓓⦆ = Σ[𝓓]
+
+ _⊑_ : ⟨ 𝓓 ⟩∙ → ⟨ 𝓓 ⟩∙ → Ω 𝓤
+ x ⊑ y = (x ⊑⟨ 𝓓 ⟩ y) , prop-valuedness 𝓓 x y
+
+\end{code}
+
+We first define what it means for an element to be sharp.
+
+\begin{code}
+
+ is-sharp : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ is-sharp x = Ɐ c ꞉ ⟨ 𝓓 ⟩∙ , is-compactₚ 𝓓 c ⇒ is-decidableₚ (c ⊑ x)
+
+\end{code}
+
+This definition of the notion of sharpness is a predicate with large truth
+values as it quantifier over the compact opens. Because we are working with an
+algebraic dcpo, however, we could define a small version.
+
+\begin{code}
+
+ is-sharp⁻ : ⟨ 𝓓 ⟩∙ → Ω 𝓤
+ is-sharp⁻ x = Ɐ i ꞉ B , is-decidableₚ (β i ⊑ x)
+
+\end{code}
+
+\begin{code}
+
+ sharp-implies-sharp⁻ : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x ⇒ is-sharp⁻ x) holds
+ sharp-implies-sharp⁻ x 𝕤 i = 𝕤 (β i) (κ i)
+
+\end{code}
+
+\begin{code}
+
+ sharp⁻-implies-sharp : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp⁻ x ⇒ is-sharp x) holds
+ sharp⁻-implies-sharp x 𝕤 c χ =
+  ∥∥-rec (holds-is-prop (is-decidableₚ (c ⊑ x))) † μ
+   where
+    μ : ∃ i ꞉ B , β i ＝ c
+    μ = small-compact-basis-contains-all-compact-elements 𝓓 β scb c χ
+
+    † : Σ i ꞉ B , β i ＝ c → is-decidableₚ (c ⊑ x) holds
+    † (i , p) = transport (λ - → is-decidableₚ (- ⊑ x) holds) p (𝕤 i)
+
+\end{code}
+
+\begin{code}
+
+ ♯𝓓 : 𝓤 ⁺  ̇
+ ♯𝓓 = Σ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x holds
+
+\end{code}
+
+\begin{code}
+
+ sharp-is-equivalent-to-sharp⁻ : (x : ⟨ 𝓓 ⟩∙) → (is-sharp x ⇔ is-sharp⁻ x) holds
+ sharp-is-equivalent-to-sharp⁻ x =
+  sharp-implies-sharp⁻ x , sharp⁻-implies-sharp x
+
+\end{code}
+
+\begin{code}
+
+ open Preliminaries
+ open Locale
+ open DefnOfScottTopology 𝓓 𝓤
+
+\end{code}
+
+\begin{code}
+
+ pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 σ⦅𝓓⦆ ⟩ → Ω 𝓤
+ pt₀[_] x U = x ∈ₛ U
+
+\end{code}
+
+\begin{code}
+
+ open FrameHomomorphisms
+
+ pt[_] : ♯𝓓 → Point σ⦅𝓓⦆
+ pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
+  where
+   †₂ : preserves-binary-meets (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   †₂ x y = refl
+
+   †₃ : preserves-joins (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   †₃ = {!!}
+
+   foo : preserves-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   foo S = refl
+
+   † : is-a-frame-homomorphism (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   † = refl , (λ _ _ → refl) , †₃
+
+\end{code}
+
+Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
+
+\begin{code}
+
+ open PropertiesAlgebraic 𝓓 𝕒
+ open Properties 𝓓
+
+ pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) pt[ 𝓍 ] holds
+ pt-is-spectral 𝓍@(x , _) (K , σ) 𝕜 = decidable-implies-compact pe P {!!}
+  where
+   P : Ω 𝓤
+   P = pt₀[ x ] (K , σ)
+
+   foo : pt₀[ x ] (⋁[ 𝒪 σ⦅𝓓⦆ ] ⁅ ↑ˢ[ β i , κ i ] ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆)
+       ＝ ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅  pt₀[ x ] ↑ˢ[ β i , κ i ]  ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆
+   foo = refl
+
+   goal : is-compact-open (𝟏Loc pe) (Ǝₚ (i , _) ꞉ (Σ i ꞉ B , K (β i) holds) , pt₀[ x ] ↑ˢ[ β i , κ i ]) holds
+   goal S δ p = {!!}
+    where
+     baz : {!!} → ∃ i ꞉ index S , (S [ i ]) holds
+     baz = p
+    -- frame-homomorphisms-preserve-all-joins′
+    --  (𝒪 σ⦅𝓓⦆)
+    --  (𝟎-𝔽𝕣𝕞 pe)
+    --  pt[ 𝓍 ]
+    --  ⁅ ↑ˢ[ β i , κ i ] ∣ (i , _) ∶ (Σ i ꞉ B , K (β i) holds) ⁆
+  -- ∥∥-rec ∃-is-prop goal (bar (♠ {!!}))
+  --  where
+  --   ♠ : join-of-compact-opens K x holds → K x holds
+  --   ♠ = characterization-of-scott-opens₂ K σ x
+
+  --   bar : K x holds → ∃ i ꞉ index S , (S [ i ]) holds
+  --   bar = p
+
+  --   goal : (Σ i ꞉ index S , (S [ i ]) holds)
+  --        → ∃ i ꞉ index S , (K x ⇒ S [ i ]) holds
+  --   goal (i , p) = ∣ i , (λ _ → p) ∣
+
+\end{code}
+
+\begin{code}
+
+ sharp₀ : Point σ⦅𝓓⦆ → ⟨ 𝓓 ⟩∙
+ sharp₀ F = ⋁ (𝒦-in-point F , δ)
+  where
+   δ : is-Directed 𝓓 (𝒦-in-point F [_])
+   δ = 𝒦-in-point-is-directed F
+
+\end{code}

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -49,6 +49,7 @@ open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.Point.Definition pt fe
 open import Locales.Point.SpectralPoint-Definition pt fe
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
@@ -64,7 +65,7 @@ open import UF.Equiv
 open import UF.Logic
 open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties
-open import UF.SubtypeClassifier
+open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 
 open AllCombinators pt fe
 open DefinitionOfScottDomain
@@ -553,20 +554,63 @@ type of spectral points.
 
  open PropertiesAlgebraic 𝓓 𝕒
 
+ another-lemma : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point σ⦅𝓓⦆)
+               → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+ another-lemma 𝔘 ℱ@(F , 𝒽) = †
+  where
+   open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
+
+   † : (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ (pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p)
+    where
+     †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
+       → F 𝔘 holds
+     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) foo b
+      where
+       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 σ⦅𝓓⦆) ] 𝔘) holds
+       foo x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
+
+ final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point σ⦅𝓓⦆)
+             → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
+ final-lemma []       ℱ@(F , _) p = 𝟘-elim quux
+  where
+   φ : F 𝟎[ 𝒪 σ⦅𝓓⦆ ] holds
+   φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
+
+   baz : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
+   baz = transport _holds (frame-homomorphisms-preserve-bottom ℱ) φ
+
+   quux : ⊥ₚ holds
+   quux = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) baz
+
+ final-lemma (k ∷ ks) ℱ@(F , _) p =
+  ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ †
+   where
+    IH : (sharp₀ ℱ ∈ₛ 𝜸 ks) holds
+    IH = final-lemma ks ℱ {!!}
+
+    foo : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
+    foo = F (𝜸 (k ∷ ks))                     ＝⟨ ap F (𝜸-equal-to-𝜸₁ (k ∷ ks)) ⟩
+          F (𝜸₁ (k ∷ ks))                    ＝⟨ frame-homomorphisms-preserve-binary-joins ℱ _ _  ⟩
+          F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
+          F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
+          F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
+           where
+            Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
+            Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
+
+    † : (F ↑ᵏ[ k ] ∨ F (𝜸 ks)) holds
+    † = transport _holds foo p
+
+    ‡ : F ↑ᵏ[ k ] holds + F (𝜸 ks) holds → (sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)) holds
+    ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
+    ‡ (inr q) = ∣ inr (final-lemma ks ℱ q) ∣
+
  pt-cancels-sharp : (ℱ : Spectral-Point σ⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
  pt-cancels-sharp ℱ =
   to-spectral-point-＝ σ⦅𝓓⦆ 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
    where
     open Spectral-Point σ⦅𝓓⦆ ℱ renaming (point-fn to F; point to ℱ₀)
-
-    †₁ : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘 ⇒ F 𝔘) holds
-    †₁ 𝔘@(U , s) μ = {!lemma-6-⇐ ℱ₀ !}
-
-    †₂ : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (F 𝔘 ⇒ sharp₀ ℱ₀ ∈ₛ 𝔘) holds
-    †₂ 𝔘@(U , s) μ = {!!}
-     where
-      foo : {!!}
-      foo = {!pr₁ (characterization-of-scott-opens U s ?)!}
 
     † : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
     † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) nts
@@ -577,11 +621,17 @@ type of spectral points.
       q : 𝔘 ＝ ⋁[ 𝒪 σ⦅𝓓⦆ ] S
       q = basisₛ-covers-do-cover-eq σ⦅𝓓⦆ σᴰ 𝔘
 
+      nts₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
+      nts₁ k = ∣ k , another-lemma (S [ k ]) ℱ₀ ∣
+
+      nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
+      nts₂ (ks , p) = {!final-lemma!}
+
       nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)
       nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩
             pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 σ⦅𝓓⦆ ] S)              ＝⟨ Ⅰ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ {!!} ⟩
+            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ ⟩
             F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                              ∎
              where

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -175,9 +175,8 @@ the standard one and the notation elsewhere should be updated to use this one.
 
 \end{code}
 
-We define a version of the ordering of the domain that is packaged up with the
-proof that it is a proposition (called `prop-valuedness` in the domain theory
-development).
+We define a version of the order of `𝓓` that is packaged up with the proof that
+it is a proposition (called `prop-valuedness` in the domain theory development).
 
 \begin{code}
 
@@ -242,7 +241,8 @@ We now define the type `♯𝓓` of sharp elements of the Scott domain `𝓓`.
 \end{code}
 
 We usually pattern match on the inhabitants of `♯𝓓` to refer to the first
-component.
+component. But if the need arises, we denote the underlying element of
+a sharp element `𝓍` by `⦅ 𝓍 ⦆`.
 
 \begin{code}
 
@@ -342,7 +342,8 @@ in compact Scott opens.
 
 \end{code}
 
-The converse also holds so this is a necessary and sufficient condition.
+The converse also holds meaning elements that admit decidable membership in
+compact Scott opens are _exactly_ the sharp elements.
 
 \begin{code}
 
@@ -368,8 +369,6 @@ The converse also holds so this is a necessary and sufficient condition.
 Because clopens are compact in compact frames, we can also give as a necessary
 condition that sharp elements admit decidable membership in Scott clopens.
 
-What can be said about the converse? That is something to keep thinking about.
-
 \begin{code}
 
  admits-decidable-membership-in-scott-clopens-implies-is-sharp
@@ -390,6 +389,10 @@ What can be said about the converse? That is something to keep thinking about.
          χ
 
 \end{code}
+
+What can be said about the converse of this implication? In other words, what is
+the meaning of the set of elements of the domain that admit decidable membership
+in Scott clopens. I do not know the answer yet.
 
 \section{Some useful lemmas}
 
@@ -479,28 +482,39 @@ We now define the map `sharp` going in the opposite direction.
  sharp₀ : Point Scott⦅𝓓⦆ → ⟨ 𝓓 ⟩∙
  sharp₀ ℱ = ∐ 𝓓 (𝒦-in-point-is-directed ℱ)
 
- lemma-6-⇒ : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
-         → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ → F ↑ˢ[ c , 𝕜 ] holds
- lemma-6-⇒ ℱ@(F , 𝒽) c 𝕜 p =
+\end{code}
+
+We prove the following lemma which says `c ⊑ sharp(ℱ)` if and only if `ℱ(↑c)`,
+for every compact element `c` of the domain `𝓓`.
+
+\begin{code}
+
+ below-sharp-implies-in-point₁
+  : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+  → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
+  → F ↑ˢ[ c , 𝕜 ] holds
+ below-sharp-implies-in-point₁ ℱ@(F , 𝒽) c 𝕜 p =
   ∥∥-rec (holds-is-prop (F ↑ˢ[ c , 𝕜 ])) † γ
    where
+    𝔠 = (c , 𝕜)
+
     open 𝒪ₛᴿ (to-𝒪ₛᴿ ↑ˢ[ c , 𝕜 ])
 
     γ : ∃ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
     γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
 
     † : Σ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
-      → F ↑ˢ[ c , 𝕜 ] holds
+      → F ↑ˢ[ 𝔠 ] holds
     † ((i , p) , φ) =
-     frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ c , 𝕜 ]) ‡ p
+     frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ 𝔠 ]) ‡ p
       where
-       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] ↑ˢ[ c , 𝕜 ]) holds
-       ‡ =
-        principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
+       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] ↑ˢ[ 𝔠 ]) holds
+       ‡ = principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
 
- lemma-6-⇐ : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
-           → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
- lemma-6-⇐ ℱ@(F , ψ) c 𝕜 χ =
+ in-point-implies-below-sharp
+  : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+  → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
+ in-point-implies-below-sharp ℱ@(F , ψ) c 𝕜 χ =
   ∥∥-rec (prop-valuedness 𝓓 c (⋁ 𝒦-in-point↑ ℱ)) † γ
    where
     γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
@@ -529,22 +543,22 @@ The map `sharp₀` always gives sharp elements.
                              → is-sharp (sharp₀ F) holds
  sharp₀-gives-sharp-elements ℱ@(F , _) σ c 𝕜 = cases case₁ case₂ γ
   where
-   φ : is-compact-open (𝟏Loc pe) (F ↑ˢ[ c , 𝕜 ]) holds
-   φ = σ ↑ˢ[ c , 𝕜 ] (principal-filter-is-compact₀ c 𝕜 )
+   χ : is-compact-open (𝟏Loc pe) (F ↑ˢ[ c , 𝕜 ]) holds
+   χ = σ ↑ˢ[ c , 𝕜 ] (principal-filter-is-compact₀ c 𝕜 )
 
    γ : is-decidableₚ (F ↑ˢ[ c , 𝕜 ]) holds
-   γ = compact-implies-boolean pe (F ↑ˢ[ c , 𝕜 ]) φ
+   γ = compact-implies-boolean pe (F ↑ˢ[ c , 𝕜 ]) χ
 
    case₁ : F ↑ˢ[ c , 𝕜 ] holds → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
-   case₁ = inl ∘ lemma-6-⇐ ℱ c 𝕜
+   case₁ = inl ∘ in-point-implies-below-sharp ℱ c 𝕜
 
    case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
-   case₂ χ = inr λ q → χ (lemma-6-⇒ ℱ c 𝕜 q)
+   case₂ χ = inr (χ ∘ below-sharp-implies-in-point₁ ℱ c 𝕜)
 
 \end{code}
 
-We package up `sharp₀` with the proof that it always gives sharp elements
-and denote it by `sharp`.
+We denote by `sharp` the version of `sharp₀` that is packaged up with the proof
+that it always gives sharp elements and denote it by `sharp`.
 
 \begin{code}
 
@@ -568,33 +582,25 @@ type of spectral points.
          → c ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
   lemma₁ x 𝕤 c κ p = ∥∥-rec (prop-valuedness 𝓓 c (sharp₀ pt[ x , 𝕤 ])) † γ
    where
-    † : (Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c) → c ⊑⟨ 𝓓 ⟩ sharp₀ pt[ x , 𝕤 ]
+    † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → (c ⊑ sharp₀ pt[ x , 𝕤 ]) holds
     † (i , q) = transport (λ - → underlying-order 𝓓 - (sharp₀ pt[ x , 𝕤 ])) q ‡
      where
       r : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ x
       r = transport (λ - → - ⊑⟨ 𝓓 ⟩ x) (q ⁻¹) p
 
       ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ sharp₀ pt[ x , 𝕤 ]
-      ‡ = sup-is-upperbound (underlying-order 𝓓)
+      ‡ = sup-is-upperbound
+           (underlying-order 𝓓)
            (⋁-is-sup (𝒦-in-point↑ pt[ x , 𝕤 ])) (i , r)
 
     γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
     γ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c κ
 
- lemma₃ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds) (c : ⟨ 𝓓 ⟩∙)
-        → is-compact 𝓓 c
-        → ∃ i ꞉ (index (𝒦-in-point pt[ (x , 𝕤) ])) , c ＝ 𝒦-in-point pt[ (x , 𝕤) ] [ i ]
-        → c ⊑⟨ 𝓓 ⟩ x
- lemma₃ x 𝕤 c κ = ∥∥-rec (prop-valuedness 𝓓 c x) †
-  where
-   † : Σ i ꞉ (index (𝒦-in-point pt[ (x , 𝕤) ])) , c ＝ 𝒦-in-point pt[ x , 𝕤 ] [ i ]
-     → c ⊑⟨ 𝓓 ⟩ x
-   † ((i , foo) , r) = transport (λ - → - ⊑⟨ 𝓓 ⟩ x) (r ⁻¹) foo
-
  abstract
-  lemma₄ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds)
-         → ∐ 𝓓 (↓ᴮₛ-is-directed x) ＝ ∐ 𝓓 (𝒦-in-point-is-directed pt[ (x , 𝕤) ])
-  lemma₄ x 𝕤 =
+  lemma₄
+   : (𝓍 : ♯𝓓)
+   → ∐ 𝓓 (↓ᴮₛ-is-directed ⦅ 𝓍 ⦆) ＝ ∐ 𝓓 (𝒦-in-point-is-directed pt[ 𝓍 ])
+  lemma₄ (x , 𝕤) =
    antisymmetry 𝓓 (∐ 𝓓 (↓ᴮₛ-is-directed x)) (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) † ‡
     where
      abstract
@@ -623,14 +629,14 @@ type of spectral points.
              goal (i , q) = ∐-is-upperbound 𝓓 (↓ᴮₛ-is-directed x) (i , ⊑ᴮ-to-⊑ᴮₛ q)
 
  sharp-cancels-pt : (𝓍 : ♯𝓓) → sharp 𝓅𝓉[ 𝓍 ] ＝ 𝓍
- sharp-cancels-pt 𝓍@(x , 𝕤) = to-sharp-＝ (sharp 𝓅𝓉[ 𝓍 ]) 𝓍 †
+ sharp-cancels-pt 𝓍 = to-sharp-＝ (sharp 𝓅𝓉[ 𝓍 ]) 𝓍 †
   where
-   † : ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆ ＝ x
-   † = ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆        ＝⟨ Ⅰ ⟩
-       ∐ 𝓓 (↓ᴮₛ-is-directed x)  ＝⟨ Ⅱ ⟩
-       ⦅ 𝓍 ⦆                    ∎
+   † : ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆ ＝ ⦅ 𝓍 ⦆
+   † = ⦅ sharp 𝓅𝓉[ 𝓍 ] ⦆           ＝⟨ Ⅰ ⟩
+       ∐ 𝓓 (↓ᴮₛ-is-directed ⦅ 𝓍 ⦆) ＝⟨ Ⅱ ⟩
+       ⦅ 𝓍 ⦆                       ∎
         where
-         Ⅰ = lemma₄ x 𝕤 ⁻¹
+         Ⅰ = lemma₄ 𝓍 ⁻¹
          Ⅱ = ↓ᴮₛ-∐-＝ ⦅ 𝓍 ⦆
 
  open PropertiesAlgebraic 𝓓 𝕒

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -285,8 +285,7 @@ membership in compact Scott opens.
 
 \end{code}
 
-Every sharp element satisfies this property of admitting decidable membership
-in compact Scott opens.
+Every sharp element admits decidable membership in compact Scott opens.
 
 \begin{code}
 
@@ -347,8 +346,8 @@ Because clopens are compact in compact frames, we can also prove that admitting
 decidable membership in Scott clopens is a necessary condition for an element of
 the domain to be sharp.
 
-We do not need this result in the present development, but we note it down as it
-is a potentially useful observation.
+We do not need this result for the main result in this module, but we note it
+down regardless as it is a potentially useful observation.
 
 \begin{code}
 
@@ -379,6 +378,8 @@ What can be said about the converse of this implication? In other words, what is
 the meaning of the set of elements that admit decidable membership in Scott
 clopens. I do not know the answer yet.
 
+TODO: think more about this.
+
 \section{The equivalence}
 
 We now start constructing an equivalence between the type
@@ -393,9 +394,9 @@ We now construct these maps in this order.
 
 \subsection{Definition of the map `𝓅𝓉`}
 
-We follow our usual convention denoting by the subscript `₀` the preliminary
-version of the construction of interest, which is then packaged up with a proof
-that it satisfies some property.
+We follow our usual convention of distinguishing the preliminary version of the
+construction of interest using the subscript `₀`, which we then package up with
+the proof that it satisfies some property.
 
 \begin{code}
 
@@ -486,8 +487,7 @@ every Scott open `𝔘`.
 
 \end{code}
 
-As an immediate special case of this lemma, we obtain the following which we
-record explicitly.
+As an immediate special case of this lemma, we obtain the following.
 
 \begin{code}
 
@@ -504,14 +504,16 @@ record explicitly.
 
 \end{code}
 
-In fact, it can be generalized to finite joins of principal filters on compact
-elements i.e. compact Scott opens.
+The converse of this special case also holds. In fact, the converse holds
+for _all_ compact Scott opens.
 
 \begin{code}
 
- in-point-implies-below-sharp⋆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
-                              → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
- in-point-implies-below-sharp⋆ [] ℱ@(F , _) p = 𝟘-elim Ⅰ
+ in-point-implies-contains-sharp⋆
+  : (ks : List (index B𝓓))
+  → (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+  → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
+ in-point-implies-contains-sharp⋆ [] ℱ@(F , _) p = 𝟘-elim Ⅰ
   where
    φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
@@ -522,7 +524,7 @@ elements i.e. compact Scott opens.
    Ⅰ : ⊥ₚ holds
    Ⅰ = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) Ⅱ
 
- in-point-implies-below-sharp⋆ (k ∷ ks) ℱ@(F , _) p =
+ in-point-implies-contains-sharp⋆ (k ∷ ks) ℱ@(F , _) p =
   ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ (transport _holds ♠ p)
    where
     ♠ : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
@@ -539,7 +541,7 @@ elements i.e. compact Scott opens.
 
     ‡ : F ↑ᵏ[ k ] holds + F (𝜸 ks) holds → (sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)) holds
     ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
-    ‡ (inr q) = ∣ inr (in-point-implies-below-sharp⋆ ks ℱ q) ∣
+    ‡ (inr q) = ∣ inr (in-point-implies-contains-sharp⋆ ks ℱ q) ∣
 
 \end{code}
 
@@ -549,12 +551,12 @@ principal filters on compact opens.
 
 \begin{code}
 
- in-point-implies-below-sharp
+ in-point-implies-contains-sharp
   : (ℱ@(F , _) : Point Scott⦅𝓓⦆)
   → (K : ⟨ σ⦅𝓓⦆ ⟩)
   → (𝕜 : is-compact-open Scott⦅𝓓⦆ K holds)
   → (F K ⇒ sharp₀ ℱ ∈ₛ K) holds
- in-point-implies-below-sharp ℱ@(F , ψ) K 𝕜 χ =
+ in-point-implies-contains-sharp ℱ@(F , ψ) K 𝕜 χ =
   ∥∥-rec (holds-is-prop (sharp₀ ℱ ∈ₛ K)) † γ
    where
     ℬ↑ : directed-basisᴰ (𝒪 Scott⦅𝓓⦆)
@@ -570,7 +572,7 @@ principal filters on compact opens.
       μ = transport (λ - → F - holds) (p ⁻¹) χ
 
       ‡ : (sharp₀ (F , ψ) ∈ₛ βσ i) holds
-      ‡ = in-point-implies-below-sharp⋆ i ℱ μ
+      ‡ = in-point-implies-contains-sharp⋆ i ℱ μ
 
 \end{code}
 
@@ -593,7 +595,7 @@ We now prove that the map `sharp₀` always gives sharp elements.
    κ = principal-filter-is-compact₀ c 𝕜
 
    case₁ : F ↑ˢ[ c , 𝕜 ] holds → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
-   case₁ = inl ∘ in-point-implies-below-sharp ℱ ↑ˢ[ (c , 𝕜) ] κ
+   case₁ = inl ∘ in-point-implies-contains-sharp ℱ ↑ˢ[ (c , 𝕜) ] κ
 
    case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
    case₂ χ = inr (χ ∘ below-sharp-implies-in-point ℱ c 𝕜)
@@ -630,7 +632,7 @@ the compact approximants of `𝓍`.
   antisymmetry 𝓓 (∐ 𝓓 (↓ᴮₛ-is-directed x)) (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) † ‡
    where
     γ : ((i , _) : ↓ᴮₛ x) → (sharp₀ pt[ x , 𝕤 ] ∈ₛ ↑ˢ[ βₖ i ]) holds
-    γ (i , q) = in-point-implies-below-sharp
+    γ (i , q) = in-point-implies-contains-sharp
                  pt[ x , 𝕤 ]
                  ↑ˢ[ βₖ i ]
                  (principal-filter-is-compact i)
@@ -701,7 +703,7 @@ The map `𝓅𝓉[_]` is a retraction of the map `sharp`.
       ‡₁ k = ∣ k , sharp-in-scott-open-implies-in-point (S [ k ]) ℱ₀ ∣
 
       ‡₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
-      ‡₂ (ks , p) = ∣ (ks , p) , in-point-implies-below-sharp⋆ ks ℱ₀ ∣
+      ‡₂ (ks , p) = ∣ (ks , p) , in-point-implies-contains-sharp⋆ ks ℱ₀ ∣
 
       ‡ : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
       ‡ = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)               ＝⟨ refl ⟩

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -96,7 +96,7 @@ up with the proof that it is a proposition.
 
 \begin{code}
 
-is-decidableₚ : (P : Ω 𝓤) → Ω 𝓤
+is-decidableₚ : Ω 𝓤 → Ω 𝓤
 is-decidableₚ P =
  is-decidable (P holds) , decidability-of-prop-is-prop fe (holds-is-prop P)
 
@@ -145,16 +145,12 @@ We denote by `scott[𝓓]` the Scott locale of domain `𝓓`.
 
 For the frame of opens of the Scott locale `scott[𝓓]`, we reserve the notation
 `σ[𝓓]`. This notation differs from other uses in TypeTopology, but it should be
-the standard one and the notation elsewhere should be updated to this one.
+the standard one and the notation elsewhere should be updated to use this one.
 
 \begin{code}
 
  σ[𝓓] : Frame (𝓤 ⁺) 𝓤 𝓤
  σ[𝓓] = 𝒪 scott[𝓓]
-
-\end{code}
-
-\begin{code}
 
  open SpectralScottLocaleConstruction  𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -285,29 +285,6 @@ membership in compact Scott opens.
 
 \end{code}
 
-I used the following lemma when proving that `pt` gives spectral points. I
-looked around in TypeTopology but could not find it anywhere.
-
-TODO: avoid duplicating this if it has not been written down already.
-
-\begin{code}
-
- ∨-preserves-decidability : (P Q : Ω 𝓤)
-                          → is-decidableₚ P holds
-                          → is-decidableₚ Q holds
-                          → is-decidableₚ (P ∨ Q) holds
- ∨-preserves-decidability P Q φ ψ =
-  cases case₁ case₂ (+-preserves-decidability φ ψ)
-   where
-    case₁ : P holds + Q holds → is-decidableₚ (P ∨ Q) holds
-    case₁ (inl p) = inl ∣ inl p ∣
-    case₁ (inr q) = inl ∣ inr q ∣
-
-    case₂ : ¬ (P holds + Q holds) → is-decidableₚ (P ∨ Q) holds
-    case₂ = inr ∘ ∥∥-rec 𝟘-is-prop
-
-\end{code}
-
 Every sharp element satisfies this property of admitting decidable membership
 in compact Scott opens.
 
@@ -329,7 +306,7 @@ in compact Scott opens.
     lemma : (xs : List (index B𝓓)) → is-decidableₚ (x ∈ₛ βσ xs) holds
     lemma []       = inr 𝟘-elim
     lemma (i ∷ is) =
-     ∨-preserves-decidability (x ∈ₛ ↑ˢ[ βₖ i ]) (x ∈ₛ 𝜸 is) † IH
+     ∨-preserves-decidability pt (x ∈ₛ ↑ˢ[ βₖ i ]) (x ∈ₛ 𝜸 is) † IH
       where
        † : is-decidableₚ (x ∈ₛ ↑ˢ[ βₖ i ]) holds
        † = 𝓈𝒽 (β i) (basis-is-compact i)

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -440,6 +440,10 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
    case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
    case₂ χ = inr λ q → χ (lemma-6-⇒ ℱ c 𝕜 q)
 
+\end{code}
+
+\begin{code}
+
  sharp : (ℱ : Point σ⦅𝓓⦆) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds → ♯𝓓
  sharp ℱ@(F , _) σ = sharp₀ ℱ , sharp₀-gives-sharp-elements ℱ σ
 

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -745,5 +745,12 @@ sharp elements and the spectral points.
 
 \end{code}
 
+\section{Acknowledgements}
+
+I am grateful to Tom de Jong for his comments on a write-up of the proof
+formalized in this module.
+
+\section{References}
+
 [1]: de Jong, Tom. "Apartness, sharp elements, and the Scott topology of
      domains." Mathematical Structures in Computer Science 33.7 (2023): 573-604.

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -13,7 +13,7 @@ Arrieta)
 
 The formalization was completed on 2024-05-28
 
-\begin{code}
+\begin{code}[hide]
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
@@ -76,6 +76,7 @@ open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 
 open AllCombinators pt fe
 open DefinitionOfScottDomain
+open Locale
 open PropositionalTruncation pt hiding (_∨_)
 
 \end{code}
@@ -103,9 +104,17 @@ is-decidableₚ P =
 
 \end{code}
 
+\section{Introduction}
+
+We work in a module parameterized by
+
+ - a large and locally small Scott domain `𝓓`,
+ - assumed to satisfy `decidability-condition` which says that upper boundedness
+   of its compact elements is a decidable property.
+
 \begin{code}
 
-module ResultOnSharpElements
+module Sharp-Element-Spectral-Point-Equivalence
         (𝓓    : DCPO {𝓤 ⁺} {𝓤})
         (hl   : has-least (underlying-order 𝓓))
         (sd   : is-scott-domain 𝓓 holds)
@@ -117,43 +126,75 @@ module ResultOnSharpElements
 
 \end{code}
 
-We define a version of the order `_⊑_` packaged up with the proof that it
-is proposition-valued.
+The following is a bit of preparation for the development of the proofs. We open
+up relevant proofs and define abbreviations for them for the sake of readability
+and self-containment.
 
 \begin{code}
 
  𝒷₀ : has-unspecified-small-compact-basis 𝓓
  𝒷₀ = pr₁ sd
 
- open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe
- open SpectralScottLocaleConstruction 𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
- open ScottLocaleProperties 𝓓 hl hscb pe renaming (⊤-is-compact to σ⦅𝓓⦆-is-compact)
+\end{code}
 
- open structurally-algebraic
+We denote by `scott[𝓓]` the Scott locale of domain `𝓓`.
+
+\begin{code}
+
+ open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe renaming (σ⦅𝓓⦆ to scott[𝓓])
+
+\end{code}
+
+For the frame of opens of the Scott locale `scott[𝓓]`, we reserve the notation
+`σ[𝓓]`. This notation differs from other uses in TypeTopology, but it should be
+the standard one and the notation elsewhere should be updated to this one.
+
+\begin{code}
+
+ σ[𝓓] : Frame (𝓤 ⁺) 𝓤 𝓤
+ σ[𝓓] = 𝒪 scott[𝓓]
+
+\end{code}
+
+\begin{code}
+
+ open SpectralScottLocaleConstruction  𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
+
+ open ScottLocaleProperties 𝓓 hl hscb pe renaming (⊤-is-compact to scott[𝓓]-is-compact)
  open is-small-compact-basis scb
- open Locale
+ open structurally-algebraic
 
- σᴰ : spectralᴰ σ⦅𝓓⦆
+ σᴰ : spectralᴰ scott[𝓓]
  σᴰ = scott-locale-spectralᴰ
 
- basis : Fam 𝓤 ⟨ 𝒪 σ⦅𝓓⦆ ⟩
- basis = basisₛ σ⦅𝓓⦆ σᴰ
+ basis : Fam 𝓤 ⟨ 𝒪 scott[𝓓] ⟩
+ basis = basisₛ scott[𝓓] σᴰ
 
  Bσ : 𝓤  ̇
  Bσ = index basis
 
- βσ : Bσ → ⟨ 𝒪 σ⦅𝓓⦆ ⟩
+ βσ : Bσ → ⟨ 𝒪 scott[𝓓] ⟩
  βσ = basis [_]
 
- κσ : (i : Bσ) → is-compact-open σ⦅𝓓⦆ (βσ i) holds
- κσ = basisₛ-consists-of-compact-opens σ⦅𝓓⦆ σᴰ
+ κσ : (i : Bσ) → is-compact-open scott[𝓓] (βσ i) holds
+ κσ = basisₛ-consists-of-compact-opens scott[𝓓] σᴰ
+
+\end{code}
+
+We define a version of the ordering of the domain that is packaged up with the
+proof that it is a proposition (called `prop-valuedness` in the domain theory
+development).
+
+\begin{code}
 
  _⊑_ : ⟨ 𝓓 ⟩∙ → ⟨ 𝓓 ⟩∙ → Ω 𝓤
  x ⊑ y = (x ⊑⟨ 𝓓 ⟩ y) , prop-valuedness 𝓓 x y
 
 \end{code}
 
-We first define what it means for an element to be sharp.
+\section{Definition of sharpness}
+
+We now define what it means for an element to be _sharp_.
 
 \begin{code}
 
@@ -163,8 +204,9 @@ We first define what it means for an element to be sharp.
 \end{code}
 
 This definition of the notion of sharpness is a predicate with large truth
-values as it quantifier over the compact opens. Because we are working with an
-algebraic dcpo, however, we could define a small version.
+values as it quantifies over the compact opens. Because we are working with an
+algebraic dcpo, however, we can define a small version which we denote
+`is-sharp⁻`.
 
 \begin{code}
 
@@ -173,14 +215,12 @@ algebraic dcpo, however, we could define a small version.
 
 \end{code}
 
+These two are equivalent.
+
 \begin{code}
 
  sharp-implies-sharp⁻ : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x ⇒ is-sharp⁻ x) holds
  sharp-implies-sharp⁻ x 𝕤 i = 𝕤 (B𝓓 [ i ]) (basis-is-compact i)
-
-\end{code}
-
-\begin{code}
 
  sharp⁻-implies-sharp : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp⁻ x ⇒ is-sharp x) holds
  sharp⁻-implies-sharp x 𝕤 c χ =
@@ -192,32 +232,22 @@ algebraic dcpo, however, we could define a small version.
     † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → is-decidableₚ (c ⊑ x) holds
     † (i , p) = transport (λ - → is-decidableₚ (- ⊑ x) holds) p (𝕤 i)
 
+ sharp-is-equivalent-to-sharp⁻ : (Ɐ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x ⇔ is-sharp⁻ x) holds
+ sharp-is-equivalent-to-sharp⁻ x =
+  sharp-implies-sharp⁻ x , sharp⁻-implies-sharp x
+
 \end{code}
+
+We now define the type `♯𝓓` of sharp elements of the Scott domain `𝓓`.
 
 \begin{code}
 
  ♯𝓓 : 𝓤 ⁺  ̇
  ♯𝓓 = Σ x ꞉ ⟨ 𝓓 ⟩∙ , is-sharp x holds
 
-\end{code}
-
-\begin{code}
-
  abstract
   to-sharp-＝ : (𝓍 𝓎 : ♯𝓓) → pr₁ 𝓍 ＝ pr₁ 𝓎 → 𝓍 ＝ 𝓎
   to-sharp-＝ 𝓍 𝓎 = to-subtype-＝ (holds-is-prop ∘ is-sharp)
-
-\end{code}
-
-\begin{code}
-
- sharp-is-equivalent-to-sharp⁻ : (x : ⟨ 𝓓 ⟩∙) → (is-sharp x ⇔ is-sharp⁻ x) holds
- sharp-is-equivalent-to-sharp⁻ x =
-  sharp-implies-sharp⁻ x , sharp⁻-implies-sharp x
-
-\end{code}
-
-\begin{code}
 
  open Preliminaries
  open Locale
@@ -225,38 +255,34 @@ algebraic dcpo, however, we could define a small version.
 
 \end{code}
 
+\section{Characterization of sharp elements}
+
+In this section, we give a characterization of sharp elements that we use when
+constructing the equivalence (which we do in the next section).
+
+We define the following predicate expressing that an element `x` has decidable
+membership in compact Scott opens.
+
 \begin{code}
 
- pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 σ⦅𝓓⦆ ⟩ → Ω 𝓤
- pt₀[_] x U = x ∈ₛ U
+ open Properties 𝓓
+
+ admits-decidable-membership-in-compact-scott-opens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ admits-decidable-membership-in-compact-scott-opens x =
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 scott[𝓓] ⟩ , is-compact-open scott[𝓓] 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
+
+ admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ admits-decidable-membership-in-scott-clopens x =
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 scott[𝓓] ⟩ , is-clopen (𝒪 scott[𝓓]) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
 \end{code}
 
-\begin{code}
+I used the following lemma when proving that `pt` gives spectral points. I
+looked around in TypeTopology but could not find it anywhere.
 
- open FrameHomomorphisms
- open FrameHomomorphismProperties (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe)
-
- pt[_] : ♯𝓓 → Point σ⦅𝓓⦆
- pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
-  where
-   ‡ : preserves-joins (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   ‡ S = (⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆) , goal
-    where
-     open Joins _⇒_
-
-     goal : ((u , _) : upper-bound ⁅ pt₀[ x ] y ∣ y ε S ⁆)
-          → (pt₀[ x ] (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ⇒ u) holds
-     goal (u , a) p = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆ (u , a) p
-
-   † : is-a-frame-homomorphism (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
-   † = refl , (λ _ _ → refl) , ‡
-
-\end{code}
+TODO: avoid duplicating this if it has not been written down already.
 
 \begin{code}
-
- -- TODO: has this been written down somewhere?
 
  ∨-preserves-decidability : (P Q : Ω 𝓤)
                           → is-decidableₚ P holds
@@ -265,7 +291,7 @@ algebraic dcpo, however, we could define a small version.
  ∨-preserves-decidability P Q φ ψ =
   cases case₁ case₂ (+-preserves-decidability φ ψ)
    where
-    case₁ : (P holds) + (Q holds) → is-decidableₚ (P ∨ Q) holds
+    case₁ : P holds + Q holds → is-decidableₚ (P ∨ Q) holds
     case₁ (inl p) = inl ∣ inl p ∣
     case₁ (inr q) = inl ∣ inr q ∣
 
@@ -274,32 +300,8 @@ algebraic dcpo, however, we could define a small version.
 
 \end{code}
 
-For any sharp element `𝓍` and any compact Scott open `𝒦`, `𝓍 ∈ 𝒦` is a decidable
-proposition.
-
-\begin{code}
-
- open BottomLemma 𝓓 𝕒 hl
- open Properties 𝓓
-
-\end{code}
-
-We define the following predicate expressing that an element `x` has decidable
-membership in compact Scott opens.
-
-\begin{code}
-
- admits-decidable-membership-in-compact-scott-opens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
- admits-decidable-membership-in-compact-scott-opens x =
-  Ɐ 𝒦 ꞉ ⟨ 𝒪 σ⦅𝓓⦆ ⟩ , is-compact-open σ⦅𝓓⦆ 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
-
- admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
- admits-decidable-membership-in-scott-clopens x =
-  Ɐ 𝒦 ꞉ ⟨ 𝒪 σ⦅𝓓⦆ ⟩ , is-clopen (𝒪 σ⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
-
-\end{code}
-
-Every sharp element satisfies this property.
+Every sharp element satisfies this property of admitting decidable membership
+in compact Scott opens.
 
 \begin{code}
 
@@ -307,35 +309,32 @@ Every sharp element satisfies this property.
   : (x : ⟨ 𝓓 ⟩∙)
   → (is-sharp x ⇒ admits-decidable-membership-in-compact-scott-opens x) holds
  sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽 𝒦 𝕜 =
-  ∥∥-rec (holds-is-prop (is-decidableₚ (x ∈ₛ 𝒦))) † ♢
+  ∥∥-rec (holds-is-prop (is-decidableₚ (x ∈ₛ 𝒦))) (uncurry ‡) ♢
    where
-    ♢ : is-basic σ⦅𝓓⦆ 𝒦 (spectralᴰ-implies-directed-basisᴰ σ⦅𝓓⦆ σᴰ) holds
+    ♢ : is-basic scott[𝓓] 𝒦 (spectralᴰ-implies-directed-basisᴰ scott[𝓓] σᴰ) holds
     ♢ = compact-opens-are-basic
-         σ⦅𝓓⦆
-         (spectralᴰ-implies-directed-basisᴰ σ⦅𝓓⦆ σᴰ)
+         scott[𝓓]
+         (spectralᴰ-implies-directed-basisᴰ scott[𝓓] σᴰ)
          𝒦
          𝕜
 
-    quux : βσ [] ＝ 𝟎[ 𝒪 σ⦅𝓓⦆ ]
-    quux = 𝜸-equal-to-𝜸₁ []
-
     lemma : (xs : List (index B𝓓)) → is-decidableₚ (x ∈ₛ βσ xs) holds
     lemma []       = inr 𝟘-elim
-    lemma (i ∷ is) = ∨-preserves-decidability (x ∈ₛ ↑ˢ[ βₖ i ]) (x ∈ₛ 𝜸 is) †₁ †₂
-     where
-      †₁ : is-decidableₚ (x ∈ₛ ↑ˢ[ βₖ i ]) holds
-      †₁ = 𝓈𝒽 (β i) (basis-is-compact i)
+    lemma (i ∷ is) =
+     ∨-preserves-decidability (x ∈ₛ ↑ˢ[ βₖ i ]) (x ∈ₛ 𝜸 is) † IH
+      where
+       † : is-decidableₚ (x ∈ₛ ↑ˢ[ βₖ i ]) holds
+       † = 𝓈𝒽 (β i) (basis-is-compact i)
 
-      †₂ : is-decidableₚ (x ∈ₛ 𝜸 is) holds
-      †₂ = lemma is
+       IH : is-decidableₚ (x ∈ₛ 𝜸 is) holds
+       IH = lemma is
 
     ‡ : (xs : List (index B𝓓)) → βσ xs ＝ 𝒦 → is-decidableₚ (x ∈ₛ 𝒦) holds
     ‡ xs p = transport (λ - → is-decidableₚ (x ∈ₛ -) holds) p (lemma xs)
 
-    † : Σ xs ꞉ List (index B𝓓) , βσ xs ＝ 𝒦 → is-decidableₚ (x ∈ₛ 𝒦) holds
-    † (xs , q) = ‡ xs q
-
 \end{code}
+
+The converse also holds so this is a necessary and sufficient condition.
 
 \begin{code}
 
@@ -346,7 +345,22 @@ Every sharp element satisfies this property.
  admits-decidable-membership-in-compact-scott-opens-implies-is-sharp x φ c 𝕜 =
   φ ↑ˢ[ (c , 𝕜) ] (principal-filter-is-compact₀ c 𝕜)
 
+ characterization-of-sharp-elements
+  : (x : ⟨ 𝓓 ⟩∙)
+  → (admits-decidable-membership-in-compact-scott-opens x ⇔ is-sharp x) holds
+ characterization-of-sharp-elements x = † , ‡
+  where
+   † = admits-decidable-membership-in-compact-scott-opens-implies-is-sharp x
+   ‡ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x
+
 \end{code}
+
+\section{A small digression}
+
+Because clopens are compact in compact frames, we can also give as a necessary
+condition that sharp elements admit decidable membership in Scott clopens.
+
+What can be said about the converse? That is something to keep thinking about.
 
 \begin{code}
 
@@ -360,25 +374,65 @@ Every sharp element satisfies this property.
     ψ : admits-decidable-membership-in-compact-scott-opens x holds
     ψ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x 𝓈𝒽
 
-    κ : is-compact-open σ⦅𝓓⦆ K holds
+    κ : is-compact-open scott[𝓓] K holds
     κ = clopens-are-compact-in-compact-frames
-         (𝒪 σ⦅𝓓⦆)
-         σ⦅𝓓⦆-is-compact
+         (𝒪 scott[𝓓])
+         scott[𝓓]-is-compact
          K
          χ
 
-
 \end{code}
+
+\section{Some useful lemmas}
+
+\section{The equivalence}
+
+We now start constructing an equivalence between the type `Spectral-Point scott[𝓓]`
+and the type `♯𝓓`.
+
+This equivalence consists of the maps:
+
+  1. `𝓅𝓉[_] : ♯𝓓 → Spectral-Point scott[𝓓]`, and
+  2. `sharp : Spectral-Point scott[𝓓] → ♯𝓓`.
+
+We now construct these maps in this order.
+
+\subsection{Definition of the map `𝓅𝓉`}
+
+We follow our usual convention denoting by the subscript `₀` the preliminary
+version of the construction of interest, which is then packaged up with a proof.
 
 \begin{code}
 
- characterization-of-sharp-elements
-  : (x : ⟨ 𝓓 ⟩∙)
-  → (admits-decidable-membership-in-compact-scott-opens x ⇔ is-sharp x) holds
- characterization-of-sharp-elements x = † , ‡
+ pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 scott[𝓓] ⟩ → Ω 𝓤
+ pt₀[_] x U = x ∈ₛ U
+
+ open FrameHomomorphisms
+ open FrameHomomorphismProperties (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe)
+
+ pt[_] : ♯𝓓 → Point scott[𝓓]
+ pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
   where
-   † = admits-decidable-membership-in-compact-scott-opens-implies-is-sharp x
-   ‡ = sharp-implies-admits-decidable-membership-in-compact-scott-opens x
+   ‡ : preserves-joins (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   ‡ S = (⋁[ 𝟎-𝔽𝕣𝕞 pe ]-upper ⁅ pt₀[ x ] y ∣ y ε S ⁆) , goal
+    where
+     open Joins _⇒_
+
+     goal : ((u , _) : upper-bound ⁅ pt₀[ x ] y ∣ y ε S ⁆)
+          → (pt₀[ x ] (⋁[ 𝒪 scott[𝓓] ] S) ⇒ u) holds
+     goal (u , a) p = ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-least ⁅ pt₀[ x ] y ∣ y ε S ⁆ (u , a) p
+
+   † : is-a-frame-homomorphism (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
+   † = refl , (λ _ _ → refl) , ‡
+
+\end{code}
+
+For any sharp element `𝓍` and any compact Scott open `𝒦`, `𝓍 ∈ 𝒦` is a decidable
+proposition.
+
+\begin{code}
+
+ open BottomLemma 𝓓 𝕒 hl
 
 \end{code}
 
@@ -386,7 +440,7 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) pt[ 𝓍 ] holds
+ pt-is-spectral : (𝓍 : ♯𝓓) → is-spectral-map scott[𝓓] (𝟏Loc pe) pt[ 𝓍 ] holds
  pt-is-spectral 𝓍@(x , 𝓈𝒽) 𝒦@(K , σ) 𝕜 = decidable-implies-compact pe (x ∈ₛ 𝒦) †
   where
    † : is-decidableₚ (x ∈ₛ (K , σ)) holds
@@ -394,20 +448,30 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
  open Notion-Of-Spectral-Point pe
 
- 𝓅𝓉[_] : ♯𝓓 → Spectral-Point σ⦅𝓓⦆
- 𝓅𝓉[_] 𝓍 = to-spectral-point σ⦅𝓓⦆ ℱ
+\end{code}
+
+We package `pt[_]` up with this proof spectrality to obtain the following:
+
+\begin{code}
+
+ 𝓅𝓉[_] : ♯𝓓 → Spectral-Point scott[𝓓]
+ 𝓅𝓉[_] 𝓍 = to-spectral-point scott[𝓓] ℱ
   where
-   ℱ : Spectral-Map (𝟏Loc pe) σ⦅𝓓⦆
+   ℱ : Spectral-Map (𝟏Loc pe) scott[𝓓]
    ℱ = pt[ 𝓍 ] , pt-is-spectral 𝓍
 
 \end{code}
 
+\subsection{Definition of the map `sharp`}
+
+We now define the map `sharp` going in the opposite direction.
+
 \begin{code}
 
- sharp₀ : Point σ⦅𝓓⦆ → ⟨ 𝓓 ⟩∙
+ sharp₀ : Point scott[𝓓] → ⟨ 𝓓 ⟩∙
  sharp₀ ℱ = ∐ 𝓓 (𝒦-in-point-is-directed ℱ)
 
- lemma-6-⇒ : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+ lemma-6-⇒ : (ℱ@(F , _) : Point scott[𝓓]) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
          → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ → F ↑ˢ[ c , 𝕜 ] holds
  lemma-6-⇒ ℱ@(F , 𝒽) c 𝕜 p =
   ∥∥-rec (holds-is-prop (F ↑ˢ[ c , 𝕜 ])) † γ
@@ -422,11 +486,11 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
     † ((i , p) , φ) =
      frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ c , 𝕜 ]) ‡ p
       where
-       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 σ⦅𝓓⦆) ] ↑ˢ[ c , 𝕜 ]) holds
+       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 scott[𝓓]) ] ↑ˢ[ c , 𝕜 ]) holds
        ‡ =
         principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
 
- lemma-6-⇐ : (ℱ@(F , _) : Point σ⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+ lemma-6-⇐ : (ℱ@(F , _) : Point scott[𝓓]) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
            → F ↑ˢ[ c , 𝕜 ] holds → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
  lemma-6-⇐ ℱ@(F , ψ) c 𝕜 χ =
   ∥∥-rec (prop-valuedness 𝓓 c (⋁ 𝒦-in-point↑ ℱ)) † γ
@@ -446,8 +510,8 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
       ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ ℱ)
       ‡ = ⋁-is-upperbound (𝒦-in-point↑ ℱ) (i , μ)
 
- sharp₀-gives-sharp-elements : (F : Point σ⦅𝓓⦆)
-                             → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
+ sharp₀-gives-sharp-elements : (F : Point scott[𝓓])
+                             → is-spectral-map scott[𝓓] (𝟏Loc pe) F holds
                              → is-sharp (sharp₀ F) holds
  sharp₀-gives-sharp-elements ℱ@(F , _) σ c 𝕜 = cases case₁ case₂ γ
   where
@@ -467,10 +531,10 @@ Given any sharp element `𝓍`, the point `pt 𝓍` is a spectral map.
 
 \begin{code}
 
- sharp : Spectral-Point σ⦅𝓓⦆ → ♯𝓓
+ sharp : Spectral-Point scott[𝓓] → ♯𝓓
  sharp ℱ = sharp₀ F· , sharp₀-gives-sharp-elements F· σ
   where
-   open Spectral-Point σ⦅𝓓⦆ ℱ
+   open Spectral-Point scott[𝓓] ℱ
     renaming (point-fn to F; point to F·; point-preserves-compactness to σ)
 
 \end{code}
@@ -561,7 +625,7 @@ type of spectral points.
 
  open PropertiesAlgebraic 𝓓 𝕒
 
- another-lemma : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point σ⦅𝓓⦆)
+ another-lemma : (𝔘 : ⟨ 𝒪 scott[𝓓] ⟩) (ℱ@(F , _) : Point scott[𝓓])
                → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
  another-lemma 𝔘 ℱ@(F , 𝒽) = †
   where
@@ -574,14 +638,14 @@ type of spectral points.
        → F 𝔘 holds
      †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) foo b
       where
-       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 σ⦅𝓓⦆) ] 𝔘) holds
+       foo : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 scott[𝓓]) ] 𝔘) holds
        foo x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
 
- final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point σ⦅𝓓⦆)
+ final-lemma : (ks : List (index B𝓓)) (ℱ@(F , _) : Point scott[𝓓])
              → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
  final-lemma []       ℱ@(F , _) p = 𝟘-elim quux
   where
-   φ : F 𝟎[ 𝒪 σ⦅𝓓⦆ ] holds
+   φ : F 𝟎[ 𝒪 scott[𝓓] ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
 
    baz : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
@@ -610,20 +674,20 @@ type of spectral points.
     ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
     ‡ (inr q) = ∣ inr (final-lemma ks ℱ q) ∣
 
- pt-cancels-sharp : (ℱ : Spectral-Point σ⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
+ pt-cancels-sharp : (ℱ : Spectral-Point scott[𝓓]) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
  pt-cancels-sharp ℱ =
-  to-spectral-point-＝ σ⦅𝓓⦆ 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
+  to-spectral-point-＝ scott[𝓓] 𝓅𝓉[ sharp ℱ ] ℱ (dfunext fe †)
    where
-    open Spectral-Point σ⦅𝓓⦆ ℱ renaming (point-fn to F; point to ℱ₀)
+    open Spectral-Point scott[𝓓] ℱ renaming (point-fn to F; point to ℱ₀)
 
-    † : (𝔘 : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
+    † : (𝔘 : ⟨ 𝒪 scott[𝓓] ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
     † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) nts
      where
-      S : Fam 𝓤 ⟨ 𝒪 σ⦅𝓓⦆ ⟩
-      S = covering-familyₛ σ⦅𝓓⦆ σᴰ 𝔘
+      S : Fam 𝓤 ⟨ 𝒪 scott[𝓓] ⟩
+      S = covering-familyₛ scott[𝓓] σᴰ 𝔘
 
-      q : 𝔘 ＝ ⋁[ 𝒪 σ⦅𝓓⦆ ] S
-      q = basisₛ-covers-do-cover-eq σ⦅𝓓⦆ σᴰ 𝔘
+      q : 𝔘 ＝ ⋁[ 𝒪 scott[𝓓] ] S
+      q = basisₛ-covers-do-cover-eq scott[𝓓] σᴰ 𝔘
 
       nts₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
       nts₁ k = ∣ k , another-lemma (S [ k ]) ℱ₀ ∣
@@ -631,19 +695,19 @@ type of spectral points.
       nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
       nts₂ (ks , p) = ∣ (ks , p) , final-lemma ks ℱ₀ ∣
 
-      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)
-      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                  ＝⟨ refl ⟩
-            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 σ⦅𝓓⦆ ] S)              ＝⟨ Ⅰ ⟩
+      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 scott[𝓓] ] S) ＝ F (⋁[ 𝒪 scott[𝓓] ] S)
+      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 scott[𝓓] ] S)                  ＝⟨ refl ⟩
+            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 scott[𝓓] ] S)              ＝⟨ Ⅰ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂ ⟩
             ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ ⟩
-            F (⋁[ 𝒪 σ⦅𝓓⦆ ] S)                              ∎
+            F (⋁[ 𝒪 scott[𝓓] ] S)                              ∎
              where
-              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
-              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 σ⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
+              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
+              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 scott[𝓓]) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
 
- ♯𝓓-equivalent-to-spectral-points-of-σ⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point σ⦅𝓓⦆
- ♯𝓓-equivalent-to-spectral-points-of-σ⦅𝓓⦆ = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
+ ♯𝓓-equivalent-to-spectral-points-of-scott[𝓓] : ♯𝓓 ≃ Spectral-Point scott[𝓓]
+ ♯𝓓-equivalent-to-spectral-points-of-scott[𝓓] = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
   where
    † : qinv 𝓅𝓉[_]
    † = sharp , sharp-cancels-pt , pt-cancels-sharp

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -7,8 +7,8 @@ dates-updated:  [2024-06-03]
 ---
 
 This module contains the proof of equivalence between the sharp elements of a
-Scott domain and the “spectral points” of its Scott locale. This equivalence
-was conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
+Scott domain and the “spectral points” of its Scott locale. This equivalence was
+conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
 
 The formalization of the proof was completed on 2024-05-28.
 
@@ -125,9 +125,9 @@ module Sharp-Element-Spectral-Point-Equivalence
 
 \end{code}
 
-The following is a bit of preparation for the proofs. We open up relevant proofs
-and define abbreviations for them for the sake of readability and
-self-containment.
+The following is a bit of preparation for the proofs. We open up relevant
+modules and define abbreviations for constructions that we use for the sake of
+readability and self-containment.
 
 \begin{code}
 
@@ -194,8 +194,8 @@ it is a proposition (called `prop-valuedness` in the domain theory development).
 
 \section{Definition of sharpness}
 
-We now define what it means for an element to be _sharp_ as defined by de Jong
-[1].
+We now define what it means for an element to be _sharp_, following the work of
+de Jong [1].
 
 \begin{code}
 
@@ -249,8 +249,8 @@ We now define the type `♯𝓓` of sharp elements of the Scott domain `𝓓`.
 \end{code}
 
 We usually pattern match on the inhabitants of `♯𝓓` to refer to the first
-component. But if the need arises, we denote the underlying element of
-a sharp element `𝓍` by `⦅ 𝓍 ⦆`.
+component. But if the need arises, we denote the underlying element of a sharp
+element `𝓍` by `⦅ 𝓍 ⦆`.
 
 \begin{code}
 
@@ -269,8 +269,8 @@ a sharp element `𝓍` by `⦅ 𝓍 ⦆`.
 
 \section{Characterization of sharp elements}
 
-In this section, we give a characterization of sharp elements that we use when
-constructing the equivalence (which we do in the next section).
+In this section, we give a characterization of sharp elements which we use
+when constructing the equivalence (in the next section).
 
 We define the following predicate expressing that an element `x` has decidable
 membership in compact Scott opens.
@@ -376,8 +376,8 @@ is a potentially useful observation.
 \end{code}
 
 What can be said about the converse of this implication? In other words, what is
-the meaning of the set of elements of the domain that admit decidable membership
-in Scott clopens. I do not know the answer yet.
+the meaning of the set of elements that admit decidable membership in Scott
+clopens. I do not know the answer yet.
 
 \section{The equivalence}
 
@@ -456,7 +456,8 @@ We now define the map `sharp` going in the opposite direction.
 
 \end{code}
 
-The following lemma says if `sharp(ℱ) ∈ 𝔘` then `U ∈ ℱ`.
+The following lemma says if `sharp(ℱ) ∈ 𝔘` then `U ∈ ℱ`, for every point `ℱ` and
+every Scott open `𝔘`.
 
 \begin{code}
 
@@ -485,13 +486,15 @@ The following lemma says if `sharp(ℱ) ∈ 𝔘` then `U ∈ ℱ`.
 
 \end{code}
 
-As an immediate special case of this lemma, we obtain the following lemma
-which we record explicitly.
+As an immediate special case of this lemma, we obtain the following which we
+record explicitly.
 
 \begin{code}
 
  below-sharp-implies-in-point
-  : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
+  : (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+  → (c : ⟨ 𝓓 ⟩∙)
+  → (𝕜 : is-compact 𝓓 c)
   → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
   → F ↑ˢ[ c , 𝕜 ] holds
  below-sharp-implies-in-point ℱ@(F , 𝒽) c 𝕜 =
@@ -501,14 +504,14 @@ which we record explicitly.
 
 \end{code}
 
-In fact, it can be generalized to finite joins of compact element i.e. compact
-Scott opens.
+In fact, it can be generalized to finite joins of principal filters on compact
+elements i.e. compact Scott opens.
 
 \begin{code}
 
  in-point-implies-below-sharp⋆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
                               → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
- in-point-implies-below-sharp⋆ []       ℱ@(F , _) p = 𝟘-elim Ⅰ
+ in-point-implies-below-sharp⋆ [] ℱ@(F , _) p = 𝟘-elim Ⅰ
   where
    φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
@@ -612,8 +615,8 @@ that it always gives sharp elements.
 
 \subsection{A useful lemma}
 
-We now prove some useful lemmas that we use in showing that these two maps
-form an equivalence.
+We now prove a lemma which we use when showing that these two maps form an
+equivalence.
 
 Given a sharp element `𝓍`, the element `sharp (pt 𝓍)` is exactly the join of
 the compact approximants of `𝓍`.

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -648,7 +648,7 @@ type of spectral points.
    open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
 
    † : (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
-   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ (pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p)
+   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ γ
     where
      †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
        → F 𝔘 holds
@@ -657,29 +657,34 @@ type of spectral points.
        q : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
        q x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
 
+     γ : ∥ Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds ∥
+     γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
+
  lemma₆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
         → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
- lemma₆ []       ℱ@(F , _) p = 𝟘-elim quux
+ lemma₆ []       ℱ@(F , _) p = 𝟘-elim Ⅰ
   where
    φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
    φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
 
-   baz : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
-   baz = transport _holds (frame-homomorphisms-preserve-bottom ℱ) φ
+   Ⅱ : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
+   Ⅱ = transport _holds (frame-homomorphisms-preserve-bottom ℱ) φ
 
-   quux : ⊥ₚ holds
-   quux = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) baz
+   Ⅰ : ⊥ₚ holds
+   Ⅰ = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) Ⅱ
 
  lemma₆ (k ∷ ks) ℱ@(F , _) p =
   ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ (transport _holds ♠ p)
    where
     ♠ : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
-    ♠ = F (𝜸 (k ∷ ks))                     ＝⟨ ap F (𝜸-equal-to-𝜸₁ (k ∷ ks)) ⟩
-        F (𝜸₁ (k ∷ ks))                    ＝⟨ frame-homomorphisms-preserve-binary-joins ℱ _ _  ⟩
+    ♠ = F (𝜸 (k ∷ ks))                     ＝⟨ Ⅰ ⟩
+        F (𝜸₁ (k ∷ ks))                    ＝⟨ Ⅱ ⟩
         F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
         F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
         F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
          where
+          Ⅰ = ap F (𝜸-equal-to-𝜸₁ (k ∷ ks))
+          Ⅱ = frame-homomorphisms-preserve-binary-joins ℱ _ _
           Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
           Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
 
@@ -694,7 +699,7 @@ type of spectral points.
     open Spectral-Point Scott⦅𝓓⦆ ℱ renaming (point-fn to F; point to ℱ₀)
 
     † : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → (sharp₀ ℱ₀ ∈ₛ 𝔘) ＝ F 𝔘
-    † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) nts
+    † 𝔘@(U , s) = transport (λ - → (sharp₀ ℱ₀ ∈ₛ -) ＝ F -) (q ⁻¹) ‡
      where
       S : Fam 𝓤 ⟨ 𝒪 Scott⦅𝓓⦆ ⟩
       S = covering-familyₛ Scott⦅𝓓⦆ σᴰ 𝔘
@@ -702,23 +707,36 @@ type of spectral points.
       q : 𝔘 ＝ ⋁[ 𝒪 Scott⦅𝓓⦆ ] S
       q = basisₛ-covers-do-cover-eq Scott⦅𝓓⦆ σᴰ 𝔘
 
-      nts₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
-      nts₁ k = ∣ k , lemma₅ (S [ k ]) ℱ₀ ∣
+      ‡₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
+      ‡₁ k = ∣ k , lemma₅ (S [ k ]) ℱ₀ ∣
 
-      nts₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
-      nts₂ (ks , p) = ∣ (ks , p) , lemma₆ ks ℱ₀ ∣
+      ‡₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
+      ‡₂ (ks , p) = ∣ (ks , p) , lemma₆ ks ℱ₀ ∣
 
-      nts : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
-      nts = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)               ＝⟨ refl ⟩
-            pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)           ＝⟨ Ⅰ    ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ Ⅳ    ⟩
-            ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ    ⟩
-            F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                          ∎
-             where
-              Ⅰ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt[ sharp ℱ ] S
-              Ⅳ = bicofinal-implies-same-join (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ nts₁ nts₂
-              Ⅴ = frame-homomorphisms-preserve-all-joins′ (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) ℱ₀ S ⁻¹
+      ‡ : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
+      ‡ = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)               ＝⟨ refl ⟩
+          pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)           ＝⟨ Ⅰ    ⟩
+          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
+          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ Ⅳ    ⟩
+          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ    ⟩
+          F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                          ∎
+           where
+            Ⅰ = frame-homomorphisms-preserve-all-joins′
+                 (𝒪 Scott⦅𝓓⦆)
+                 (𝟎-𝔽𝕣𝕞 pe)
+                 pt[ sharp ℱ ]
+                 S
+            Ⅳ = bicofinal-implies-same-join
+                 (𝟎-𝔽𝕣𝕞 pe)
+                 ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆
+                 ⁅ F 𝔘 ∣ 𝔘 ε S ⁆
+                 ‡₁
+                 ‡₂
+            Ⅴ = frame-homomorphisms-preserve-all-joins′
+                 (𝒪 Scott⦅𝓓⦆)
+                 (𝟎-𝔽𝕣𝕞 pe)
+                 ℱ₀
+                 S ⁻¹
 
  ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point Scott⦅𝓓⦆
  ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -9,7 +9,7 @@ This module contains the proof of equivalence between the sharp elements of a
 Scott domain and the “spectral points” of its Scott locale. This equivalence
 was conjectured by Martín Escardó and proved by Ayberk Tosun on 2024-03-15.
 
-The formalization of the proof was completed on 2024-05-28
+The formalization of the proof was completed on 2024-05-28.
 
 \begin{code}[hide]
 
@@ -124,9 +124,9 @@ module Sharp-Element-Spectral-Point-Equivalence
 
 \end{code}
 
-The following is a bit of preparation for the development of the proofs. We open
-up relevant proofs and define abbreviations for them for the sake of readability
-and self-containment.
+The following is a bit of preparation for the proofs. We open up relevant proofs
+and define abbreviations for them for the sake of readability and
+self-containment.
 
 \begin{code}
 
@@ -144,13 +144,13 @@ We denote by `Scott⦅𝓓⦆` the Scott locale of domain `𝓓`.
 \end{code}
 
 For the frame of opens of the Scott locale `Scott⦅𝓓⦆`, we reserve the notation
-`σ[𝓓]`. This notation differs from other uses in TypeTopology, but it should be
+`σ⦅𝓓⦆`. This notation differs from other uses in TypeTopology, but it should be
 the standard one and the notation elsewhere should be updated to use this one.
 
 \begin{code}
 
- σ[𝓓] : Frame (𝓤 ⁺) 𝓤 𝓤
- σ[𝓓] = 𝒪 Scott⦅𝓓⦆
+ σ⦅𝓓⦆ : Frame (𝓤 ⁺) 𝓤 𝓤
+ σ⦅𝓓⦆ = 𝒪 Scott⦅𝓓⦆
 
  open SpectralScottLocaleConstruction  𝓓 hl hscb dc bc pe hiding (scb; σᴰ)
 
@@ -160,6 +160,12 @@ the standard one and the notation elsewhere should be updated to use this one.
 
  σᴰ : spectralᴰ Scott⦅𝓓⦆
  σᴰ = scott-locale-spectralᴰ
+
+\end{code}
+
+The family `basis` given below is the basis of the Scott locale of domain `𝓓`.
+
+\begin{code}
 
  basis : Fam 𝓤 ⟨ 𝒪 Scott⦅𝓓⦆ ⟩
  basis = basisₛ Scott⦅𝓓⦆ σᴰ
@@ -187,7 +193,8 @@ it is a proposition (called `prop-valuedness` in the domain theory development).
 
 \section{Definition of sharpness}
 
-We now define what it means for an element to be _sharp_.
+We now define what it means for an element to be _sharp_ as defined by de Jong
+[1].
 
 \begin{code}
 
@@ -249,10 +256,6 @@ a sharp element `𝓍` by `⦅ 𝓍 ⦆`.
  ⦅_⦆ : ♯𝓓 → ⟨ 𝓓 ⟩∙
  ⦅_⦆ (x , _) = x
 
-\end{code}
-
-\begin{code}
-
  abstract
   to-sharp-＝ : (𝓍 𝓎 : ♯𝓓) → pr₁ 𝓍 ＝ pr₁ 𝓎 → 𝓍 ＝ 𝓎
   to-sharp-＝ 𝓍 𝓎 = to-subtype-＝ (holds-is-prop ∘ is-sharp)
@@ -278,10 +281,6 @@ membership in compact Scott opens.
  admits-decidable-membership-in-compact-scott-opens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
  admits-decidable-membership-in-compact-scott-opens x =
   Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-compact-open Scott⦅𝓓⦆ 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
-
- admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
- admits-decidable-membership-in-scott-clopens x =
-  Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-clopen (𝒪 Scott⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
 \end{code}
 
@@ -341,12 +340,20 @@ compact Scott opens are _exactly_ the sharp elements.
 
 \end{code}
 
-\section{A small digression}
+\subsection{A corollary of the characterization}
 
-Because clopens are compact in compact frames, we can also give as a necessary
-condition that sharp elements admit decidable membership in Scott clopens.
+Because clopens are compact in compact frames, we can also prove that admitting
+decidable membership in Scott clopens is a necessary condition for an element of
+the domain to be sharp.
+
+We do not need this result in the present development, but we note it down as it
+is a potentially useful observation.
 
 \begin{code}
+
+ admits-decidable-membership-in-scott-clopens : ⟨ 𝓓 ⟩∙ → Ω (𝓤 ⁺)
+ admits-decidable-membership-in-scott-clopens x =
+  Ɐ 𝒦 ꞉ ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ , is-clopen (𝒪 Scott⦅𝓓⦆) 𝒦 ⇒ is-decidableₚ (x ∈ₛ 𝒦)
 
  admits-decidable-membership-in-scott-clopens-implies-is-sharp
   : (x : ⟨ 𝓓 ⟩∙)
@@ -371,12 +378,10 @@ What can be said about the converse of this implication? In other words, what is
 the meaning of the set of elements of the domain that admit decidable membership
 in Scott clopens. I do not know the answer yet.
 
-\section{Some useful lemmas}
-
 \section{The equivalence}
 
-We now start constructing an equivalence between the type `Spectral-Point Scott⦅𝓓⦆`
-and the type `♯𝓓`.
+We now start constructing an equivalence between the type
+`Spectral-Point Scott⦅𝓓⦆` and the type `♯𝓓`.
 
 This equivalence consists of the maps:
 
@@ -388,15 +393,16 @@ We now construct these maps in this order.
 \subsection{Definition of the map `𝓅𝓉`}
 
 We follow our usual convention denoting by the subscript `₀` the preliminary
-version of the construction of interest, which is then packaged up with a proof.
+version of the construction of interest, which is then packaged up with a proof
+that it satisfies some property.
 
 \begin{code}
 
  pt₀[_] : ⟨ 𝓓 ⟩∙ → ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ → Ω 𝓤
  pt₀[_] x U = x ∈ₛ U
 
- open FrameHomomorphisms
  open FrameHomomorphismProperties (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe)
+ open FrameHomomorphisms
 
  pt[_] : ♯𝓓 → Point Scott⦅𝓓⦆
  pt[_] 𝓍@(x , 𝕤) = pt₀[ x ] , †
@@ -412,13 +418,6 @@ version of the construction of interest, which is then packaged up with a proof.
 
    † : is-a-frame-homomorphism (𝒪 Scott⦅𝓓⦆) (𝟎-𝔽𝕣𝕞 pe) pt₀[ x ] holds
    † = refl , (λ _ _ → refl) , ‡
-
-\end{code}
-
-For any sharp element `𝓍` and any compact Scott open `𝒦`, `𝓍 ∈ 𝒦` is a decidable
-proposition.
-
-\begin{code}
 
  open BottomLemma 𝓓 𝕒 hl
 
@@ -461,32 +460,54 @@ We now define the map `sharp` going in the opposite direction.
 
 \end{code}
 
-We prove the following lemma which says `c ⊑ sharp(ℱ)` if and only if `ℱ(↑c)`,
-for every compact element `c` of the domain `𝓓`.
+The following lemma says if `sharp(ℱ) ∈ 𝔘` then `U ∈ ℱ`.
 
 \begin{code}
 
- below-sharp-implies-in-point₁
+ open PropertiesAlgebraic 𝓓 𝕒 hiding (is-compactₚ)
+
+ sharp-in-scott-open-implies-in-point
+  : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩)
+  → (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+  → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+ sharp-in-scott-open-implies-in-point 𝔘 ℱ@(F , 𝒽) = †
+  where
+   open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
+
+   † : (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
+   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ γ
+    where
+     †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
+       → F 𝔘 holds
+     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) q b
+      where
+       q : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
+       q x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
+
+     γ : ∥ Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds ∥
+     γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
+
+\end{code}
+
+As an immediate special case of this lemma, we obtain the following lemma
+which we record explicitly.
+
+\begin{code}
+
+ below-sharp-implies-in-point
   : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
   → c ⊑⟨ 𝓓 ⟩ sharp₀ ℱ
   → F ↑ˢ[ c , 𝕜 ] holds
- below-sharp-implies-in-point₁ ℱ@(F , 𝒽) c 𝕜 p =
-  ∥∥-rec (holds-is-prop (F ↑ˢ[ c , 𝕜 ])) † γ
+ below-sharp-implies-in-point ℱ@(F , 𝒽) c 𝕜 =
+  sharp-in-scott-open-implies-in-point ↑ˢ[ 𝔠 ] ℱ
    where
     𝔠 = (c , 𝕜)
 
-    open 𝒪ₛᴿ (to-𝒪ₛᴿ ↑ˢ[ c , 𝕜 ])
+\end{code}
 
-    γ : ∃ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
-    γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
+The converse of this special case is true as well.
 
-    † : Σ (i , _) ꞉ (index (𝒦-in-point ℱ)) , c ⊑⟨ 𝓓 ⟩ (B𝓓 [ i ])
-      → F ↑ˢ[ 𝔠 ] holds
-    † ((i , p) , φ) =
-     frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ i ] , ↑ˢ[ 𝔠 ]) ‡ p
-      where
-       ‡ : (↑ˢ[ βₖ i ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] ↑ˢ[ 𝔠 ]) holds
-       ‡ = principal-filter-is-antitone c (B𝓓 [ i ]) φ 𝕜 (basis-is-compact i)
+\begin{code}
 
  in-point-implies-below-sharp
   : (ℱ@(F , _) : Point Scott⦅𝓓⦆) (c : ⟨ 𝓓 ⟩∙) (𝕜 : is-compact 𝓓 c)
@@ -511,6 +532,44 @@ for every compact element `c` of the domain `𝓓`.
 
 \end{code}
 
+In fact, it can be generalized to finite joins of compact elements
+
+\begin{code}
+
+ in-point-implies-below-sharp⋆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
+                              → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
+ in-point-implies-below-sharp⋆ []       ℱ@(F , _) p = 𝟘-elim Ⅰ
+  where
+   φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
+   φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
+
+   Ⅱ : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
+   Ⅱ = transport _holds (frame-homomorphisms-preserve-bottom ℱ) φ
+
+   Ⅰ : ⊥ₚ holds
+   Ⅰ = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) Ⅱ
+
+ in-point-implies-below-sharp⋆ (k ∷ ks) ℱ@(F , _) p =
+  ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ (transport _holds ♠ p)
+   where
+    ♠ : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
+    ♠ = F (𝜸 (k ∷ ks))                     ＝⟨ Ⅰ ⟩
+        F (𝜸₁ (k ∷ ks))                    ＝⟨ Ⅱ ⟩
+        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
+        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
+        F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
+         where
+          Ⅰ = ap F (𝜸-equal-to-𝜸₁ (k ∷ ks))
+          Ⅱ = frame-homomorphisms-preserve-binary-joins ℱ _ _
+          Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
+          Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
+
+    ‡ : F ↑ᵏ[ k ] holds + F (𝜸 ks) holds → (sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)) holds
+    ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
+    ‡ (inr q) = ∣ inr (in-point-implies-below-sharp⋆ ks ℱ q) ∣
+
+\end{code}
+
 The map `sharp₀` always gives sharp elements.
 
 \begin{code}
@@ -530,7 +589,7 @@ The map `sharp₀` always gives sharp elements.
    case₁ = inl ∘ in-point-implies-below-sharp ℱ c 𝕜
 
    case₂ : ¬ (F ↑ˢ[ c , 𝕜 ] holds) → is-decidableₚ (c ⊑ sharp₀ ℱ) holds
-   case₂ χ = inr (χ ∘ below-sharp-implies-in-point₁ ℱ c 𝕜)
+   case₂ χ = inr (χ ∘ below-sharp-implies-in-point ℱ c 𝕜)
 
 \end{code}
 
@@ -547,63 +606,56 @@ that it always gives sharp elements and denote it by `sharp`.
 
 \end{code}
 
-We now proceed to prove that the type of sharp elements is equivalent to the
-type of spectral points.
+\subsection{Some lemmas}
+
+We now prove some useful lemmas that we use in the equivalence proof.
+
+Given a sharp element `𝓍`, the element `sharp (pt 𝓍)` is exactly the join of
+the compact approximants of `𝓍`.
 
 \begin{code}
 
- abstract
-  lemma₁ : (x : ⟨ 𝓓 ⟩∙) (𝕤 : is-sharp x holds) (c : ⟨ 𝓓 ⟩∙)
-         → is-compact 𝓓 c
-         → c ⊑⟨ 𝓓 ⟩ x
-         → c ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
-  lemma₁ x 𝕤 c κ p = ∥∥-rec (prop-valuedness 𝓓 c (sharp₀ pt[ x , 𝕤 ])) † γ
+ sharp-equal-to-join-of-covering-family
+  : (𝓍 : ♯𝓓)
+  → ∐ 𝓓 (↓ᴮₛ-is-directed ⦅ 𝓍 ⦆) ＝ sharp₀ pt[ 𝓍 ]
+ sharp-equal-to-join-of-covering-family (x , 𝕤) =
+  antisymmetry 𝓓 (∐ 𝓓 (↓ᴮₛ-is-directed x)) (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) † ‡
    where
-    † : Σ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c → (c ⊑ sharp₀ pt[ x , 𝕤 ]) holds
-    † (i , q) = transport (λ - → underlying-order 𝓓 - (sharp₀ pt[ x , 𝕤 ])) q ‡
-     where
-      r : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ x
-      r = transport (λ - → - ⊑⟨ 𝓓 ⟩ x) (q ⁻¹) p
+    γ : ((i , _) : ↓ᴮₛ x) → (sharp₀ pt[ x , 𝕤 ] ∈ₛ ↑ˢ[ βₖ i ]) holds
+    γ (i , q) = in-point-implies-below-sharp
+                 pt[ x , 𝕤 ]
+                 (B𝓓 [ i ])
+                 (basis-is-compact i)
+                 (⊑ᴮₛ-to-⊑ᴮ q)
 
-      ‡ : (B𝓓 [ i ]) ⊑⟨ 𝓓 ⟩ sharp₀ pt[ x , 𝕤 ]
-      ‡ = sup-is-upperbound
-           (underlying-order 𝓓)
-           (⋁-is-sup (𝒦-in-point↑ pt[ x , 𝕤 ])) (i , r)
+    δ : is-upperbound
+         (underlying-order 𝓓)
+         (∐ 𝓓 (↓ᴮₛ-is-directed x))
+         (𝒦-in-point pt[ x , 𝕤 ] [_])
+    δ (i , q) = ∐-is-upperbound 𝓓 (↓ᴮₛ-is-directed x) (i , ⊑ᴮ-to-⊑ᴮₛ q)
 
-    γ : ∃ i ꞉ index B𝓓 , B𝓓 [ i ] ＝ c
-    γ = small-compact-basis-contains-all-compact-elements 𝓓 (B𝓓 [_]) scb c κ
+    † : (∐ 𝓓 (↓ᴮₛ-is-directed x)) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
+    † = ∐-is-lowerbound-of-upperbounds
+         𝓓
+         (↓ᴮₛ-is-directed x)
+         (⋁ 𝒦-in-point↑ pt[ x , 𝕤 ])
+         γ
 
- abstract
-  lemma₄
-   : (𝓍 : ♯𝓓)
-   → ∐ 𝓓 (↓ᴮₛ-is-directed ⦅ 𝓍 ⦆) ＝ ∐ 𝓓 (𝒦-in-point-is-directed pt[ 𝓍 ])
-  lemma₄ (x , 𝕤) =
-   antisymmetry 𝓓 (∐ 𝓓 (↓ᴮₛ-is-directed x)) (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) † ‡
-    where
-     abstract
-      † : (∐ 𝓓 (↓ᴮₛ-is-directed x)) ⊑⟨ 𝓓 ⟩ (⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ])
-      † = ∐-is-lowerbound-of-upperbounds
-           𝓓
-           (↓ᴮₛ-is-directed x)
-           (⋁ 𝒦-in-point↑ pt[ x , 𝕤 ])
-           goal
-            where
-             goal : (i : ↓ᴮₛ x) →
-                     underlying-order 𝓓 (↓-inclusionₛ x i) (⋁ 𝒦-in-point↑ pt[ x , 𝕤 ])
-             goal (i , q) = lemma₁ x 𝕤 (B𝓓 [ i ]) (pr₂ (βₖ i)) (⊑ᴮₛ-to-⊑ᴮ q)
+    ‡ : ((⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) ⊑⟨ 𝓓 ⟩ ∐ 𝓓 (↓ᴮₛ-is-directed x))
+    ‡ = sup-is-lowerbound-of-upperbounds
+         (underlying-order 𝓓)
+         (⋁-is-sup (𝒦-in-point↑ pt[ (x , 𝕤) ]))
+         (∐ 𝓓 (↓ᴮₛ-is-directed x))
+         δ
 
-      ‡ : ((⋁ 𝒦-in-point↑ pt[ (x , 𝕤) ]) ⊑⟨ 𝓓 ⟩ ∐ 𝓓 (↓ᴮₛ-is-directed x))
-      ‡ = sup-is-lowerbound-of-upperbounds
-           (underlying-order 𝓓)
-           (⋁-is-sup (𝒦-in-point↑ pt[ (x , 𝕤) ]))
-           (∐ 𝓓 (↓ᴮₛ-is-directed x))
-           goal
-            where
-             goal : is-upperbound
-                     (underlying-order 𝓓)
-                     (∐ 𝓓 (↓ᴮₛ-is-directed x))
-                     (𝒦-in-point pt[ x , 𝕤 ] [_])
-             goal (i , q) = ∐-is-upperbound 𝓓 (↓ᴮₛ-is-directed x) (i , ⊑ᴮ-to-⊑ᴮₛ q)
+\end{code}
+
+\subsection{The equivalence proof}
+
+The fact that `sharp` is a retraction `𝓅𝓉[_]` follows easily from the lemma
+`sharp-equal-to-join-of-covering-family` above.
+
+\begin{code}
 
  sharp-cancels-pt : (𝓍 : ♯𝓓) → sharp 𝓅𝓉[ 𝓍 ] ＝ 𝓍
  sharp-cancels-pt 𝓍 = to-sharp-＝ (sharp 𝓅𝓉[ 𝓍 ]) 𝓍 †
@@ -613,61 +665,12 @@ type of spectral points.
        ∐ 𝓓 (↓ᴮₛ-is-directed ⦅ 𝓍 ⦆) ＝⟨ Ⅱ ⟩
        ⦅ 𝓍 ⦆                       ∎
         where
-         Ⅰ = lemma₄ 𝓍 ⁻¹
+         Ⅰ = sharp-equal-to-join-of-covering-family 𝓍 ⁻¹
          Ⅱ = ↓ᴮₛ-∐-＝ ⦅ 𝓍 ⦆
 
- open PropertiesAlgebraic 𝓓 𝕒
+\end{code}
 
- lemma₅ : (𝔘 : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
-        → (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
- lemma₅ 𝔘 ℱ@(F , 𝒽) = †
-  where
-   open 𝒪ₛᴿ (to-𝒪ₛᴿ 𝔘)
-
-   † : (sharp₀ ℱ ∈ₛ 𝔘 ⇒ F 𝔘) holds
-   † p = ∥∥-rec (holds-is-prop (F 𝔘)) †₁ γ
-    where
-     †₁ : Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds
-       → F 𝔘 holds
-     †₁ ((a , b) , c) = frame-morphisms-are-monotonic F 𝒽 (↑ˢ[ βₖ a ] , 𝔘) q b
-      where
-       q : (↑ˢ[ βₖ a ] ≤[ poset-of (𝒪 Scott⦅𝓓⦆) ] 𝔘) holds
-       q x = pred-is-upwards-closed (B𝓓 [ a ]) (B𝓓 [ x ]) c
-
-     γ : ∥ Σ i ꞉ index (pr₁ (𝒦-in-point↑ ℱ)) , pred (pr₁ (𝒦-in-point↑ ℱ) [ i ]) holds ∥
-     γ = pred-is-inaccessible-by-dir-joins (𝒦-in-point↑ ℱ) p
-
- lemma₆ : (ks : List (index B𝓓)) (ℱ@(F , _) : Point Scott⦅𝓓⦆)
-        → (F (𝜸 ks) ⇒ sharp₀ ℱ ∈ₛ 𝜸 ks) holds
- lemma₆ []       ℱ@(F , _) p = 𝟘-elim Ⅰ
-  where
-   φ : F 𝟎[ 𝒪 Scott⦅𝓓⦆ ] holds
-   φ = transport (λ - → (F -) holds) (𝜸-equal-to-𝜸₁ []) p
-
-   Ⅱ : 𝟎[ 𝟎-𝔽𝕣𝕞 pe ] holds
-   Ⅱ = transport _holds (frame-homomorphisms-preserve-bottom ℱ) φ
-
-   Ⅰ : ⊥ₚ holds
-   Ⅰ = transport (λ - → - holds) (𝟎-is-⊥ pe ⁻¹) Ⅱ
-
- lemma₆ (k ∷ ks) ℱ@(F , _) p =
-  ∥∥-rec (holds-is-prop ((sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)))) ‡ (transport _holds ♠ p)
-   where
-    ♠ : F (𝜸 (k ∷ ks)) ＝ F ↑ᵏ[ k ] ∨ F (𝜸 ks)
-    ♠ = F (𝜸 (k ∷ ks))                     ＝⟨ Ⅰ ⟩
-        F (𝜸₁ (k ∷ ks))                    ＝⟨ Ⅱ ⟩
-        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸₁ ks)  ＝⟨ Ⅲ ⟩
-        F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F (𝜸 ks)   ＝⟨ Ⅳ ⟩
-        F ↑ᵏ[ k ] ∨ F (𝜸 ks)               ∎
-         where
-          Ⅰ = ap F (𝜸-equal-to-𝜸₁ (k ∷ ks))
-          Ⅱ = frame-homomorphisms-preserve-binary-joins ℱ _ _
-          Ⅲ = ap (λ - → F ↑ᵏ[ k ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] F -) (𝜸-equal-to-𝜸₁ ks ⁻¹)
-          Ⅳ = binary-join-is-disjunction pe (F ↑ᵏ[ k ]) (F (𝜸 ks))
-
-    ‡ : F ↑ᵏ[ k ] holds + F (𝜸 ks) holds → (sharp₀ ℱ ∈ₛ 𝜸 (k ∷ ks)) holds
-    ‡ (inl p) = ∣ inl (∐-is-upperbound 𝓓 (𝒦-in-point-is-directed ℱ) (k , p)) ∣
-    ‡ (inr q) = ∣ inr (lemma₆ ks ℱ q) ∣
+\begin{code}
 
  pt-cancels-sharp : (ℱ : Spectral-Point Scott⦅𝓓⦆) → 𝓅𝓉[ sharp ℱ ] ＝ ℱ
  pt-cancels-sharp ℱ =
@@ -685,17 +688,17 @@ type of spectral points.
       q = basisₛ-covers-do-cover-eq Scott⦅𝓓⦆ σᴰ 𝔘
 
       ‡₁ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ holds
-      ‡₁ k = ∣ k , lemma₅ (S [ k ]) ℱ₀ ∣
+      ‡₁ k = ∣ k , sharp-in-scott-open-implies-in-point (S [ k ]) ℱ₀ ∣
 
       ‡₂ : cofinal-in (𝟎-𝔽𝕣𝕞 pe) ⁅ F 𝔘 ∣ 𝔘 ε S ⁆ ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆ holds
-      ‡₂ (ks , p) = ∣ (ks , p) , lemma₆ ks ℱ₀ ∣
+      ‡₂ (ks , p) = ∣ (ks , p) , in-point-implies-below-sharp⋆ ks ℱ₀ ∣
 
       ‡ : sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S) ＝ F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)
       ‡ = sharp₀ ℱ₀ ∈ₛ (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)               ＝⟨ refl ⟩
           pt₀[ sharp₀ ℱ₀ ] (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)           ＝⟨ Ⅰ    ⟩
           ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ pt₀[ sharp₀ ℱ₀ ] 𝔘 ∣ 𝔘  ε S ⁆  ＝⟨ refl ⟩
-          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ Ⅳ    ⟩
-          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅴ    ⟩
+          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆       ＝⟨ Ⅱ    ⟩
+          ⋁[ 𝟎-𝔽𝕣𝕞 pe ] ⁅ F 𝔘 ∣ 𝔘 ε S ⁆                  ＝⟨ Ⅲ    ⟩
           F (⋁[ 𝒪 Scott⦅𝓓⦆ ] S)                          ∎
            where
             Ⅰ = frame-homomorphisms-preserve-all-joins′
@@ -703,17 +706,24 @@ type of spectral points.
                  (𝟎-𝔽𝕣𝕞 pe)
                  pt[ sharp ℱ ]
                  S
-            Ⅳ = bicofinal-implies-same-join
+            Ⅱ = bicofinal-implies-same-join
                  (𝟎-𝔽𝕣𝕞 pe)
                  ⁅ sharp₀ ℱ₀ ∈ₛ 𝔘 ∣ 𝔘 ε S ⁆
                  ⁅ F 𝔘 ∣ 𝔘 ε S ⁆
                  ‡₁
                  ‡₂
-            Ⅴ = frame-homomorphisms-preserve-all-joins′
+            Ⅲ = frame-homomorphisms-preserve-all-joins′
                  (𝒪 Scott⦅𝓓⦆)
                  (𝟎-𝔽𝕣𝕞 pe)
                  ℱ₀
                  S ⁻¹
+
+\end{code}
+
+Finally, we conclude this development by giving the equivalence between the
+sharp elements and the spectral points.
+
+\begin{code}
 
  ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ : ♯𝓓 ≃ Spectral-Point Scott⦅𝓓⦆
  ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆ = 𝓅𝓉[_] , qinvs-are-equivs 𝓅𝓉[_] †
@@ -722,3 +732,6 @@ type of spectral points.
    † = sharp , sharp-cancels-pt , pt-cancels-sharp
 
 \end{code}
+
+[1]: de Jong, Tom. "Apartness, sharp elements, and the Scott topology of
+     domains." Mathematical Structures in Computer Science 33.7 (2023): 573-604.

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -1,0 +1,52 @@
+---
+title:          Equivalence of sharp elements with spectral points
+author:         Ayberk Tosun
+date-started:   2024-05-26
+---
+
+The formalization of a proof.
+
+\begin{code}
+
+{--# OPTIONS --safe --without-K #--}
+
+open import MLTT.List hiding ([_])
+open import MLTT.Spartan
+open import UF.FunExt
+open import UF.PropTrunc
+open import UF.Size
+open import UF.Subsingletons
+open import UF.UA-FunExt
+open import UF.Univalence
+
+module Locales.Point.SpectralPoint-Definition
+        (pt : propositional-truncations-exist)
+        (fe : Fun-Ext)
+        (pe : Prop-Ext)
+       where
+
+open import Locales.Frame pt fe
+open import Locales.ContinuousMap.Definition pt fe
+open import Locales.InitialFrame pt fe
+open import UF.SubtypeClassifier
+
+\end{code}
+
+\begin{code}
+
+module Notion-Of-Spectral-Point (X : Locale (𝓤 ⁺) 𝓤 𝓤) where
+
+ open ContinuousMaps X (𝟏Loc pe)
+ open Locale
+
+\end{code}
+
+\begin{code}
+
+ record Spectral-Point : {!!}  ̇ where
+  field
+   point : ⟨ 𝒪 X ⟩ → Ω 𝓤
+
+   point-preserves-top : {!!}
+
+\end{code}

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -1,7 +1,7 @@
 ---
 title:          The notion of spectral point
 author:         Ayberk Tosun
-date-started:   2024-05-26
+date-started:   2024-05-27
 ---
 
 A _spectral point_ of a locale `X` is a continuous map `p : 𝟏 → X` whose right

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -4,7 +4,12 @@ author:         Ayberk Tosun
 date-started:   2024-05-26
 ---
 
-The formalization of a proof.
+A _spectral point_ of a locale `X` is a continuous map `p : 𝟏 → X` whose right
+adjoint `p^* : 𝒪(X) → 𝒪(𝟏)` preserves compact opens.
+
+In this module, we give the definition of this notion. We define it using
+records for the sake of convenience, and prove that the record-based definition
+is equivalent to the standard definition.
 
 \begin{code}[hide]
 
@@ -87,10 +92,6 @@ This record-based definition is of course just a more verbose way of writing
  Spectral-Point₀ : 𝓤 ⁺  ̇
  Spectral-Point₀ = Spectral-Map (𝟏Loc pe) X
 
-\end{code}
-
-\begin{code}
-
  to-spectral-point₀ : Spectral-Point → Spectral-Point₀
  to-spectral-point₀ sp = (point-fn , †) , point-preserves-compactness
   where
@@ -98,10 +99,6 @@ This record-based definition is of course just a more verbose way of writing
 
    † : is-a-frame-homomorphism point-fn holds
    † = point-is-a-frame-homomorphism
-
-\end{code}
-
-\begin{code}
 
  to-spectral-point : Spectral-Map (𝟏Loc pe) X → Spectral-Point
  to-spectral-point ((F , α , β , γ) , σ) =
@@ -115,6 +112,8 @@ This record-based definition is of course just a more verbose way of writing
 
 \end{code}
 
+The equivalence proof.
+
 \begin{code}
 
  spectral-point-equivalent-to-spectral-map-into-Ω
@@ -126,6 +125,9 @@ This record-based definition is of course just a more verbose way of writing
     † = to-spectral-point₀ , (λ _ → refl) , (λ _ → refl)
 
 \end{code}
+
+To show that two spectral points are equal, it suffices to show that their
+underlying functions are equal. We call this lemma `to-spectral-point-＝`.
 
 \begin{code}
 

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -1,14 +1,14 @@
 ---
-title:          Equivalence of sharp elements with spectral points
+title:          The notion of spectral point
 author:         Ayberk Tosun
 date-started:   2024-05-26
 ---
 
 The formalization of a proof.
 
-\begin{code}
+\begin{code}[hide]
 
-{--# OPTIONS --safe --without-K #--}
+{-# OPTIONS --safe --without-K #-}
 
 open import MLTT.List hiding ([_])
 open import MLTT.Spartan
@@ -25,28 +25,95 @@ module Locales.Point.SpectralPoint-Definition
         (pe : Prop-Ext)
        where
 
-open import Locales.Frame pt fe
+open import Locales.Compactness pt fe
 open import Locales.ContinuousMap.Definition pt fe
+open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
+open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe
+open import Locales.Spectrality.SpectralMap pt fe
+open import UF.Equiv
 open import UF.SubtypeClassifier
 
+open Locale
+
 \end{code}
+
+We work in a module parameterized by a large and locally small locale `X`.
 
 \begin{code}
 
 module Notion-Of-Spectral-Point (X : Locale (𝓤 ⁺) 𝓤 𝓤) where
 
  open ContinuousMaps X (𝟏Loc pe)
- open Locale
+ open FrameHomomorphisms (𝒪 X) (𝟎-𝔽𝕣𝕞 pe)
+
+\end{code}
+
+A _spectral point_ of locale `X` is a frame homomorphism `𝒪(X) → Ω`
+preserving compact opens. In other words, it is a spectral map `𝟏 → X`.
+
+In the following definition, we call the underlying function of this frame
+homomorphism `point-fn.
+
+\begin{code}
+
+ record Spectral-Point : 𝓤 ⁺  ̇ where
+  field
+   point-fn : ⟨ 𝒪 X ⟩ → Ω 𝓤
+
+   point-preserves-top          : preserves-top point-fn holds
+   point-preserves-binary-meets : preserves-binary-meets point-fn holds
+   point-preserves-joins        : preserves-joins point-fn holds
+   point-preserves-compactness  : (K : ⟨ 𝒪 X ⟩)
+                                → is-compact-open X K holds
+                                → is-compact-open (𝟏Loc pe) (point-fn K) holds
+
+  point-is-a-frame-homomorphism : is-a-frame-homomorphism point-fn holds
+  point-is-a-frame-homomorphism = point-preserves-top
+                                , point-preserves-binary-meets
+                                , point-preserves-joins
+
+  point : _─f→_
+  point = point-fn , point-is-a-frame-homomorphism
+
+\end{code}
+
+We now prove the equivalence of this definition
+
+\begin{code}
+
+ to-spectral-map-into-Ω : Spectral-Point → Spectral-Map (𝟏Loc pe) X
+ to-spectral-map-into-Ω sp = (point-fn , †) , point-preserves-compactness
+  where
+   open Spectral-Point sp
+
+   † : is-a-frame-homomorphism point-fn holds
+   † = point-is-a-frame-homomorphism
 
 \end{code}
 
 \begin{code}
 
- record Spectral-Point : {!!}  ̇ where
-  field
-   point : ⟨ 𝒪 X ⟩ → Ω 𝓤
+ to-spectral-point : Spectral-Map (𝟏Loc pe) X → Spectral-Point
+ to-spectral-point ((F , α , β , γ) , σ) =
+  record
+   { point-fn                     = F
+   ; point-preserves-top          = α
+   ; point-preserves-binary-meets = β
+   ; point-preserves-joins        = γ
+   ; point-preserves-compactness  = σ
+   }
 
-   point-preserves-top : {!!}
+\end{code}
+
+\begin{code}
+
+ spectral-point-equivalent-to-spectral-map-into-Ω
+  : Spectral-Map (𝟏Loc pe) X ≃ Spectral-Point
+ spectral-point-equivalent-to-spectral-map-into-Ω =
+  to-spectral-point , qinvs-are-equivs to-spectral-point †
+   where
+    † : qinv to-spectral-point
+    † = to-spectral-map-into-Ω , (λ _ → refl) , (λ _ → refl)
 
 \end{code}

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -78,12 +78,21 @@ homomorphism `point-fn.
 
 \end{code}
 
-We now prove the equivalence of this definition
+This record-based definition is of course just a more verbose way of writing
+“spectral map into the initial frame”. We call this alternative definition
+`Spectral-Point₀` and prove its equivalence to the type `Spectral-Point`.
 
 \begin{code}
 
- to-spectral-map-into-Ω : Spectral-Point → Spectral-Map (𝟏Loc pe) X
- to-spectral-map-into-Ω sp = (point-fn , †) , point-preserves-compactness
+ Spectral-Point₀ : 𝓤 ⁺  ̇
+ Spectral-Point₀ = Spectral-Map (𝟏Loc pe) X
+
+\end{code}
+
+\begin{code}
+
+ to-spectral-point₀ : Spectral-Point → Spectral-Point₀
+ to-spectral-point₀ sp = (point-fn , †) , point-preserves-compactness
   where
    open Spectral-Point sp
 
@@ -109,11 +118,37 @@ We now prove the equivalence of this definition
 \begin{code}
 
  spectral-point-equivalent-to-spectral-map-into-Ω
-  : Spectral-Map (𝟏Loc pe) X ≃ Spectral-Point
+  : Spectral-Point₀ ≃ Spectral-Point
  spectral-point-equivalent-to-spectral-map-into-Ω =
   to-spectral-point , qinvs-are-equivs to-spectral-point †
    where
     † : qinv to-spectral-point
-    † = to-spectral-map-into-Ω , (λ _ → refl) , (λ _ → refl)
+    † = to-spectral-point₀ , (λ _ → refl) , (λ _ → refl)
+
+\end{code}
+
+\begin{code}
+
+ open Spectral-Point
+
+ to-spectral-point-＝ : (ℱ 𝒢 : Spectral-Point)
+                      → point-fn ℱ ＝ point-fn 𝒢
+                      → ℱ ＝ 𝒢
+ to-spectral-point-＝ ℱ 𝒢 p =
+  ℱ                                          ＝⟨ Ⅰ ⟩
+  to-spectral-point (to-spectral-point₀ ℱ)   ＝⟨ Ⅱ ⟩
+  to-spectral-point (to-spectral-point₀ 𝒢)   ＝⟨ Ⅲ ⟩
+  𝒢                                          ∎
+  where
+   e = spectral-point-equivalent-to-spectral-map-into-Ω
+
+   † : to-spectral-point₀ ℱ ＝ to-spectral-point₀ 𝒢
+   † = to-subtype-＝
+        (holds-is-prop ∘ is-spectral-map X (𝟏Loc pe))
+        (to-subtype-＝ (holds-is-prop ∘ is-a-frame-homomorphism) p)
+
+   Ⅰ = inverses-are-sections' e ℱ
+   Ⅱ = ap to-spectral-point †
+   Ⅲ = inverses-are-sections' e 𝒢 ⁻¹
 
 \end{code}

--- a/source/Locales/TerminalLocale/Properties.lagda
+++ b/source/Locales/TerminalLocale/Properties.lagda
@@ -48,7 +48,7 @@ open import UF.SubtypeClassifier
 
 open AllCombinators pt fe
 open Locale
-open PropositionalTruncation pt
+open PropositionalTruncation pt hiding (_∨_; ∨-elim)
 
 module _ (pe : propext 𝓤) where
 
@@ -126,6 +126,31 @@ this fact is not a definitional equality.
            (holds-gives-equal-⊤ pe fe _ ((λ ()) , 𝟎-is-bottom (𝒪 (𝟏Loc pe)) ⊥))
 
 \end{code}
+
+Added on 2024-05-28.
+
+The following is probably written down somewhere else, but this is the right
+place for it.
+
+\begin{code}
+
+ binary-join-is-disjunction : (P Q : ⟨ 𝒪 (𝟏Loc pe) ⟩)
+                            → P ∨[ 𝟎-𝔽𝕣𝕞 pe ] Q ＝ P ∨ Q
+ binary-join-is-disjunction P Q =
+  ⋁[ 𝟎-𝔽𝕣𝕞 pe ]-unique ⁅ P , Q ⁆ (P ∨ Q) (υ , φ) ⁻¹
+   where
+    open Joins (λ x y → x ≤[ poset-of (𝟎-𝔽𝕣𝕞 pe) ] y)
+
+    υ : ((P ∨ Q) is-an-upper-bound-of ⁅ P , Q ⁆) holds
+    υ ₀ p = ∣ inl p ∣
+    υ ₁ q = ∣ inr q ∣
+
+    φ : ((R , _) : upper-bound ⁅ P , Q ⁆) → ((P ∨ Q) ⇒ R) holds
+    φ (R , ψ) = ∨-elim P Q R (ψ (inl ⋆)) (ψ (inr ⋆))
+
+\end{code}
+
+End of addition
 
 Every compact open of the initial frame is a clopen i.e. is a complemented
 proposition.

--- a/source/Locales/index.lagda
+++ b/source/Locales/index.lagda
@@ -125,5 +125,6 @@ import Locales.DirectedFamily-Poset
 import Locales.StoneDuality.ForSpectralLocales
 
 import Locales.LawsonLocale.CompactElementsOfPoint
+import Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints
 
 \end{code}

--- a/source/Locales/index.lagda
+++ b/source/Locales/index.lagda
@@ -101,8 +101,8 @@ import Locales.Spectrality.LatticeOfCompactOpens
 import Locales.Spectrality.SpectralMapToLatticeHomomorphism
 
 import Locales.Point.Definition                  -- (36)
-
 import Locales.Point.Properties                  -- (37)
+import Locales.Point.SpectralPoint-Definition
 
 import Locales.TerminalLocale.Properties
 

--- a/source/UF/Logic.lagda
+++ b/source/UF/Logic.lagda
@@ -203,6 +203,22 @@ module Disjunction (pt : propositional-truncations-exist) where
 
 \end{code}
 
+Added by Ayberk Tosun 2024-05-28.
+
+\begin{code}
+
+ ∨-elim : (P : Ω 𝓤) (Q : Ω 𝓥) (R : Ω 𝓦)
+        → (P holds → R holds)
+        → (Q holds → R holds)
+        → ((P ∨ Q) holds → R holds)
+ ∨-elim P Q R φ ψ = ∥∥-rec (holds-is-prop R) †
+  where
+   † : P holds + Q holds → R holds
+   † (inl p) = φ p
+   † (inr q) = ψ q
+
+\end{code}
+
 \section{Truncation}
 
 \begin{code}


### PR DESCRIPTION
This pull request adds a new module, named `Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints`, containing the following new result:

---

Given any Scott domain $\mathcal{D}$ (satisfying the usual decidability condition), the type of _sharp elements_ of $\mathcal{D}$ is equivalent to the type of _spectral points_ of the Scott locale of $\mathcal{D}$.

---

The proof is at the end of the mentioned module and is called `♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆`.