### PR TITLE
Prove equivalence between sharp elements and the points of patch

### DIFF
--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -105,15 +105,15 @@ module points-of-patch-are-spectral-points
  zd : zero-dimensionalᴰ {𝓤 ⁺} (𝒪 (𝟏Loc pe))
  zd = 𝟏-zero-dimensionalᴰ pe
 
- open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe
+ open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe renaming (σ⦅𝓓⦆ to Scott⦅𝓓⦆)
  open Notion-Of-Spectral-Point
- open SmallPatchConstruction σ⦅𝓓⦆ scott-locale-spectralᴰ
+ open SmallPatchConstruction Scott⦅𝓓⦆ scott-locale-spectralᴰ
  open Preliminaries
- open UniversalProperty σ⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
+ open UniversalProperty Scott⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
  open ContinuousMaps
- open ClosedNucleus σ⦅𝓓⦆ scott-locale-is-spectral
- open Epsilon σ⦅𝓓⦆ scott-locale-spectralᴰ
- open PatchStoneᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ
+ open ClosedNucleus Scott⦅𝓓⦆ scott-locale-is-spectral
+ open Epsilon Scott⦅𝓓⦆ scott-locale-spectralᴰ
+ open PatchStoneᴰ Scott⦅𝓓⦆ scott-locale-spectralᴰ
 
 \end{code}
 
@@ -134,11 +134,11 @@ We now instantiate to the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to 
 
 \begin{code}
 
- patch-ump : (𝓅 : 𝟏Loc pe ─c→ σ⦅𝓓⦆)
-           → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
-           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
+ patch-ump : (𝓅 : 𝟏Loc pe ─c→ Scott⦅𝓓⦆)
+           → is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
+           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
  patch-ump = ump-of-patch
-              σ⦅𝓓⦆
+              Scott⦅𝓓⦆
               scott-locale-is-spectral
               scott-locale-has-small-𝒦
               (𝟏Loc pe)
@@ -151,7 +151,7 @@ This universal property immediately gives us a map from the spectral points of
 
 \begin{code}
 
- to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+ to-patch-point : Spectral-Point Scott⦅𝓓⦆ → Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
  to-patch-point ℱ = to-spectral-point Patch⦅Scott⦅𝓓⦆⦆ (𝓅 , †)
   where
    open Spectral-Point ℱ renaming (point to F; point-preserves-compactness to 𝕤)
@@ -172,12 +172,12 @@ The proof below should be placed in a more appropriate place.
 
 \begin{code}
 
- ϵ-is-a-spectral-map : is-spectral-map σ⦅𝓓⦆ Patch⦅Scott⦅𝓓⦆⦆ ϵ holds
+ ϵ-is-a-spectral-map : is-spectral-map Scott⦅𝓓⦆ Patch⦅Scott⦅𝓓⦆⦆ ϵ holds
  ϵ-is-a-spectral-map =
   perfect-maps-are-spectral
    Patch⦅Scott⦅𝓓⦆⦆
-   σ⦅𝓓⦆
-   ∣ spectralᴰ-implies-basisᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ ∣
+   Scott⦅𝓓⦆
+   ∣ spectralᴰ-implies-basisᴰ Scott⦅𝓓⦆ scott-locale-spectralᴰ ∣
    ϵ
    ϵ-is-a-perfect-map
 
@@ -185,15 +185,15 @@ The proof below should be placed in a more appropriate place.
 
 \begin{code}
 
- to-scott-point : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point σ⦅𝓓⦆
- to-scott-point ℱ⁻ₛ = to-spectral-point σ⦅𝓓⦆ (ℱ , 𝕤)
+ to-scott-point : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point Scott⦅𝓓⦆
+ to-scott-point ℱ⁻ₛ = to-spectral-point Scott⦅𝓓⦆ (ℱ , 𝕤)
   where
    open Spectral-Point ℱ⁻ₛ renaming (point to ℱ⁻)
 
-   ℱ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
-   ℱ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ σ⦅𝓓⦆ ϵ ℱ⁻
+   ℱ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
+   ℱ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ ℱ⁻
 
-   𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
+   𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) ℱ holds
    𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
 
 \end{code}
@@ -207,15 +207,15 @@ The proof below should be placed in a more appropriate place.
    open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
 
    † : to-scott-point ∘ to-patch-point ∼ id
-   † ℱ = to-spectral-point-＝ σ⦅𝓓⦆ (to-scott-point (to-patch-point ℱ)) ℱ ♢
+   † ℱ = to-spectral-point-＝ Scott⦅𝓓⦆ (to-scott-point (to-patch-point ℱ)) ℱ ♢
     where
      open Spectral-Point using (point; point-fn; point-preserves-compactness)
      open Spectral-Point ℱ using () renaming (point-fn to F)
 
-     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) (point ℱ) holds
+     𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) (point ℱ) holds
      𝕤 K κ = point-preserves-compactness ℱ K κ
 
-     γ : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩)
+     γ : (U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩)
        → point-fn (to-scott-point (to-patch-point ℱ)) U ＝ F U
      γ U = pr₂ (description (patch-ump (point ℱ) 𝕤)) U ⁻¹
 
@@ -232,21 +232,21 @@ The proof below should be placed in a more appropriate place.
      open Spectral-Point 𝓅 renaming (point-fn to p⋆; point to 𝓅⋆)
      open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 Patch⦅Scott⦅𝓓⦆⦆)
 
-     𝓅₀ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
-     𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ σ⦅𝓓⦆ ϵ 𝓅⋆
+     𝓅₀ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
+     𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ 𝓅⋆
 
      p₀ = pr₁ 𝓅₀
 
-     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
+     𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
      𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
 
-     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
+     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
      υ = patch-ump 𝓅₀ 𝕤
 
      𝓅₀⁻ : 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆
      𝓅₀⁻ = ∃!-witness υ
 
-     foo : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’
+     foo : (U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’
      foo U = refl
 
      γ : 𝓅⋆ ＝ 𝓅₀⁻

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -117,7 +117,7 @@ module points-of-patch-are-spectral-points
 
 \end{code}
 
-We define an abbreviation for `Patch(Scott(𝓓))`
+We define an alias for `Patch(Scott(𝓓))`
 
 \begin{code}
 
@@ -127,36 +127,44 @@ We define an abbreviation for `Patch(Scott(𝓓))`
  Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ : stoneᴰ Patch⦅Scott⦅𝓓⦆⦆
  Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ = patchₛ-is-compact , patchₛ-zero-dimensionalᴰ
 
+\end{code}
+
+We now instantiate to the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to points
+`𝟏 → Scott⦅𝓓⦆`.
+
+\begin{code}
+
  patch-ump : (𝓅 : 𝟏Loc pe ─c→ σ⦅𝓓⦆)
            → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
            → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
- patch-ump 𝓅 σ = ump-of-patch
-                  σ⦅𝓓⦆
-                  scott-locale-is-spectral
-                  scott-locale-has-small-𝒦
-                  (𝟏Loc pe)
-                  (𝟏-is-stone pe)
-                  𝓅
-                  σ
+ patch-ump = ump-of-patch
+              σ⦅𝓓⦆
+              scott-locale-is-spectral
+              scott-locale-has-small-𝒦
+              (𝟏Loc pe)
+              (𝟏-is-stone pe)
 
 \end{code}
+
+This universal property immediately gives us a map from the spectral points of
+`Scott⦅𝓓⦆` into the spectral points of `Patch⦅Scott⦅𝓓⦆⦆`.
 
 \begin{code}
 
  to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
  to-patch-point ℱ = to-spectral-point Patch⦅Scott⦅𝓓⦆⦆ (𝓅 , †)
   where
-   open Spectral-Point ℱ renaming (point to F)
-   open continuous-maps-of-stone-locales (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ (𝟏-stoneᴰ pe) Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ
-
-   𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
-   𝕤 K κ = point-preserves-compactness K κ
+   open Spectral-Point ℱ renaming (point to F; point-preserves-compactness to 𝕤)
+   open continuous-maps-of-stone-locales (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
 
    𝓅 : 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆
    𝓅 = ∃!-witness (patch-ump F 𝕤)
 
    † : is-spectral-map Patch⦅Scott⦅𝓓⦆⦆ (𝟏Loc pe) 𝓅 holds
-   † = continuous-maps-between-stone-locales-are-spectral 𝓅
+   † = continuous-maps-between-stone-locales-are-spectral
+        (𝟏-stoneᴰ pe)
+        Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ
+        𝓅
 
 \end{code}
 
@@ -177,8 +185,8 @@ The proof below should be placed in a more appropriate place.
 
 \begin{code}
 
- to-spectral-point′ : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point σ⦅𝓓⦆
- to-spectral-point′ ℱ⁻ₛ = to-spectral-point σ⦅𝓓⦆ (ℱ , 𝕤)
+ to-scott-point : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point σ⦅𝓓⦆
+ to-scott-point ℱ⁻ₛ = to-spectral-point σ⦅𝓓⦆ (ℱ , 𝕤)
   where
    open Spectral-Point ℱ⁻ₛ renaming (point to ℱ⁻)
 
@@ -193,13 +201,13 @@ The proof below should be placed in a more appropriate place.
 \begin{code}
 
  to-patch-point-qinv : qinv to-patch-point
- to-patch-point-qinv = to-spectral-point′ , † , ‡
+ to-patch-point-qinv = to-scott-point , † , ‡
   where
    open ContinuousMaps
    open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
 
-   † : to-spectral-point′ ∘ to-patch-point ∼ id
-   † ℱ = to-spectral-point-＝ σ⦅𝓓⦆ (to-spectral-point′ (to-patch-point ℱ)) ℱ ♢
+   † : to-scott-point ∘ to-patch-point ∼ id
+   † ℱ = to-spectral-point-＝ σ⦅𝓓⦆ (to-scott-point (to-patch-point ℱ)) ℱ ♢
     where
      open Spectral-Point using (point; point-fn; point-preserves-compactness)
      open Spectral-Point ℱ using () renaming (point-fn to F)
@@ -208,16 +216,16 @@ The proof below should be placed in a more appropriate place.
      𝕤 K κ = point-preserves-compactness ℱ K κ
 
      γ : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩)
-       → point-fn (to-spectral-point′ (to-patch-point ℱ)) U ＝ F U
+       → point-fn (to-scott-point (to-patch-point ℱ)) U ＝ F U
      γ U = pr₂ (description (patch-ump (point ℱ) 𝕤)) U ⁻¹
 
-     ♢ : point-fn (to-spectral-point′ (to-patch-point ℱ)) ＝ F
+     ♢ : point-fn (to-scott-point (to-patch-point ℱ)) ＝ F
      ♢ = dfunext fe γ
 
-   ‡ : to-patch-point ∘ to-spectral-point′ ∼ id
+   ‡ : to-patch-point ∘ to-scott-point ∼ id
    ‡ 𝓅 = to-spectral-point-＝'
           Patch⦅Scott⦅𝓓⦆⦆
-          (to-patch-point (to-spectral-point′ 𝓅))
+          (to-patch-point (to-scott-point 𝓅))
           𝓅
           (γ ⁻¹)
     where

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -121,15 +121,15 @@ We define an abbreviation for `Patch(Scott(𝓓))`
 
 \begin{code}
 
- patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
- patch-σ𝓓 = SmallPatch
+ Patch⦅Scott⦅𝓓⦆⦆ : Locale (𝓤 ⁺) 𝓤 𝓤
+ Patch⦅Scott⦅𝓓⦆⦆ = SmallPatch
 
- patch-σ𝓓-stoneᴰ : stoneᴰ patch-σ𝓓
- patch-σ𝓓-stoneᴰ = patchₛ-is-compact , patchₛ-zero-dimensionalᴰ
+ Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ : stoneᴰ Patch⦅Scott⦅𝓓⦆⦆
+ Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ = patchₛ-is-compact , patchₛ-zero-dimensionalᴰ
 
  patch-ump : (𝓅 : 𝟏Loc pe ─c→ σ⦅𝓓⦆)
            → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
-           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
+           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
  patch-ump 𝓅 σ = ump-of-patch
                   σ⦅𝓓⦆
                   scott-locale-is-spectral
@@ -143,19 +143,19 @@ We define an abbreviation for `Patch(Scott(𝓓))`
 
 \begin{code}
 
- to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point patch-σ𝓓
- to-patch-point ℱ = to-spectral-point patch-σ𝓓 (𝓅 , †)
+ to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+ to-patch-point ℱ = to-spectral-point Patch⦅Scott⦅𝓓⦆⦆ (𝓅 , †)
   where
    open Spectral-Point ℱ renaming (point to F)
-   open continuous-maps-of-stone-locales (𝟏Loc pe) patch-σ𝓓 (𝟏-stoneᴰ pe) patch-σ𝓓-stoneᴰ
+   open continuous-maps-of-stone-locales (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ (𝟏-stoneᴰ pe) Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ
 
    𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
    𝕤 K κ = point-preserves-compactness K κ
 
-   𝓅 : 𝟏Loc pe ─c→ patch-σ𝓓
+   𝓅 : 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆
    𝓅 = ∃!-witness (patch-ump F 𝕤)
 
-   † : is-spectral-map patch-σ𝓓 (𝟏Loc pe) 𝓅 holds
+   † : is-spectral-map Patch⦅Scott⦅𝓓⦆⦆ (𝟏Loc pe) 𝓅 holds
    † = continuous-maps-between-stone-locales-are-spectral 𝓅
 
 \end{code}
@@ -164,10 +164,10 @@ The proof below should be placed in a more appropriate place.
 
 \begin{code}
 
- ϵ-is-a-spectral-map : is-spectral-map σ⦅𝓓⦆ patch-σ𝓓 ϵ holds
+ ϵ-is-a-spectral-map : is-spectral-map σ⦅𝓓⦆ Patch⦅Scott⦅𝓓⦆⦆ ϵ holds
  ϵ-is-a-spectral-map =
   perfect-maps-are-spectral
-   patch-σ𝓓
+   Patch⦅Scott⦅𝓓⦆⦆
    σ⦅𝓓⦆
    ∣ spectralᴰ-implies-basisᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ ∣
    ϵ
@@ -177,13 +177,13 @@ The proof below should be placed in a more appropriate place.
 
 \begin{code}
 
- to-spectral-point′ : Spectral-Point patch-σ𝓓 → Spectral-Point σ⦅𝓓⦆
+ to-spectral-point′ : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point σ⦅𝓓⦆
  to-spectral-point′ ℱ⁻ₛ = to-spectral-point σ⦅𝓓⦆ (ℱ , 𝕤)
   where
    open Spectral-Point ℱ⁻ₛ renaming (point to ℱ⁻)
 
    ℱ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
-   ℱ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ ℱ⁻
+   ℱ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ σ⦅𝓓⦆ ϵ ℱ⁻
 
    𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
    𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
@@ -196,7 +196,7 @@ The proof below should be placed in a more appropriate place.
  to-patch-point-qinv = to-spectral-point′ , † , ‡
   where
    open ContinuousMaps
-   open ContinuousMapNotation (𝟏Loc pe) patch-σ𝓓
+   open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
 
    † : to-spectral-point′ ∘ to-patch-point ∼ id
    † ℱ = to-spectral-point-＝ σ⦅𝓓⦆ (to-spectral-point′ (to-patch-point ℱ)) ℱ ♢
@@ -216,26 +216,26 @@ The proof below should be placed in a more appropriate place.
 
    ‡ : to-patch-point ∘ to-spectral-point′ ∼ id
    ‡ 𝓅 = to-spectral-point-＝'
-          patch-σ𝓓
+          Patch⦅Scott⦅𝓓⦆⦆
           (to-patch-point (to-spectral-point′ 𝓅))
           𝓅
           (γ ⁻¹)
     where
      open Spectral-Point 𝓅 renaming (point-fn to p⋆; point to 𝓅⋆)
-     open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 patch-σ𝓓)
+     open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 Patch⦅Scott⦅𝓓⦆⦆)
 
      𝓅₀ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
-     𝓅₀ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ 𝓅⋆
+     𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ σ⦅𝓓⦆ ϵ 𝓅⋆
 
      p₀ = pr₁ 𝓅₀
 
      𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
      𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
 
-     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
+     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
      υ = patch-ump 𝓅₀ 𝕤
 
-     𝓅₀⁻ : 𝟏Loc pe ─c→ patch-σ𝓓
+     𝓅₀⁻ : 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆
      𝓅₀⁻ = ∃!-witness υ
 
      foo : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -4,6 +4,9 @@ author:         Ayberk Tosun
 date-started:   2024-08-04
 ---
 
+We prove that the sharp elements of a Scott domain `𝓓` are in bijection with the
+points of `Patch(Scott(𝓓))`.
+
 \begin{code}[hide]
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
@@ -83,6 +86,13 @@ open PropositionalTruncation pt hiding (_∨_)
 
 \end{code}
 
+In the module below, we show that points `𝟏 → Patch(Scott(𝓓))` are in
+bijection with spectral points `𝟏 → Scott(𝓓)`. This is done by constructing
+an equivalence
+```
+Point(Patch(Scott(𝓓))) ≃ Spectral-Point(Patch(Scott(𝓓))) ≃ Spectral-Point(Scott(𝓓))
+```
+
 \begin{code}
 
 module points-of-patch-are-spectral-points
@@ -105,6 +115,12 @@ module points-of-patch-are-spectral-points
  open Epsilon σ⦅𝓓⦆ scott-locale-spectralᴰ
  open PatchStoneᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ
 
+\end{code}
+
+We define an abbreviation for `Patch(Scott(𝓓))`
+
+\begin{code}
+
  patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
  patch-σ𝓓 = SmallPatch
 
@@ -122,6 +138,10 @@ module points-of-patch-are-spectral-points
                   (𝟏-is-stone pe)
                   𝓅
                   σ
+
+\end{code}
+
+\begin{code}
 
  to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point patch-σ𝓓
  to-patch-point ℱ = to-spectral-point patch-σ𝓓 (𝓅 , †)

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -187,7 +187,8 @@ This universal property immediately gives us a map from the spectral points of
 
 \end{code}
 
-The proof below should be placed in a more appropriate place.
+Recall that the map `ϵ` denotes the continuous map given by the frame
+homomorphism `x ↦ ‘ x ’`.
 
 \begin{code}
 
@@ -201,6 +202,8 @@ The proof below should be placed in a more appropriate place.
    ϵ-is-a-perfect-map
 
 \end{code}
+
+TODO: The proof above should be placed in a more appropriate place.
 
 We now define the inverse of `to-patch-point`: given a spectral point `𝟏 →
 Patch⦅Scott⦅𝓓⦆⦆`, we can compose this with `ϵ : Patch⦅Scott⦅𝓓⦆⦆ → Scott⦅𝓓⦆` to

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -42,12 +42,14 @@ open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
 open import Locales.Clopen pt fe sr
 open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
 open import Locales.Compactness pt fe hiding (is-compact)
+open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
 open import Locales.PatchLocale pt fe sr
+open import Locales.PatchProperties pt fe sr
 open import Locales.Point.Definition pt fe
 open import Locales.Point.SpectralPoint-Definition pt fe pe
 open import Locales.ScottLocale.Definition pt fe 𝓤
@@ -93,12 +95,23 @@ module points-of-patch-are-spectral-points
  open SmallPatchConstruction σ⦅𝓓⦆ scott-locale-spectralᴰ
  open Preliminaries
  open UniversalProperty σ⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
+ open ContinuousMaps
+ open ClosedNucleus σ⦅𝓓⦆ scott-locale-is-spectral
 
  patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
  patch-σ𝓓 = SmallPatch
 
- patch-ump : {!!}
- patch-ump = {!ump-of-patch σ⦅𝓓⦆ scott-locale-is-spectral ? (𝟏Loc pe) ?!}
+ patch-ump : (𝓅 : 𝟏Loc pe ─c→ σ⦅𝓓⦆)
+           → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
+           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
+ patch-ump 𝓅 σ = ump-of-patch
+                  σ⦅𝓓⦆
+                  scott-locale-is-spectral
+                  scott-locale-has-small-𝒦
+                  (𝟏Loc pe)
+                  (𝟏-is-stone pe)
+                  𝓅
+                  σ
 
  spectral-point-to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
  spectral-point-to-patch-point ℱ = {!ump-of-patch!}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -183,18 +183,35 @@ The proof below should be placed in a more appropriate place.
 
 \end{code}
 
+We now define the inverse of `to-patch-point`: given a spectral point `𝟏 →
+Patch⦅Scott⦅𝓓⦆⦆`, we can compose this with `ϵ : Patch⦅Scott⦅𝓓⦆⦆ → Scott⦅𝓓⦆` to
+obtain a map `𝟏 → Scott⦅𝓓⦆`. We call this map `to-scott-point`.
+
 \begin{code}
 
  to-scott-point : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Spectral-Point Scott⦅𝓓⦆
- to-scott-point ℱ⁻ₛ = to-spectral-point Scott⦅𝓓⦆ (ℱ , 𝕤)
+ to-scott-point 𝓅 = to-spectral-point Scott⦅𝓓⦆ (𝓅₀ , 𝕤)
   where
-   open Spectral-Point ℱ⁻ₛ renaming (point to ℱ⁻)
+   open Spectral-Point 𝓅 renaming (point to 𝓅⋆)
 
-   ℱ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
-   ℱ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ ℱ⁻
+   𝓅₀ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
+   𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ 𝓅⋆
 
-   𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) ℱ holds
+   𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
    𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
+
+\end{code}
+
+We now proceed to show these form a section-retraction pair.
+
+\begin{code}
+
+ to-scott-point-cancels-to-patch-point : to-scott-point ∘ to-patch-point ∼ id
+ to-scott-point-cancels-to-patch-point 𝓅 =
+  to-spectral-point-＝ Scott⦅𝓓⦆ (to-scott-point (to-patch-point 𝓅)) 𝓅 †
+   where
+    † : {!!} ＝ {!!}
+    † = {!!}
 
 \end{code}
 

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -143,8 +143,8 @@ We define an alias for Patch(Scott(𝓓)).
 
 \end{code}
 
-We now instantiate to the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to points
-`𝟏 → Scott⦅𝓓⦆`.
+We now instantiate the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to points `𝟏 →
+Scott⦅𝓓⦆`.
 
 \begin{code}
 

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -114,6 +114,11 @@ module points-of-patch-are-spectral-points
                   σ
 
  spectral-point-to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
- spectral-point-to-patch-point ℱ = {!ump-of-patch!}
+ spectral-point-to-patch-point ℱ = pr₁ (center (patch-ump F 𝕤))
+  where
+   open Spectral-Point ℱ renaming (point to F)
+
+   𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
+   𝕤 K κ = point-preserves-compactness K κ
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -56,8 +56,10 @@ open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralMap pt fe
+open import Locales.Spectrality.SpectralityOfOmega pt fe sr 𝓤 pe
 open import Locales.TerminalLocale.Properties pt fe sr
 open import Locales.UniversalPropertyOfPatch pt fe sr
+open import Locales.ZeroDimensionality pt fe sr
 open import NotionsOfDecidability.Decidable
 open import NotionsOfDecidability.SemiDecidable fe pe pt
 open import Slice.Family
@@ -83,16 +85,22 @@ module points-of-patch-are-spectral-points
         (dc : decidability-condition 𝓓)
        where
 
+ zd : zero-dimensionalᴰ {𝓤 ⁺} (𝒪 (𝟏Loc pe))
+ zd = 𝟏-zero-dimensionalᴰ pe
+
  open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe
  open Notion-Of-Spectral-Point
  open SmallPatchConstruction σ⦅𝓓⦆ scott-locale-spectralᴰ
  open Preliminaries
- open UniversalProperty (𝟏Loc pe) σ⦅𝓓⦆ {!!} {!!}
+ open UniversalProperty σ⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
 
  patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
  patch-σ𝓓 = SmallPatch
 
+ patch-ump : {!!}
+ patch-ump = {!ump-of-patch σ⦅𝓓⦆ scott-locale-is-spectral ? (𝟏Loc pe) ?!}
+
  spectral-point-to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
- spectral-point-to-patch-point = {!ump-of-patch!}
+ spectral-point-to-patch-point ℱ = {!ump-of-patch!}
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -50,6 +50,7 @@ open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
 open import Locales.PatchLocale pt fe sr
 open import Locales.PatchProperties pt fe sr
+open import Locales.PerfectMaps pt fe
 open import Locales.Point.Definition pt fe
 open import Locales.Point.SpectralPoint-Definition pt fe pe
 open import Locales.ScottLocale.Definition pt fe 𝓤
@@ -74,6 +75,7 @@ open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 open AllCombinators pt fe
 open DefinitionOfScottDomain
 open Locale
+open PerfectMaps
 open PropositionalTruncation pt hiding (_∨_)
 
 \end{code}
@@ -97,6 +99,7 @@ module points-of-patch-are-spectral-points
  open UniversalProperty σ⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
  open ContinuousMaps
  open ClosedNucleus σ⦅𝓓⦆ scott-locale-is-spectral
+ open Epsilon σ⦅𝓓⦆ scott-locale-spectralᴰ
 
  patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
  patch-σ𝓓 = SmallPatch
@@ -113,12 +116,42 @@ module points-of-patch-are-spectral-points
                   𝓅
                   σ
 
- spectral-point-to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
- spectral-point-to-patch-point ℱ = pr₁ (center (patch-ump F 𝕤))
+ to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
+ to-patch-point ℱ = ∃!-witness (patch-ump F 𝕤)
   where
    open Spectral-Point ℱ renaming (point to F)
 
    𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
    𝕤 K κ = point-preserves-compactness K κ
+
+\end{code}
+
+The proof below should be placed in a more appropriate place.
+
+\begin{code}
+
+ ϵ-is-a-spectral-map : is-spectral-map σ⦅𝓓⦆ patch-σ𝓓 ϵ holds
+ ϵ-is-a-spectral-map =
+  perfect-maps-are-spectral
+   patch-σ𝓓
+   σ⦅𝓓⦆
+   ∣ spectralᴰ-implies-basisᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ ∣
+   ϵ
+   ϵ-is-a-perfect-map
+
+\end{code}
+
+\begin{code}
+
+ to-spectral-point′ : Spectral-Point patch-σ𝓓 → Spectral-Point σ⦅𝓓⦆
+ to-spectral-point′ ℱ⁻ₛ = to-spectral-point σ⦅𝓓⦆ (ℱ , 𝕤)
+  where
+   open Spectral-Point ℱ⁻ₛ renaming (point to ℱ⁻)
+
+   ℱ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
+   ℱ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ ℱ⁻
+
+   𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
+   𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -1,7 +1,8 @@
 ---
-title:          Sharp elements and the points of patch
+title:          Equivalence of sharp elements and the points of patch
 author:         Ayberk Tosun
 date-started:   2024-08-04
+date-completed: 2024-08-13
 ---
 
 We prove that the sharp elements of a Scott domain `𝓓` are in bijection with the
@@ -51,6 +52,7 @@ open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints 𝓤 ua pt sr
 open import Locales.PatchLocale pt fe sr
 open import Locales.PatchProperties pt fe sr
 open import Locales.PerfectMaps pt fe
@@ -93,9 +95,12 @@ an equivalence
 Point(Patch(Scott(𝓓))) ≃ Spectral-Point(Patch(Scott(𝓓))) ≃ Spectral-Point(Scott(𝓓))
 ```
 
+We then use this equivalence to show that the sharp elements of `𝓓` are in
+bijection with `Point(Patch(Scott(𝓓)))`.
+
 \begin{code}
 
-module points-of-patch-are-spectral-points
+module sharp-elements-and-points-of-patch
         (𝓓  : DCPO {𝓤 ⁺} {𝓤})
         (hl : has-least (underlying-order 𝓓))
         (sd : is-scott-domain 𝓓 holds)
@@ -106,18 +111,25 @@ module points-of-patch-are-spectral-points
  zd = 𝟏-zero-dimensionalᴰ pe
 
  open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe renaming (σ⦅𝓓⦆ to Scott⦅𝓓⦆)
- open Notion-Of-Spectral-Point
- open SmallPatchConstruction Scott⦅𝓓⦆ scott-locale-spectralᴰ
- open Preliminaries
- open UniversalProperty Scott⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
- open ContinuousMaps
- open ClosedNucleus Scott⦅𝓓⦆ scott-locale-is-spectral
- open Epsilon Scott⦅𝓓⦆ scott-locale-spectralᴰ
- open PatchStoneᴰ Scott⦅𝓓⦆ scott-locale-spectralᴰ
 
 \end{code}
 
-We define an alias for `Patch(Scott(𝓓))`
+Some more module opening bureaucracy.
+
+\begin{code}
+
+ open ClosedNucleus Scott⦅𝓓⦆ scott-locale-is-spectral
+ open ContinuousMaps
+ open Epsilon Scott⦅𝓓⦆ scott-locale-spectralᴰ
+ open Notion-Of-Spectral-Point
+ open PatchStoneᴰ Scott⦅𝓓⦆ scott-locale-spectralᴰ
+ open Preliminaries
+ open SmallPatchConstruction Scott⦅𝓓⦆ scott-locale-spectralᴰ
+ open UniversalProperty Scott⦅𝓓⦆ (𝟏Loc pe) scott-locale-spectralᴰ zd 𝟎Frm-is-compact
+
+\end{code}
+
+We define an alias for Patch(Scott(𝓓)).
 
 \begin{code}
 
@@ -134,9 +146,13 @@ We now instantiate to the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to 
 
 \begin{code}
 
- patch-ump : (𝓅 : 𝟏Loc pe ─c→ Scott⦅𝓓⦆)
+ patch-ump : (𝓅@(p , _) : 𝟏Loc pe ─c→ Scott⦅𝓓⦆)
            → is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
-           → ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → 𝓅 .pr₁ U  ＝ 𝒻⁻ .pr₁ ‘ U ’ )
+           → let
+              open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
+             in
+              ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ ,
+               ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p U  ＝ 𝒻⁻ ⋆∙ ‘ U ’ )
  patch-ump = ump-of-patch
               Scott⦅𝓓⦆
               scott-locale-is-spectral
@@ -147,7 +163,8 @@ We now instantiate to the universal property of `Patch⦅Scott⦅𝓓⦆⦆` to 
 \end{code}
 
 This universal property immediately gives us a map from the spectral points of
-`Scott⦅𝓓⦆` into the spectral points of `Patch⦅Scott⦅𝓓⦆⦆`.
+`Scott⦅𝓓⦆` into the spectral points of `Patch⦅Scott⦅𝓓⦆⦆`. We call this map
+`to-patch-point`.
 
 \begin{code}
 
@@ -185,7 +202,7 @@ The proof below should be placed in a more appropriate place.
 
 We now define the inverse of `to-patch-point`: given a spectral point `𝟏 →
 Patch⦅Scott⦅𝓓⦆⦆`, we can compose this with `ϵ : Patch⦅Scott⦅𝓓⦆⦆ → Scott⦅𝓓⦆` to
-obtain a map `𝟏 → Scott⦅𝓓⦆`. We call this map `to-scott-point`.
+obtain a spectral point `𝟏 → Scott⦅𝓓⦆`. We call this map `to-scott-point`.
 
 \begin{code}
 
@@ -202,7 +219,7 @@ obtain a map `𝟏 → Scott⦅𝓓⦆`. We call this map `to-scott-point`.
 
 \end{code}
 
-We now proceed to show these form a section-retraction pair.
+We now proceed to show that these maps form a section-retraction pair.
 
 The fact that `to-scott-point` is a retraction of `to-patch-point` follows
 directly from the existence part of the universal property.
@@ -227,6 +244,12 @@ directly from the existence part of the universal property.
 
     † : p′⋆ ＝ p⋆
     † = dfunext fe ‡
+
+\end{code}
+
+The fact that it is a section follows from the uniqueness.
+
+\begin{code}
 
  to-patch-point-cancels-to-scott-point : to-patch-point ∘ to-scott-point ∼ id
  to-patch-point-cancels-to-scott-point 𝓅 =
@@ -263,8 +286,8 @@ directly from the existence part of the universal property.
 
 \end{code}
 
-We package these up into a proof that `to-patch-point` has `to-scott-point` as a
-quasi-inverse.
+We package these up into a proof that `to-patch-point` and `to-scott-point` form
+an equivalence.
 
 \begin{code}
 
@@ -276,5 +299,91 @@ quasi-inverse.
 
    ‡ : to-patch-point ∘ to-scott-point ∼ id
    ‡ = to-patch-point-cancels-to-scott-point
+
+ spectral-points-of-patch-are-equivalent-to-spectral-points-of-scott
+  : Spectral-Point Scott⦅𝓓⦆ ≃ Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+ spectral-points-of-patch-are-equivalent-to-spectral-points-of-scott =
+  to-patch-point , qinvs-are-equivs to-patch-point to-patch-point-qinv
+
+\end{code}
+
+We now proceed to show that `Point⦅Patch⦅Scott⦅𝓓⦆⦆⦆` is equivalent to
+`Spectral-Point⦅Patch⦅Scott⦅𝓓⦆⦆⦆`, since all points of `Patch⦅Scott⦅𝓓⦆⦆` are
+_automatically_ spectral.
+
+\begin{code}
+
+ forget-spectrality : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ → Point Patch⦅Scott⦅𝓓⦆⦆
+ forget-spectrality = Spectral-Point.point
+
+ to-spectral-point-of-patch : Point Patch⦅Scott⦅𝓓⦆⦆
+                            → Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+ to-spectral-point-of-patch 𝓅 = to-spectral-point Patch⦅Scott⦅𝓓⦆⦆ (𝓅 , 𝕤)
+  where
+   open continuous-maps-of-stone-locales (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
+
+   𝕤 : is-spectral-map Patch⦅Scott⦅𝓓⦆⦆ (𝟏Loc pe) 𝓅 holds
+   𝕤 = continuous-maps-between-stone-locales-are-spectral
+        (𝟏-stoneᴰ pe)
+        Patch⦅Scott⦅𝓓⦆⦆-stoneᴰ
+        𝓅
+
+ open FrameHomomorphismProperties
+
+ forget-spectrality-qinv : qinv forget-spectrality
+ forget-spectrality-qinv = to-spectral-point-of-patch , † , ‡
+  where
+   † : to-spectral-point-of-patch ∘ forget-spectrality ∼ id
+   † 𝓅ₛ = to-spectral-point-＝ Patch⦅Scott⦅𝓓⦆⦆ 𝓅 𝓅ₛ refl
+    where
+     𝓅 : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+     𝓅 = to-spectral-point-of-patch (forget-spectrality 𝓅ₛ)
+
+   ‡ : forget-spectrality ∘ to-spectral-point-of-patch  ∼ id
+   ‡ 𝓅 =
+    to-frame-homomorphism-＝ (𝒪 Patch⦅Scott⦅𝓓⦆⦆) (𝒪 (𝟏Loc pe)) 𝓅 𝓅′ (λ _ → refl)
+     where
+      𝓅′ : Point Patch⦅Scott⦅𝓓⦆⦆
+      𝓅′ = forget-spectrality (to-spectral-point-of-patch 𝓅)
+
+ spectral-points-of-patch-are-equivalent-to-points-of-patch
+  : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ ≃ Point Patch⦅Scott⦅𝓓⦆⦆
+ spectral-points-of-patch-are-equivalent-to-points-of-patch =
+  forget-spectrality , qinvs-are-equivs forget-spectrality forget-spectrality-qinv
+
+\end{code}
+
+We combine these two equivalences to obtain an equivalence between the points of
+`Patch⦅Scott⦅𝓓⦆⦆` and spectral points of `Scott⦅𝓓⦆`.
+
+\begin{code}
+
+ points-of-patch-are-spectral-points-of-scott
+  : Point Patch⦅Scott⦅𝓓⦆⦆ ≃ Spectral-Point Scott⦅𝓓⦆
+ points-of-patch-are-spectral-points-of-scott =
+  Point Patch⦅Scott⦅𝓓⦆⦆              ≃⟨ Ⅰ ⟩
+  Spectral-Point Patch⦅Scott⦅𝓓⦆⦆     ≃⟨ Ⅱ ⟩
+  Spectral-Point Scott⦅𝓓⦆            ■
+   where
+    Ⅰ = ≃-sym spectral-points-of-patch-are-equivalent-to-points-of-patch
+    Ⅱ = ≃-sym spectral-points-of-patch-are-equivalent-to-spectral-points-of-scott
+
+\end{code}
+
+Finally, we combine this equivalence with the equivalence between sharp elements
+and spectral points.
+
+\begin{code}
+
+ open Sharp-Element-Spectral-Point-Equivalence 𝓓 hl sd dc
+
+ points-of-patch-are-the-sharp-elements : ♯𝓓 ≃ Point Patch⦅Scott⦅𝓓⦆⦆
+ points-of-patch-are-the-sharp-elements =
+  ♯𝓓                         ≃⟨ Ⅰ ⟩
+  Spectral-Point Scott⦅𝓓⦆    ≃⟨ Ⅱ ⟩
+  Point Patch⦅Scott⦅𝓓⦆⦆      ■
+   where
+    Ⅰ = ♯𝓓-equivalent-to-spectral-points-of-Scott⦅𝓓⦆
+    Ⅱ = ≃-sym points-of-patch-are-spectral-points-of-scott
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -204,69 +204,77 @@ obtain a map `𝟏 → Scott⦅𝓓⦆`. We call this map `to-scott-point`.
 
 We now proceed to show these form a section-retraction pair.
 
+The fact that `to-scott-point` is a retraction of `to-patch-point` follows
+directly from the existence part of the universal property.
+
 \begin{code}
 
  to-scott-point-cancels-to-patch-point : to-scott-point ∘ to-patch-point ∼ id
  to-scott-point-cancels-to-patch-point 𝓅 =
   to-spectral-point-＝ Scott⦅𝓓⦆ (to-scott-point (to-patch-point 𝓅)) 𝓅 †
    where
-    † : {!!} ＝ {!!}
-    † = {!!}
+    open Spectral-Point 𝓅
+     using ()
+     renaming (point to 𝓅⋆; point-fn to p⋆; point-preserves-compactness to 𝕤)
+
+    𝓅′ : Spectral-Point Scott⦅𝓓⦆
+    𝓅′ = to-scott-point (to-patch-point 𝓅)
+
+    open Spectral-Point 𝓅′ using () renaming (point to 𝓅′⋆; point-fn to p′⋆)
+
+    ‡ : p′⋆ ∼ p⋆
+    ‡ U = pr₂ (description (patch-ump 𝓅⋆ 𝕤)) U ⁻¹
+
+    † : p′⋆ ＝ p⋆
+    † = dfunext fe ‡
+
+ to-patch-point-cancels-to-scott-point : to-patch-point ∘ to-scott-point ∼ id
+ to-patch-point-cancels-to-scott-point 𝓅 =
+  to-spectral-point-＝' Patch⦅Scott⦅𝓓⦆⦆ 𝓅′ 𝓅 †
+   where
+    open Spectral-Point 𝓅
+     using ()
+     renaming (point to 𝓅⋆; point-fn to p⋆; point-preserves-compactness to 𝕤)
+    open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
+
+    𝓅′ : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
+    𝓅′ = to-patch-point (to-scott-point 𝓅)
+
+    𝓅₀ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
+    𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ 𝓅⋆
+
+    p₀ : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩ → ⟨ 𝒪 (𝟏Loc pe) ⟩
+    p₀ = pr₁ 𝓅₀
+
+    𝕤₀ : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
+    𝕤₀ K κ = 𝕤 ‘ K ’ (ϵ-is-a-spectral-map K κ)
+
+    open Spectral-Point 𝓅′ using () renaming (point to 𝓅′⋆; point-fn to p′⋆)
+
+    υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ ,
+         ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U ＝ 𝓅₀⁻ ⋆∙ ‘ U ’)
+    υ = patch-ump 𝓅₀ 𝕤₀
+
+    r : (U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’
+    r = λ _ → refl
+
+    † : 𝓅′⋆ ＝ 𝓅⋆
+    † = pr₁ (from-Σ-＝ (∃!-uniqueness υ 𝓅⋆ r))
 
 \end{code}
+
+We package these up into a proof that `to-patch-point` has `to-scott-point` as a
+quasi-inverse.
 
 \begin{code}
 
  to-patch-point-qinv : qinv to-patch-point
  to-patch-point-qinv = to-scott-point , † , ‡
   where
-   open ContinuousMaps
-   open ContinuousMapNotation (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆
-
    † : to-scott-point ∘ to-patch-point ∼ id
-   † ℱ = to-spectral-point-＝ Scott⦅𝓓⦆ (to-scott-point (to-patch-point ℱ)) ℱ ♢
-    where
-     open Spectral-Point using (point; point-fn; point-preserves-compactness)
-     open Spectral-Point ℱ using () renaming (point-fn to F)
-
-     𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) (point ℱ) holds
-     𝕤 K κ = point-preserves-compactness ℱ K κ
-
-     γ : (U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩)
-       → point-fn (to-scott-point (to-patch-point ℱ)) U ＝ F U
-     γ U = pr₂ (description (patch-ump (point ℱ) 𝕤)) U ⁻¹
-
-     ♢ : point-fn (to-scott-point (to-patch-point ℱ)) ＝ F
-     ♢ = dfunext fe γ
+   † = to-scott-point-cancels-to-patch-point
 
    ‡ : to-patch-point ∘ to-scott-point ∼ id
-   ‡ 𝓅 = to-spectral-point-＝'
-          Patch⦅Scott⦅𝓓⦆⦆
-          (to-patch-point (to-scott-point 𝓅))
-          𝓅
-          (γ ⁻¹)
-    where
-     open Spectral-Point 𝓅 renaming (point-fn to p⋆; point to 𝓅⋆)
-     open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 Patch⦅Scott⦅𝓓⦆⦆)
-
-     𝓅₀ : 𝟏Loc pe ─c→ Scott⦅𝓓⦆
-     𝓅₀ = cont-comp (𝟏Loc pe) Patch⦅Scott⦅𝓓⦆⦆ Scott⦅𝓓⦆ ϵ 𝓅⋆
-
-     p₀ = pr₁ 𝓅₀
-
-     𝕤 : is-spectral-map Scott⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
-     𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
-
-     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆ , ((U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
-     υ = patch-ump 𝓅₀ 𝕤
-
-     𝓅₀⁻ : 𝟏Loc pe ─c→ Patch⦅Scott⦅𝓓⦆⦆
-     𝓅₀⁻ = ∃!-witness υ
-
-     foo : (U : ⟨ 𝒪 Scott⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’
-     foo U = refl
-
-     γ : 𝓅⋆ ＝ 𝓅₀⁻
-     γ = pr₁ (from-Σ-＝ (∃!-uniqueness υ 𝓅⋆ foo)) ⁻¹
+   ‡ = to-patch-point-cancels-to-scott-point
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -1,0 +1,98 @@
+---
+title:          Sharp elements and the points of patch
+author:         Ayberk Tosun
+date-started:   2024-08-04
+---
+
+\begin{code}[hide]
+
+{-# OPTIONS --safe --without-K --lossy-unification #-}
+
+open import MLTT.List hiding ([_])
+open import MLTT.Spartan
+open import UF.FunExt
+open import UF.PropTrunc
+open import UF.Size
+open import UF.Subsingletons
+open import UF.UA-FunExt
+open import UF.Univalence
+
+module Locales.LawsonLocale.PointsOfPatch
+        (𝓤  : Universe)
+        (ua : Univalence)
+        (pt : propositional-truncations-exist)
+        (sr : Set-Replacement pt)
+       where
+
+private
+ fe : Fun-Ext
+ fe {𝓤} {𝓥} = univalence-gives-funext' 𝓤 𝓥 (ua 𝓤) (ua (𝓤 ⊔ 𝓥))
+
+ pe : Prop-Ext
+ pe {𝓤} = univalence-gives-propext (ua 𝓤)
+
+open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.CompactBasis pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
+open import DomainTheory.BasesAndContinuity.ScottDomain pt fe 𝓤
+open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
+open import DomainTheory.Basics.WayBelow pt fe 𝓤
+open import DomainTheory.Topology.ScottTopology pt fe 𝓤
+open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
+open import Locales.Clopen pt fe sr
+open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
+open import Locales.Compactness pt fe hiding (is-compact)
+open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
+open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
+open import Locales.Frame pt fe
+open import Locales.InitialFrame pt fe hiding (_⊑_)
+open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
+open import Locales.PatchLocale pt fe sr
+open import Locales.Point.Definition pt fe
+open import Locales.Point.SpectralPoint-Definition pt fe pe
+open import Locales.ScottLocale.Definition pt fe 𝓤
+open import Locales.ScottLocale.Properties pt fe 𝓤
+open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
+open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
+open import Locales.SmallBasis pt fe sr
+open import Locales.Spectrality.SpectralMap pt fe
+open import Locales.TerminalLocale.Properties pt fe sr
+open import Locales.UniversalPropertyOfPatch pt fe sr
+open import NotionsOfDecidability.Decidable
+open import NotionsOfDecidability.SemiDecidable fe pe pt
+open import Slice.Family
+open import UF.Equiv
+open import UF.Logic
+open import UF.Subsingletons-FunExt
+open import UF.Subsingletons-Properties
+open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
+
+open AllCombinators pt fe
+open DefinitionOfScottDomain
+open Locale
+open PropositionalTruncation pt hiding (_∨_)
+
+\end{code}
+
+\begin{code}
+
+module points-of-patch-are-spectral-points
+        (𝓓  : DCPO {𝓤 ⁺} {𝓤})
+        (hl : has-least (underlying-order 𝓓))
+        (sd : is-scott-domain 𝓓 holds)
+        (dc : decidability-condition 𝓓)
+       where
+
+ open SpectralScottLocaleConstruction₂ 𝓓 ua hl sd dc pe
+ open Notion-Of-Spectral-Point
+ open SmallPatchConstruction σ⦅𝓓⦆ scott-locale-spectralᴰ
+ open Preliminaries
+ open UniversalProperty (𝟏Loc pe) σ⦅𝓓⦆ {!!} {!!}
+
+ patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
+ patch-σ𝓓 = SmallPatch
+
+ spectral-point-to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
+ spectral-point-to-patch-point = {!ump-of-patch!}
+
+\end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -68,6 +68,7 @@ open import Locales.ZeroDimensionality pt fe sr
 open import NotionsOfDecidability.Decidable
 open import NotionsOfDecidability.SemiDecidable fe pe pt
 open import Slice.Family
+open import UF.Base
 open import UF.Equiv
 open import UF.Logic
 open import UF.Subsingletons-FunExt
@@ -190,34 +191,37 @@ The proof below should be placed in a more appropriate place.
        → point-fn (to-spectral-point′ (to-patch-point ℱ)) U ＝ F U
      γ U = pr₂ (description (patch-ump (point ℱ) 𝕤)) U ⁻¹
 
-
      ♢ : point-fn (to-spectral-point′ (to-patch-point ℱ)) ＝ F
      ♢ = dfunext fe γ
 
    ‡ : to-patch-point ∘ to-spectral-point′ ∼ id
-   ‡ ℱ⁻ₛ = to-spectral-point-＝ patch-σ𝓓 (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) ℱ⁻ₛ ♢
+   ‡ 𝓅 = to-spectral-point-＝'
+          patch-σ𝓓
+          (to-patch-point (to-spectral-point′ 𝓅))
+          𝓅
+          (γ ⁻¹)
     where
-     open Spectral-Point ℱ⁻ₛ renaming (point-fn to F⁻; point to ℱ⁻)
+     open Spectral-Point 𝓅 renaming (point-fn to p⋆; point to 𝓅⋆)
      open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 patch-σ𝓓)
 
-     ℱ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
-     ℱ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ ℱ⁻
+     𝓅₀ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
+     𝓅₀ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ 𝓅⋆
 
-     F = pr₁ ℱ
+     p₀ = pr₁ 𝓅₀
 
-     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
+     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅₀ holds
      𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
 
-     υ : ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → F U  ＝ 𝒻⁻ ⋆∙ ‘ U ’ )
-     υ = patch-ump ℱ 𝕤
+     υ : ∃! 𝓅₀⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U  ＝ 𝓅₀⁻ ⋆∙ ‘ U ’ )
+     υ = patch-ump 𝓅₀ 𝕤
 
-     γ : (U : ⟨ 𝒪 patch-σ𝓓 ⟩)
-       → Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) U ＝ F⁻ U
-     γ U = Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) U  ＝⟨ refl ⟩
-           (∃!-witness υ ⋆∙ U)  ＝⟨ {!pr₂ (description υ) !} ⟩
-           F⁻ U    ∎
+     𝓅₀⁻ : 𝟏Loc pe ─c→ patch-σ𝓓
+     𝓅₀⁻ = ∃!-witness υ
 
-     ♢ : Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) ＝ F⁻
-     ♢ = dfunext fe γ
+     foo : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → p₀ U ＝ p⋆ ‘ U ’
+     foo U = refl
+
+     γ : 𝓅⋆ ＝ 𝓅₀⁻
+     γ = pr₁ (from-Σ-＝ (∃!-uniqueness υ 𝓅⋆ foo)) ⁻¹
 
 \end{code}

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -296,8 +296,8 @@ an equivalence.
 
 \begin{code}
 
- to-patch-point-qinv : qinv to-patch-point
- to-patch-point-qinv = to-scott-point , † , ‡
+ to-patch-point-is-invertible : invertible to-patch-point
+ to-patch-point-is-invertible = to-scott-point , † , ‡
   where
    † : to-scott-point ∘ to-patch-point ∼ id
    † = to-scott-point-cancels-to-patch-point
@@ -308,7 +308,7 @@ an equivalence.
  spectral-points-of-patch-are-equivalent-to-spectral-points-of-scott
   : Spectral-Point Scott⦅𝓓⦆ ≃ Spectral-Point Patch⦅Scott⦅𝓓⦆⦆
  spectral-points-of-patch-are-equivalent-to-spectral-points-of-scott =
-  to-patch-point , qinvs-are-equivs to-patch-point to-patch-point-qinv
+  to-patch-point , qinvs-are-equivs to-patch-point to-patch-point-is-invertible
 
 \end{code}
 
@@ -335,8 +335,8 @@ _automatically_ spectral.
 
  open FrameHomomorphismProperties
 
- forget-spectrality-qinv : qinv forget-spectrality
- forget-spectrality-qinv = to-spectral-point-of-patch , † , ‡
+ forget-spectrality-is-invertible : invertible forget-spectrality
+ forget-spectrality-is-invertible = to-spectral-point-of-patch , † , ‡
   where
    † : to-spectral-point-of-patch ∘ forget-spectrality ∼ id
    † 𝓅ₛ = to-spectral-point-＝ Patch⦅Scott⦅𝓓⦆⦆ 𝓅 𝓅ₛ refl
@@ -354,7 +354,10 @@ _automatically_ spectral.
  spectral-points-of-patch-are-equivalent-to-points-of-patch
   : Spectral-Point Patch⦅Scott⦅𝓓⦆⦆ ≃ Point Patch⦅Scott⦅𝓓⦆⦆
  spectral-points-of-patch-are-equivalent-to-points-of-patch =
-  forget-spectrality , qinvs-are-equivs forget-spectrality forget-spectrality-qinv
+  forget-spectrality , e
+   where
+    e : is-equiv forget-spectrality
+    e = qinvs-are-equivs forget-spectrality forget-spectrality-is-invertible
 
 \end{code}
 

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -5,6 +5,8 @@ date-started:   2024-08-04
 date-completed: 2024-08-13
 ---
 
+Joint work with Martín Escardó.
+
 We prove that the sharp elements of a Scott domain `𝓓` are in bijection with the
 points of `Patch(Scott(𝓓))`.
 

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -60,6 +60,8 @@ open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralMap pt fe
 open import Locales.Spectrality.SpectralityOfOmega pt fe sr 𝓤 pe
+open import Locales.Stone pt fe sr
+open import Locales.StoneImpliesSpectral pt fe sr
 open import Locales.TerminalLocale.Properties pt fe sr
 open import Locales.UniversalPropertyOfPatch pt fe sr
 open import Locales.ZeroDimensionality pt fe sr
@@ -100,9 +102,13 @@ module points-of-patch-are-spectral-points
  open ContinuousMaps
  open ClosedNucleus σ⦅𝓓⦆ scott-locale-is-spectral
  open Epsilon σ⦅𝓓⦆ scott-locale-spectralᴰ
+ open PatchStoneᴰ σ⦅𝓓⦆ scott-locale-spectralᴰ
 
  patch-σ𝓓 : Locale (𝓤 ⁺) 𝓤 𝓤
  patch-σ𝓓 = SmallPatch
+
+ patch-σ𝓓-stoneᴰ : stoneᴰ patch-σ𝓓
+ patch-σ𝓓-stoneᴰ = patchₛ-is-compact , patchₛ-zero-dimensionalᴰ
 
  patch-ump : (𝓅 : 𝟏Loc pe ─c→ σ⦅𝓓⦆)
            → is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) 𝓅 holds
@@ -116,13 +122,20 @@ module points-of-patch-are-spectral-points
                   𝓅
                   σ
 
- to-patch-point : Spectral-Point σ⦅𝓓⦆ → Point patch-σ𝓓
- to-patch-point ℱ = ∃!-witness (patch-ump F 𝕤)
+ to-patch-point : Spectral-Point σ⦅𝓓⦆ → Spectral-Point patch-σ𝓓
+ to-patch-point ℱ = to-spectral-point patch-σ𝓓 (𝓅 , †)
   where
    open Spectral-Point ℱ renaming (point to F)
+   open continuous-maps-of-stone-locales (𝟏Loc pe) patch-σ𝓓 (𝟏-stoneᴰ pe) patch-σ𝓓-stoneᴰ
 
    𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) F holds
    𝕤 K κ = point-preserves-compactness K κ
+
+   𝓅 : 𝟏Loc pe ─c→ patch-σ𝓓
+   𝓅 = ∃!-witness (patch-ump F 𝕤)
+
+   † : is-spectral-map patch-σ𝓓 (𝟏Loc pe) 𝓅 holds
+   † = continuous-maps-between-stone-locales-are-spectral 𝓅
 
 \end{code}
 
@@ -153,5 +166,58 @@ The proof below should be placed in a more appropriate place.
 
    𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
    𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
+
+\end{code}
+
+\begin{code}
+
+ to-patch-point-qinv : qinv to-patch-point
+ to-patch-point-qinv = to-spectral-point′ , † , ‡
+  where
+   open ContinuousMaps
+   open ContinuousMapNotation (𝟏Loc pe) patch-σ𝓓
+
+   † : to-spectral-point′ ∘ to-patch-point ∼ id
+   † ℱ = to-spectral-point-＝ σ⦅𝓓⦆ (to-spectral-point′ (to-patch-point ℱ)) ℱ ♢
+    where
+     open Spectral-Point using (point; point-fn; point-preserves-compactness)
+     open Spectral-Point ℱ using () renaming (point-fn to F)
+
+     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) (point ℱ) holds
+     𝕤 K κ = point-preserves-compactness ℱ K κ
+
+     γ : (U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩)
+       → point-fn (to-spectral-point′ (to-patch-point ℱ)) U ＝ F U
+     γ U = pr₂ (description (patch-ump (point ℱ) 𝕤)) U ⁻¹
+
+
+     ♢ : point-fn (to-spectral-point′ (to-patch-point ℱ)) ＝ F
+     ♢ = dfunext fe γ
+
+   ‡ : to-patch-point ∘ to-spectral-point′ ∼ id
+   ‡ ℱ⁻ₛ = to-spectral-point-＝ patch-σ𝓓 (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) ℱ⁻ₛ ♢
+    where
+     open Spectral-Point ℱ⁻ₛ renaming (point-fn to F⁻; point to ℱ⁻)
+     open FrameHomomorphismProperties (𝒪 (𝟏Loc pe)) (𝒪 patch-σ𝓓)
+
+     ℱ : 𝟏Loc pe ─c→ σ⦅𝓓⦆
+     ℱ = cont-comp (𝟏Loc pe) patch-σ𝓓 σ⦅𝓓⦆ ϵ ℱ⁻
+
+     F = pr₁ ℱ
+
+     𝕤 : is-spectral-map σ⦅𝓓⦆ (𝟏Loc pe) ℱ holds
+     𝕤 K κ = point-preserves-compactness ‘ K ’ (ϵ-is-a-spectral-map K κ)
+
+     υ : ∃! 𝒻⁻ ꞉ 𝟏Loc pe ─c→ patch-σ𝓓 , ((U : ⟨ 𝒪 σ⦅𝓓⦆ ⟩) → F U  ＝ 𝒻⁻ ⋆∙ ‘ U ’ )
+     υ = patch-ump ℱ 𝕤
+
+     γ : (U : ⟨ 𝒪 patch-σ𝓓 ⟩)
+       → Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) U ＝ F⁻ U
+     γ U = Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) U  ＝⟨ refl ⟩
+           (∃!-witness υ ⋆∙ U)  ＝⟨ {!pr₂ (description υ) !} ⟩
+           F⁻ U    ∎
+
+     ♢ : Spectral-Point.point-fn (to-patch-point (to-spectral-point′ ℱ⁻ₛ)) ＝ F⁻
+     ♢ = dfunext fe γ
 
 \end{code}

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -154,3 +154,25 @@ underlying functions are equal. We call this lemma `to-spectral-point-＝`.
    Ⅲ = inverses-are-sections' e 𝒢 ⁻¹
 
 \end{code}
+
+Added on 2024-08-12.
+
+\begin{code}
+
+ to-spectral-point-＝' : (ℱ 𝒢 : Spectral-Point) → point ℱ ＝ point 𝒢 → ℱ ＝ 𝒢
+ to-spectral-point-＝' ℱ 𝒢 p =
+  ℱ                                           ＝⟨ Ⅰ ⟩
+  to-spectral-point (to-spectral-point₀ ℱ)    ＝⟨ Ⅱ ⟩
+  to-spectral-point (to-spectral-point₀ 𝒢)    ＝⟨ Ⅲ ⟩
+  𝒢                                           ∎
+   where
+    e = spectral-point-equivalent-to-spectral-map-into-Ω
+
+    † : to-spectral-point₀ ℱ ＝ to-spectral-point₀ 𝒢
+    † = to-subtype-＝ (holds-is-prop ∘ is-spectral-map X (𝟏Loc pe)) p
+
+    Ⅰ = inverses-are-sections' e ℱ
+    Ⅱ = ap to-spectral-point †
+    Ⅲ = inverses-are-sections' e 𝒢 ⁻¹
+
+\end{code}

--- a/source/Locales/Spectrality/SpectralityOfOmega.lagda
+++ b/source/Locales/Spectrality/SpectralityOfOmega.lagda
@@ -110,21 +110,16 @@ and₂-lemma₃ (inr ⋆) y (z , p₁ , p₂) = p₂
        , (pr₂ (pr₁ ℬ𝟎-is-directed-basis-for-𝟎 U)
        , pr₂ ℬ𝟎-is-directed-basis-for-𝟎 U)
 
-𝟎-𝔽𝕣𝕞-is-spectral : is-spectral 𝟏-loc holds
-𝟎-𝔽𝕣𝕞-is-spectral =
- spectralᴰ-gives-spectrality
-  𝟏-loc
-  (ℬ𝟎↑ , pr₂ ℬ𝟎↑-directed-basisᴰ , ℬ𝟎↑-consists-of-compact-opens , γ)
-  where
-   κ : consists-of-compact-opens 𝟏-loc ℬ𝟎↑ holds
-   κ []       = 𝟎-is-compact 𝟏-loc
-   κ (i ∷ is) = compact-opens-are-closed-under-∨
-                 𝟏-loc
-                 (ℬ𝟎 [ i ])
-                 (ℬ𝟎↑ [ is ])
-                 (ℬ𝟎-consists-of-compact-opens i)
-                 (κ is)
+\end{code}
 
+The result below was cleaned up and refactored on 2024-08-05.
+
+\begin{code}
+
+𝟎-𝔽𝕣𝕞-spectralᴰ : spectralᴰ 𝟏-loc
+𝟎-𝔽𝕣𝕞-spectralᴰ =
+ pr₁ Σ-assoc (ℬ𝟎↑-directed-basisᴰ , ℬ𝟎↑-consists-of-compact-opens , γ)
+  where
    t : is-top (𝟎-𝔽𝕣𝕞 pe) (𝟏[ 𝟎-𝔽𝕣𝕞 pe ] ∨[ 𝟎-𝔽𝕣𝕞 pe ] 𝟎[ 𝟎-𝔽𝕣𝕞 pe ]) holds
    t = transport
         (λ - → is-top (𝟎-𝔽𝕣𝕞 pe) - holds)
@@ -140,5 +135,12 @@ and₂-lemma₃ (inr ⋆) y (z , p₁ , p₂) = p₂
 
    γ : closed-under-finite-meets (𝟎-𝔽𝕣𝕞 pe) ℬ𝟎↑ holds
    γ = ∣ (inr ⋆ ∷ []) , t ∣ , c
+
+\end{code}
+
+\begin{code}
+
+𝟎-𝔽𝕣𝕞-is-spectral : is-spectral 𝟏-loc holds
+𝟎-𝔽𝕣𝕞-is-spectral = spectralᴰ-gives-spectrality 𝟏-loc 𝟎-𝔽𝕣𝕞-spectralᴰ
 
 \end{code}

--- a/source/Locales/StoneImpliesSpectral.lagda
+++ b/source/Locales/StoneImpliesSpectral.lagda
@@ -35,19 +35,21 @@ Importations of other locale theory modules.
 \begin{code}
 
 open import Locales.AdjointFunctorTheoremForFrames
-open import Locales.Frame            pt fe
-open import Locales.WayBelowRelation.Definition pt fe
+open import Locales.Clopen             pt fe sr
 open import Locales.Compactness      pt fe
 open import Locales.Complements      pt fe
+open import Locales.ContinuousMap.Definition pt fe
+open import Locales.Frame            pt fe
 open import Locales.GaloisConnection pt fe
 open import Locales.InitialFrame     pt fe
-open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.ZeroDimensionality pt fe sr
-open import Locales.Stone              pt fe sr
-open import Locales.SmallBasis         pt fe sr
-open import Locales.Clopen             pt fe sr
-open import Locales.WellInside         pt fe sr
 open import Locales.ScottContinuity    pt fe sr
+open import Locales.SmallBasis         pt fe sr
+open import Locales.Spectrality.SpectralLocale pt fe
+open import Locales.Spectrality.SpectralMap pt fe
+open import Locales.Stone              pt fe sr
+open import Locales.WayBelowRelation.Definition pt fe
+open import Locales.WellInside         pt fe sr
+open import Locales.ZeroDimensionality pt fe sr
 
 open Locale
 
@@ -217,5 +219,63 @@ stone-locales-are-spectral X σ@(κ , ζ) = spectralᴰ-gives-spectrality X σ�
  where
   σᴰ : spectralᴰ X
   σᴰ = stoneᴰ-implies-spectralᴰ X σ
+
+\end{code}
+
+Added on 2024-08-11.
+
+\begin{code}
+
+stoneᴰ-locales-are-compact : (X : Locale 𝓤 𝓥 𝓦)
+                           → stoneᴰ X → is-compact X holds
+stoneᴰ-locales-are-compact X (κ , _) = κ
+
+\end{code}
+
+\begin{code}
+
+module continuous-maps-of-stone-locales
+        (X : Locale 𝓤 𝓥 𝓥)
+        (Y : Locale 𝓤 𝓥 𝓥)
+        (𝕤₁ : stoneᴰ X)
+        (𝕤₂ : stoneᴰ Y)
+       where
+
+ open ContinuousMaps
+
+ κ₁ : is-compact X holds
+ κ₁ = stoneᴰ-locales-are-compact X 𝕤₁
+
+ κ₂ : is-compact Y holds
+ κ₂ = stoneᴰ-locales-are-compact Y 𝕤₂
+
+ zd₂ : zero-dimensionalᴰ (𝒪 Y)
+ zd₂ = pr₂ 𝕤₂
+
+ continuous-maps-between-stone-locales-are-spectral
+  : (f : X ─c→ Y)
+  → is-spectral-map Y X f holds
+ continuous-maps-between-stone-locales-are-spectral 𝒻 K κ =
+  clopens-are-compact-in-compact-locales X κ₁ (𝒻 ⋆∙ K) ϑ
+   where
+    open ContinuousMapNotation X Y
+
+    ψ : is-clopen (𝒪 Y) K holds
+    ψ = compacts-are-clopen-in-zd-locales Y ∣ zd₂ ∣ K κ
+
+    K' : ⟨ 𝒪 Y ⟩
+    K' = pr₁ ψ
+
+    χ : is-boolean-complement-of (𝒪 Y) K' K holds
+    χ = pr₂ ψ
+
+    χ' : is-boolean-complement-of (𝒪 Y) K K' holds
+    χ' = complementation-is-symmetric (𝒪 Y) K' K χ
+
+    † : is-boolean-complement-of (𝒪 X) (𝒻 ⋆∙ K') (𝒻 ⋆∙ K) holds
+    † = frame-homomorphisms-preserve-complements (𝒪 Y) (𝒪 X) (_⋆ 𝒻) χ'
+
+    ϑ : is-clopen (𝒪 X) (𝒻 ⋆∙ K) holds
+    ϑ = 𝒻 ⋆∙ K' , †
 
 \end{code}

--- a/source/Locales/TerminalLocale/Properties.lagda
+++ b/source/Locales/TerminalLocale/Properties.lagda
@@ -38,6 +38,7 @@ open import Locales.InitialFrame pt fe
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralityOfOmega pt fe sr
 open import Locales.StoneImpliesSpectral pt fe sr
+open import Locales.ZeroDimensionality pt fe sr
 open import Slice.Family
 open import UF.Equiv
 open import UF.Logic
@@ -259,5 +260,39 @@ decidable propositions
    ‡ : (g ∘ h) ∼ id
    ‡ (P , _) =
     to-subtype-＝ (λ Q → decidability-of-prop-is-prop fe (holds-is-prop Q)) refl
+
+\end{code}
+
+Added on 2024-08-05.
+
+\begin{code}
+
+ ℬ𝟎-consists-of-clopens : consists-of-clopens (𝒪 (𝟏Loc pe)) ℬ𝟎 holds
+ ℬ𝟎-consists-of-clopens (inl ⋆) =
+  transport (λ - → is-clopen (𝒪 (𝟏Loc pe)) - holds) (p ⁻¹) †
+   where
+    p : ⊥ ＝ 𝟎[ 𝒪 (𝟏Loc pe) ]
+    p = 𝟎-is-⊥
+
+    † : is-clopen (𝒪 (𝟏Loc pe)) 𝟎[ 𝒪 (𝟏Loc pe) ] holds
+    † = 𝟎-is-clopen (𝒪 (𝟏Loc pe))
+ ℬ𝟎-consists-of-clopens (inr ⋆) =
+  𝟏-is-clopen (𝒪 (𝟏Loc pe))
+
+ ℬ𝟎↑-consists-of-clopens : consists-of-clopens (𝒪 (𝟏Loc pe)) ℬ𝟎↑ holds
+ ℬ𝟎↑-consists-of-clopens []       = 𝟎-is-clopen (𝒪 (𝟏Loc pe))
+ ℬ𝟎↑-consists-of-clopens (i ∷ is) =
+  clopens-are-closed-under-∨ (𝒪 (𝟏Loc pe)) (ℬ𝟎 [ i ]) (ℬ𝟎↑ [ is ]) † ‡
+   where
+    † : is-clopen (𝒪 (𝟏Loc pe)) (ℬ𝟎 [ i ]) holds
+    † = ℬ𝟎-consists-of-clopens i
+
+    ‡ : is-clopen (𝒪 (𝟏Loc pe)) (ℬ𝟎↑ [ is ]) holds
+    ‡ = ℬ𝟎↑-consists-of-clopens is
+
+ 𝟏-zero-dimensionalᴰ : zero-dimensionalᴰ (𝒪 (𝟏Loc pe))
+ 𝟏-zero-dimensionalᴰ = ℬ𝟎↑
+                     , pr₂ (ℬ𝟎↑-directed-basisᴰ 𝓤 pe)
+                     , ℬ𝟎↑-consists-of-clopens
 
 \end{code}

--- a/source/Locales/TerminalLocale/Properties.lagda
+++ b/source/Locales/TerminalLocale/Properties.lagda
@@ -37,6 +37,7 @@ open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralityOfOmega pt fe sr
+open import Locales.Stone pt fe sr
 open import Locales.StoneImpliesSpectral pt fe sr
 open import Locales.ZeroDimensionality pt fe sr
 open import Slice.Family
@@ -294,5 +295,14 @@ Added on 2024-08-05.
  𝟏-zero-dimensionalᴰ = ℬ𝟎↑
                      , pr₂ (ℬ𝟎↑-directed-basisᴰ 𝓤 pe)
                      , ℬ𝟎↑-consists-of-clopens
+
+\end{code}
+
+Added on 2024-08-10.
+
+\begin{code}
+
+ 𝟏-is-stone : is-stone (𝟏Loc pe) holds
+ 𝟏-is-stone = 𝟎Frm-is-compact 𝓤 pe , ∣ 𝟏-zero-dimensionalᴰ ∣
 
 \end{code}

--- a/source/Locales/TerminalLocale/Properties.lagda
+++ b/source/Locales/TerminalLocale/Properties.lagda
@@ -302,6 +302,9 @@ Added on 2024-08-10.
 
 \begin{code}
 
+ 𝟏-stoneᴰ : stoneᴰ (𝟏Loc pe)
+ 𝟏-stoneᴰ = 𝟎Frm-is-compact 𝓤 pe , 𝟏-zero-dimensionalᴰ
+
  𝟏-is-stone : is-stone (𝟏Loc pe) holds
  𝟏-is-stone = 𝟎Frm-is-compact 𝓤 pe , ∣ 𝟏-zero-dimensionalᴰ ∣
 

--- a/source/Locales/index.lagda
+++ b/source/Locales/index.lagda
@@ -132,5 +132,6 @@ import Locales.StoneDuality.ForSpectralLocales
 
 import Locales.LawsonLocale.CompactElementsOfPoint
 import Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints
+import Locales.LawsonLocale.PointsOfPatch
 
 \end{code}


### PR DESCRIPTION
This module adds a proof of the following theorem:

- For every Scott domain 𝓓 (satisfying the decidability condition), the points of Patch(Scott(𝓓)) are in bijection with the sharp elements of 𝓓.