### PR TITLE
Unused imports

### DIFF
--- a/source/UF/Choice.lagda
+++ b/source/UF/Choice.lagda
@@ -38,14 +38,11 @@ choice where X is a proposition (see https://arxiv.org/abs/1610.03346).
 open import MLTT.Spartan
 open import UF.DiscreteAndSeparated
 open import UF.Base
-open import UF.Equiv
 open import UF.ClassicalLogic
 open import UF.FunExt
-open import UF.Hedberg
 open import UF.LeftCancellable
 open import UF.Powerset
 open import UF.PropTrunc
-open import UF.Retracts
 open import UF.Sets
 open import UF.Sets-Properties
 open import UF.Subsingletons

--- a/source/UF/ClassicalLogic.lagda
+++ b/source/UF/ClassicalLogic.lagda
@@ -18,7 +18,6 @@ module UF.ClassicalLogic where
 open import MLTT.Spartan
 
 open import UF.Base
-open import UF.Embeddings
 open import UF.Equiv
 open import UF.FunExt
 open import UF.PropTrunc

--- a/source/UF/EquivalenceExamples.lagda
+++ b/source/UF/EquivalenceExamples.lagda
@@ -15,7 +15,6 @@ open import UF.FunExt
 open import UF.Lower-FunExt
 open import UF.PropIndexedPiSigma
 open import UF.Retracts
-open import UF.SubtypeClassifier
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties

--- a/source/UF/FunExt-Properties.lagda
+++ b/source/UF/FunExt-Properties.lagda
@@ -16,7 +16,6 @@ open import UF.Equiv-FunExt
 open import UF.Yoneda
 open import UF.Subsingletons
 open import UF.Retracts
-open import UF.EquivalenceExamples
 
 \end{code}
 

--- a/source/UF/FunExt-from-Naive-FunExt.lagda
+++ b/source/UF/FunExt-from-Naive-FunExt.lagda
@@ -23,7 +23,6 @@ open import MLTT.Spartan
 open import UF.Base
 open import UF.FunExt
 open import UF.Equiv
-open import UF.EquivalenceExamples
 open import UF.Equiv-FunExt
 open import UF.Yoneda
 open import UF.Subsingletons

--- a/source/UF/H-Levels.lagda
+++ b/source/UF/H-Levels.lagda
@@ -31,7 +31,6 @@ open import Naturals.Order
 open import UF.Embeddings
 open import UF.Equiv
 open import UF.EquivalenceExamples
-open import UF.PropTrunc
 open import UF.Retracts
 open import UF.Singleton-Properties
 open import UF.Subsingletons

--- a/source/UF/HLevels.lagda
+++ b/source/UF/HLevels.lagda
@@ -28,7 +28,6 @@ module UF.HLevels (ua : Univalence) where
 
 open import UF.EquivalenceExamples
 open import UF.FunExt
-open import UF.Sets
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties

--- a/source/UF/Knapp-UA.lagda
+++ b/source/UF/Knapp-UA.lagda
@@ -17,8 +17,6 @@ module UF.Knapp-UA where
 
 open import MLTT.Spartan
 open import UF.Base
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.Equiv
 open import UF.Equiv-FunExt
 open import UF.Univalence

--- a/source/UF/NotNotStablePropositions.lagda
+++ b/source/UF/NotNotStablePropositions.lagda
@@ -8,11 +8,6 @@ module UF.NotNotStablePropositions where
 
 open import MLTT.Spartan
 
-open import MLTT.Plus-Properties
-open import MLTT.Two-Properties
-open import Naturals.Properties
-open import NotionsOfDecidability.Complemented
-open import NotionsOfDecidability.Decidable
 open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Embeddings
@@ -79,8 +74,6 @@ Added 25 August 2023 by Martin Escardo from the former file UF.Miscelanea.
 
 \begin{code}
 
-open import UF.DiscreteAndSeparated
-open import UF.SubtypeClassifier
 
 decidable-types-are-¬¬-stable : {X : 𝓤 ̇ } → is-decidable X → ¬¬-stable X
 decidable-types-are-¬¬-stable (inl x) φ = x

--- a/source/UF/Powerset-Fin.lagda
+++ b/source/UF/Powerset-Fin.lagda
@@ -28,16 +28,12 @@ open import UF.Base
 open import UF.Equiv
 open import UF.EquivalenceExamples
 open import UF.FunExt
-open import UF.Classifiers
 open import UF.Lower-FunExt
 open import UF.ImageAndSurjection pt
 open import UF.Powerset
 open import UF.Sets
 open import UF.Sets-Properties
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.SubtypeClassifier
-open import UF.SubtypeClassifier-Properties
 
 open binary-unions-of-subsets pt
 

--- a/source/UF/Powerset-Resizing.lagda
+++ b/source/UF/Powerset-Resizing.lagda
@@ -15,17 +15,10 @@ module UF.Powerset-Resizing
        where
 
 open import MLTT.Spartan
-open import UF.Equiv
-open import UF.Equiv-FunExt
-open import UF.FunExt
-open import UF.Lower-FunExt
+open import UF.Powerset
 open import UF.PropTrunc
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
-open import UF.UA-FunExt
-open import UF.Univalence
-open import UF.Powerset
-open import UF.PropTrunc
 open import UF.SubtypeClassifier
 
 \end{code}

--- a/source/UF/PreSIP-Examples.lagda
+++ b/source/UF/PreSIP-Examples.lagda
@@ -9,7 +9,6 @@ Modified from SIP-Examples. Only the examples we need are included for the momen
 module UF.PreSIP-Examples where
 
 open import MLTT.Spartan
-open import Notation.Order
 
 open import UF.Base
 open import UF.PreSIP

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -16,7 +16,6 @@ axiom and the K axiom.
 module UF.PreUnivalence where
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
 open import UF.Sets

--- a/source/UF/PropTrunc-Variation.lagda
+++ b/source/UF/PropTrunc-Variation.lagda
@@ -14,7 +14,6 @@ open import MLTT.Spartan
 module UF.PropTrunc-Variation (F : Universe → Universe) where
 
 open import MLTT.Plus-Properties
-open import UF.Base
 open import UF.Subsingletons
 open import UF.FunExt
 open import UF.Subsingletons-FunExt

--- a/source/UF/Retracts-FunExt.lagda
+++ b/source/UF/Retracts-FunExt.lagda
@@ -5,7 +5,6 @@
 module UF.Retracts-FunExt where
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Retracts
 open import UF.FunExt
 

--- a/source/UF/SIP-Examples.lagda
+++ b/source/UF/SIP-Examples.lagda
@@ -47,7 +47,6 @@ open import UF.Embeddings
 open import UF.Equiv hiding (_≅_)
 open import UF.EquivalenceExamples
 open import UF.FunExt
-open import UF.Retracts
 open import UF.SIP
 open import UF.Sets
 open import UF.Sets-Properties

--- a/source/UF/Section-Embedding.lagda
+++ b/source/UF/Section-Embedding.lagda
@@ -12,14 +12,12 @@ https://lmcs.episciences.org/2027
 module UF.Section-Embedding where
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
 open import UF.EquivalenceExamples
 open import UF.Hedberg
 open import UF.KrausLemma
 open import UF.PropTrunc
-open import UF.Retracts
 open import UF.Subsingletons
 
 splits : {X : 𝓤 ̇ } → (X → X) → (𝓥 : Universe) → 𝓤 ⊔ (𝓥 ⁺) ̇

--- a/source/UF/SetTrunc.lagda
+++ b/source/UF/SetTrunc.lagda
@@ -8,7 +8,6 @@ module UF.SetTrunc where
 
 open import MLTT.Spartan
 open import UF.Sets
-open import UF.Subsingletons
 
 \end{code}
 

--- a/source/UF/Sets.lagda
+++ b/source/UF/Sets.lagda
@@ -10,7 +10,6 @@ module UF.Sets where
 
 open import MLTT.Plus-Properties
 open import MLTT.Spartan
-open import MLTT.Unit-Properties
 open import UF.Base
 open import UF.Subsingletons
 

--- a/source/UF/SmallnessProperties.lagda
+++ b/source/UF/SmallnessProperties.lagda
@@ -16,12 +16,10 @@ open import NotionsOfDecidability.Decidable
 open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
-open import UF.Equiv-FunExt
 open import UF.EquivalenceExamples
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Size
-open import UF.Subsingletons
 
 smallness-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                          → X is 𝓦 small

--- a/source/UF/StructureIdentityPrinciple.lagda
+++ b/source/UF/StructureIdentityPrinciple.lagda
@@ -315,7 +315,6 @@ module ∞-magma (𝓤 : Universe) (ua : is-univalent 𝓤) where
 
  open import UF.FunExt
  open import UF.UA-FunExt
- open import UF.EquivalenceExamples
 
  fe : funext 𝓤 𝓤
  fe = univalence-gives-funext ua

--- a/source/UF/SubtypeClassifier-Properties.lagda
+++ b/source/UF/SubtypeClassifier-Properties.lagda
@@ -17,7 +17,6 @@ open import UF.FunExt
 open import UF.Hedberg
 open import UF.Lower-FunExt
 open import UF.Sets
-open import UF.Sets-Properties
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier

--- a/source/UF/UA-FunExt.lagda
+++ b/source/UF/UA-FunExt.lagda
@@ -16,9 +16,7 @@ depend on univalence.
 module UF.UA-FunExt where
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Equiv
-open import UF.Equiv-FunExt
 open import UF.FunExt
 open import UF.FunExt-Properties
 open import UF.LeftCancellable
@@ -104,7 +102,6 @@ funext-from-successive-univalence : ∀ 𝓤
 funext-from-successive-univalence 𝓤 = univalence-gives-funext' 𝓤 (𝓤 ⁺)
 
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 Ω-ext-from-univalence : is-univalent 𝓤
                       → {p q : Ω 𝓤}

--- a/source/imports.sh
+++ b/source/imports.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+# This script will list unused imports
+#
+# Example usage
+## Run from TypeTopology/source
+## ./imports.sh UF/Embeddings.lagda
+## ./imports.sh DomainTheory/Lifting/LiftingDcpo.lagda
+
+FILE=$1
+
+# Get all line numbers that have 'open import ...'
+IMPORTS=$(grep -n "open import" $FILE | cut -d ':' -f1)
+
+# Get the cluster, e.g. 'UF' or 'DomainTheory/Lifting'
+CLUSTER=$(dirname $FILE)
+
+# And with '.' instead of '/'
+CLUSTERMOD=$(echo $CLUSTER | sed 's/\//./')
+
+# Get the (relative) module name
+MODNAME=$(basename $FILE | sed 's/.lagda$//')
+
+# Set up a temporary file for testing
+TEMP="UnusedImportTesting"
+FULLTEMP="${CLUSTER}/${TEMP}.lagda"
+
+for i in $IMPORTS;
+do
+    sed "$i s/^/-- /" $FILE > $FULLTEMP # Comment out an import
+
+    # Replace module name to match the temporary file
+    OLDMOD="module ${CLUSTERMOD}.${MODNAME}"
+    NEWMOD="module ${CLUSTERMOD}.${TEMP}"
+    sed -i "s/${OLDMOD}/${NEWMOD}/" $FULLTEMP
+
+    # Try to compile and report back
+    agda $FULLTEMP > /dev/null &&
+	{
+	    IMPORT=$(sed -n "${i}p" $FILE | cut -d ' ' -f3)
+	    echo "Importing $IMPORT was not necessary"
+	}
+done
+rm $FULLTEMP

--- a/source/rm-imports-dir.sh
+++ b/source/rm-imports-dir.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+# This script will *remove* unused imports from all files in directory
+#
+# Example usage
+## Run from TypeTopology/source
+## ./rm-imports-dir.sh UF/
+
+# WARNING: This script will break your file in case of duplicate imports.
+# This is not great, but at least it detects such duplicates as a side-effect :)
+# I think manually fixing those is the easiest way to handle this (for now).
+
+# WARNING: This script does *not* work with multi-level directories (yet),
+# e.g. TWA/ and DomainTheory/
+
+DIR=$1
+
+for i in $(ls $DIR);
+do
+    ./rm-imports.sh "${DIR}${i}"
+    echo "Done with ${i}"
+done

--- a/source/rm-imports.sh
+++ b/source/rm-imports.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+
+# This script will *remove* unused imports
+#
+# Example usage
+## Run from TypeTopology/source
+## ./rm-imports.sh UF/Embeddings.lagda
+## ./rm-imports.sh DomainTheory/Lifting/LiftingDcpo.lagda
+
+# NB: This script will break your file in case of duplicate imports.
+# This is not great, but at least it detects such duplicates as a side-effect :)
+# I think manually fixing those is the easiest way to handle this (for now).
+
+FILE=$1
+
+# Get all line numbers that have 'open import ...'
+IMPORTS=$(grep -n "open import" $FILE | cut -d ':' -f1)
+
+# Get the cluster, e.g. 'UF' or 'DomainTheory/Lifting'
+CLUSTER=$(dirname $FILE)
+
+# And with '.' instead of '/'
+CLUSTERMOD=$(echo $CLUSTER | sed 's/\//./')
+
+# Get the (relative) module name
+MODNAME=$(basename $FILE | sed 's/.lagda$//')
+
+# Set up a temporary file for testing
+TEMP="UnusedImportTesting"
+FULLTEMP="${CLUSTER}/${TEMP}.lagda"
+
+UNUSED=()
+
+for i in $IMPORTS;
+do
+    sed "$i s/^/-- /" $FILE > $FULLTEMP # Comment out an import
+
+    # Replace module name to match the temporary file
+    OLDMOD="module ${CLUSTERMOD}.${MODNAME}"
+    NEWMOD="module ${CLUSTERMOD}.${TEMP}"
+    sed -i "s/${OLDMOD}/${NEWMOD}/" $FULLTEMP
+
+    # Try to compile and save line numbers of unused imports
+    agda $FULLTEMP > /dev/null &&
+	{
+	    UNUSED+=( $i )
+	}
+done
+rm $FULLTEMP
+
+# Remove unused imports from the file
+sed -i "${UNUSED[*]/%/d;}" $FILE


### PR DESCRIPTION
The removal of unused imports in this PR was achieved with `./rm-imports-dir.sh UF/`.

All of this is quite rudimentary.