### PR TITLE
Unused imports

### DIFF
--- a/source/Locales/AdjointFunctorTheoremForFrames.lagda
+++ b/source/Locales/AdjointFunctorTheoremForFrames.lagda
@@ -12,7 +12,6 @@ Originally part of `ayberkt/formal-topology-in-UF`. Ported to TypeTopology on
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 
@@ -27,7 +26,6 @@ open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe
 open import Slice.Family
 open import UF.Logic
-open import UF.Subsingletons
 
 open AllCombinators pt fe
 open PropositionalTruncation pt

--- a/source/Locales/Adjunctions/Properties-DistributiveLattice.lagda
+++ b/source/Locales/Adjunctions/Properties-DistributiveLattice.lagda
@@ -14,7 +14,6 @@ frames.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 
@@ -24,7 +23,6 @@ module Locales.Adjunctions.Properties-DistributiveLattice
        where
 
 open import Locales.Adjunctions.Properties pt fe
-open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe

--- a/source/Locales/Adjunctions/Properties.lagda
+++ b/source/Locales/Adjunctions/Properties.lagda
@@ -20,7 +20,6 @@ to apply them to distributive lattices, generalizing them has become necessary.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 

--- a/source/Locales/CharacterisationOfContinuity.lagda
+++ b/source/Locales/CharacterisationOfContinuity.lagda
@@ -4,8 +4,6 @@ Ayberk Tosun, 11 September 2023
 
 {-# OPTIONS --safe --without-K #-}
 
-open import UF.Base
-open import UF.Subsingletons
 open import UF.PropTrunc
 open import UF.FunExt
 open import MLTT.Spartan
@@ -15,7 +13,6 @@ module Locales.CharacterisationOfContinuity (pt : propositional-truncations-exis
                                             (fe : Fun-Ext)                          where
 
 open import Locales.Frame               pt fe
-open import Locales.WayBelowRelation.Definition pt fe
 open import UF.Logic
 open import Slice.Family
 open import Locales.Compactness pt fe

--- a/source/Locales/ClassificationOfScottOpens.lagda
+++ b/source/Locales/ClassificationOfScottOpens.lagda
@@ -22,19 +22,16 @@ open Implication fe
 open Existential pt
 open Conjunction
 
-open import Locales.Frame pt fe
 open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Basics.Pointed pt fe 𝓤
 open import DomainTheory.Lifting.LiftingSet pt fe
 open import DomainTheory.Basics.Miscelanea pt fe 𝓤
 open import Lifting.Construction 𝓤
-open import UF.PropTrunc
 open import UF.SubtypeClassifier
 open import UF.Subsingletons-Properties
 open import Slice.Family
 open import UF.Equiv
-open import UF.HLevels
 open PropositionalTruncation pt
 
 \end{code}

--- a/source/Locales/Clopen.lagda
+++ b/source/Locales/Clopen.lagda
@@ -7,17 +7,13 @@ Ayberk Tosun, 11 September 2023
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.Clopen (pt : propositional-truncations-exist)
                       (fe : Fun-Ext)
                       (sr : Set-Replacement pt) where
 
-open import Locales.AdjointFunctorTheoremForFrames
 open import Locales.Frame pt fe
-open import Locales.WayBelowRelation.Definition pt fe
-open import Locales.Compactness pt fe
 open import Locales.Complements pt fe
 open import Locales.WellInside pt fe sr
 open import Slice.Family
@@ -30,9 +26,7 @@ open import UF.Base using (from-Σ-＝)
 open AllCombinators pt fe
 open PropositionalTruncation pt
 
-open import Locales.GaloisConnection pt fe
 
-open import Locales.InitialFrame pt fe
 
 open Locale
 

--- a/source/Locales/CompactRegular.lagda
+++ b/source/Locales/CompactRegular.lagda
@@ -11,8 +11,6 @@ open import MLTT.Spartan hiding (𝟚)
 open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.UA-FunExt
-open import UF.Univalence
 
 module Locales.CompactRegular
         (pt : propositional-truncations-exist)

--- a/source/Locales/Compactness.lagda
+++ b/source/Locales/Compactness.lagda
@@ -12,11 +12,9 @@ will be broken down into smaller modules.
 
 {-# OPTIONS --safe --without-K #-}
 
-open import UF.Base
 open import UF.Sets
 open import UF.Subsingletons
 open import UF.Subsingletons-Properties
-open import UF.Subsingletons-FunExt
 open import UF.PropTrunc
 open import UF.FunExt
 open import MLTT.Spartan

--- a/source/Locales/Complements.lagda
+++ b/source/Locales/Complements.lagda
@@ -7,21 +7,13 @@ Ayberk Tosun, 11 September 2023
 open import MLTT.Spartan hiding (𝟚)
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.UA-FunExt
 
 module Locales.Complements (pt : propositional-truncations-exist)
                            (fe : Fun-Ext)                           where
 
-open import Locales.AdjointFunctorTheoremForFrames
-open import Locales.Compactness pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
-open import Locales.GaloisConnection pt fe
-open import Locales.InitialFrame     pt fe
-open import Locales.WayBelowRelation.Definition pt fe
-open import Slice.Family
-open import UF.Base using (from-Σ-＝)
 open import UF.Logic
 open import UF.SubtypeClassifier
 

--- a/source/Locales/ContinuousMap/Definition.lagda
+++ b/source/Locales/ContinuousMap/Definition.lagda
@@ -13,10 +13,8 @@ Factored out from the `Locales.Frame` module into this module on 2024-04-10.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
-open import MLTT.List hiding ([_])
 
 module Locales.ContinuousMap.Definition
         (pt : propositional-truncations-exist)
@@ -26,12 +24,7 @@ module Locales.ContinuousMap.Definition
 open import Locales.Frame pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Slice.Family
-open import UF.Equiv
-open import UF.Hedberg
 open import UF.Logic
-open import UF.Sets
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/FrameHomomorphism-Definition.lagda
@@ -15,10 +15,8 @@ Factored out from the `Locales.Frame` module into this module on 2024-04-10.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
-open import MLTT.List hiding ([_])
 
 module Locales.ContinuousMap.FrameHomomorphism-Definition
         (pt : propositional-truncations-exist)
@@ -28,11 +26,8 @@ module Locales.ContinuousMap.FrameHomomorphism-Definition
 open import Locales.Frame pt fe
 open import Slice.Family
 open import UF.Equiv
-open import UF.Hedberg
 open import UF.Logic
 open import UF.Sets
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/ContinuousMap/FrameHomomorphism-Properties.lagda
+++ b/source/Locales/ContinuousMap/FrameHomomorphism-Properties.lagda
@@ -13,7 +13,6 @@ Factored out from the `Locales.Frame` module on 2024-04-10.
 
 {-# OPTIONS --safe --without-K #-}
 
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
 open import UF.Base
 open import UF.FunExt
@@ -27,11 +26,8 @@ module Locales.ContinuousMap.FrameHomomorphism-Properties
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.Frame pt fe
 open import Slice.Family
-open import UF.Hedberg
 open import UF.Logic
-open import UF.Sets
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/ContinuousMap/FrameIsomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/FrameIsomorphism-Definition.lagda
@@ -24,12 +24,10 @@ module Locales.ContinuousMap.FrameIsomorphism-Definition
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
-open import Slice.Family
 open import UF.Equiv
 open import UF.Equiv-FunExt
 open import UF.Logic
 open import UF.Retracts
-open import UF.SIP
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier

--- a/source/Locales/ContinuousMap/Homeomorphism-Definition.lagda
+++ b/source/Locales/ContinuousMap/Homeomorphism-Definition.lagda
@@ -14,7 +14,6 @@ their defining frames, however, we give a different name to this notion.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 
@@ -23,17 +22,9 @@ module Locales.ContinuousMap.Homeomorphism-Definition
         (fe : Fun-Ext)
        where
 
-open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameIsomorphism-Definition pt fe
 open import Locales.Frame pt fe
-open import Slice.Family
-open import UF.Equiv
-open import UF.Hedberg
 open import UF.Logic
-open import UF.Sets
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.SubtypeClassifier
 
 open AllCombinators pt fe
 open Locale

--- a/source/Locales/ContinuousMap/Homeomorphism-Properties.lagda
+++ b/source/Locales/ContinuousMap/Homeomorphism-Properties.lagda
@@ -11,7 +11,6 @@ Some properties of locale homeomorphisms.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Size
@@ -32,18 +31,11 @@ private
  pe : Prop-Ext
  pe {𝓤} = univalence-gives-propext (ua 𝓤)
 
-open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameIsomorphism-Definition pt fe
 open import Locales.ContinuousMap.Homeomorphism-Definition pt fe
 open import Locales.Frame pt fe
 open import Locales.SIP.FrameSIP ua pt sr
-open import Slice.Family
-open import UF.Equiv
-open import UF.Hedberg
 open import UF.Logic
-open import UF.Sets
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/ContinuousMap/Properties.lagda
+++ b/source/Locales/ContinuousMap/Properties.lagda
@@ -11,10 +11,8 @@ Factored out from the `Locales.Frame` module on 2024-04-10.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
-open import MLTT.List hiding ([_])
 
 module Locales.ContinuousMap.Properties
         (pt : propositional-truncations-exist)
@@ -22,17 +20,9 @@ module Locales.ContinuousMap.Properties
        where
 
 open import Locales.Frame pt fe
-open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.ContinuousMap.Definition pt fe
-open import Slice.Family
-open import UF.Equiv
-open import UF.Hedberg
 open import UF.Logic
-open import UF.Sets
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.SubtypeClassifier
 
 open AllCombinators pt fe
 open ContinuousMaps

--- a/source/Locales/DirectedFamily-Poset.lagda
+++ b/source/Locales/DirectedFamily-Poset.lagda
@@ -24,7 +24,6 @@ module Locales.DirectedFamily-Poset (pt : propositional-truncations-exist)
 open import Locales.Frame pt fe hiding (is-directed)
 open import MLTT.Spartan
 open import UF.Logic
-open import UF.Subsingletons
 
 open AllCombinators pt fe
 open PropositionalTruncation pt

--- a/source/Locales/DirectedFamily.lagda
+++ b/source/Locales/DirectedFamily.lagda
@@ -16,7 +16,6 @@ and constructions that involve only the order of a given frame.
 open import MLTT.Spartan
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 
 module Locales.DirectedFamily
@@ -26,9 +25,7 @@ module Locales.DirectedFamily
         (_≤_ : X → X → Ω 𝓥)
        where
 
-open import Locales.Frame pt fe hiding (is-directed)
 open import Slice.Family
-open import UF.Equiv
 open import UF.Logic
 
 open AllCombinators pt fe

--- a/source/Locales/DiscreteLocale/Definition.lagda
+++ b/source/Locales/DiscreteLocale/Definition.lagda
@@ -22,7 +22,6 @@ module Locales.DiscreteLocale.Definition
         (pt : propositional-truncations-exist)
        where
 
-open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.Frame pt fe
 open import MLTT.Spartan
 open import Slice.Family

--- a/source/Locales/DiscreteLocale/Two-Properties.lagda
+++ b/source/Locales/DiscreteLocale/Two-Properties.lagda
@@ -25,22 +25,12 @@ module Locales.DiscreteLocale.Two-Properties
        where
 
 
-open import Locales.DiscreteLocale.Definition fe pe pt
 open import Locales.DiscreteLocale.Two fe pe pt
-open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.Frame pt fe
-open import Locales.SmallBasis pt fe sr
-open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.Spectrality.SpectralMap pt fe
-open import Locales.Sierpinski 𝓤 pe pt fe
-open import Locales.Stone pt fe sr
--- open import Locales.PatchProperties pt fe sr
 open import Locales.Compactness pt fe
 open import Slice.Family
-open import UF.DiscreteAndSeparated hiding (𝟚-is-set)
 open import UF.Logic
 open import UF.Powerset
-open import UF.Sets
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_; _∨_ to _∨ₚ_)

--- a/source/Locales/DiscreteLocale/Two.lagda
+++ b/source/Locales/DiscreteLocale/Two.lagda
@@ -21,16 +21,13 @@ module Locales.DiscreteLocale.Two
         (pt : propositional-truncations-exist)
        where
 
-open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DiscreteLocale.Definition fe pe pt
 open import Locales.Frame pt fe
 open import MLTT.Spartan hiding (𝟚)
-open import Slice.Family
 open import UF.Logic
 open import UF.Sets
 open import UF.DiscreteAndSeparated hiding (𝟚-is-set)
 open import UF.Powerset
-open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_; _∨_ to _∨ₚ_)
 open PropositionalSubsetInclusionNotation fe

--- a/source/Locales/DistributiveLattice/Definition-SigmaBased.lagda
+++ b/source/Locales/DistributiveLattice/Definition-SigmaBased.lagda
@@ -20,15 +20,11 @@ module Locales.DistributiveLattice.Definition-SigmaBased
        where
 
 open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.Frame pt fe
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Equiv
 open import UF.Logic
-open import UF.Powerset-MultiUniverse
 open import UF.Sets-Properties
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier
 

--- a/source/Locales/DistributiveLattice/Definition.lagda
+++ b/source/Locales/DistributiveLattice/Definition.lagda
@@ -19,9 +19,7 @@ module Locales.DistributiveLattice.Definition
 
 open import Locales.Frame pt fe
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Logic
-open import UF.Powerset-MultiUniverse
 open import UF.SubtypeClassifier
 
 open Implication fe

--- a/source/Locales/DistributiveLattice/Homomorphism.lagda
+++ b/source/Locales/DistributiveLattice/Homomorphism.lagda
@@ -14,7 +14,6 @@ homomorphism.
 
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Sets
 
 module Locales.DistributiveLattice.Homomorphism
         (fe : Fun-Ext)
@@ -24,9 +23,7 @@ module Locales.DistributiveLattice.Homomorphism
 open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.Frame pt fe
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Logic
-open import UF.Powerset-MultiUniverse
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_)

--- a/source/Locales/DistributiveLattice/Ideal-Properties.lagda
+++ b/source/Locales/DistributiveLattice/Ideal-Properties.lagda
@@ -12,7 +12,6 @@ dates-updated: [2024-03-13, 2024-03-28, 2024-05-03]
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 module Locales.DistributiveLattice.Ideal-Properties
         (pt : propositional-truncations-exist)
@@ -22,17 +21,12 @@ module Locales.DistributiveLattice.Ideal-Properties
 
 open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DistributiveLattice.Ideal pt fe pe
-open import Locales.DistributiveLattice.Properties fe pt
 open import Locales.DistributiveLattice.Spectrum fe pe pt
 open import Locales.Frame pt fe hiding (is-directed)
-open import MLTT.List
 open import MLTT.Spartan
 open import Slice.Family
-open import UF.Base
 open import UF.Classifiers
-open import UF.Equiv hiding (_■)
 open import UF.Logic
-open import UF.Powerset-MultiUniverse hiding (𝕋)
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe hiding (_∨_)

--- a/source/Locales/DistributiveLattice/Ideal.lagda
+++ b/source/Locales/DistributiveLattice/Ideal.lagda
@@ -27,7 +27,6 @@ open import Locales.DistributiveLattice.Properties fe pt
 open import Locales.Frame pt fe
 open import MLTT.List
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Equiv hiding (_■)
 open import UF.Logic
 open import UF.Powerset-MultiUniverse

--- a/source/Locales/DistributiveLattice/Isomorphism-Properties.lagda
+++ b/source/Locales/DistributiveLattice/Isomorphism-Properties.lagda
@@ -12,10 +12,8 @@ In this module, we collect properties of distributive lattice isomorphisms.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Sets
 open import UF.Size
 open import UF.Subsingletons
 open import UF.UA-FunExt
@@ -34,26 +32,10 @@ private
  pe : Prop-Ext
  pe {𝓤} = univalence-gives-propext (ua 𝓤)
 
-open import Locales.AdjointFunctorTheoremForFrames pt fe
-open import Locales.Adjunctions.Properties pt fe
-open import Locales.Adjunctions.Properties-DistributiveLattice pt fe
 open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.DistributiveLattice.Isomorphism fe pt
-open import Locales.Frame pt fe
-open import Locales.GaloisConnection pt fe
 open import Locales.SIP.DistributiveLatticeSIP ua pt sr
-open import MLTT.Spartan
-open import UF.Base
-open import UF.Equiv
-open import UF.Equiv-FunExt
 open import UF.Logic
-open import UF.Powerset-MultiUniverse
-open import UF.Retracts
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
-open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_)
 

--- a/source/Locales/DistributiveLattice/Isomorphism.lagda
+++ b/source/Locales/DistributiveLattice/Isomorphism.lagda
@@ -14,7 +14,6 @@ isomorphism.
 
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Sets
 
 module Locales.DistributiveLattice.Isomorphism
         (fe : Fun-Ext)
@@ -33,11 +32,8 @@ open import UF.Base
 open import UF.Equiv
 open import UF.Equiv-FunExt
 open import UF.Logic
-open import UF.Powerset-MultiUniverse
-open import UF.Retracts
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_)

--- a/source/Locales/DistributiveLattice/Properties.lagda
+++ b/source/Locales/DistributiveLattice/Properties.lagda
@@ -10,7 +10,6 @@ start-date:  2024-02-14
 
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Sets
 
 module Locales.DistributiveLattice.Properties
         (fe : Fun-Ext)
@@ -18,14 +17,10 @@ module Locales.DistributiveLattice.Properties
        where
 
 open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.Frame pt fe
-open import UF.Powerset-MultiUniverse
 open import MLTT.List
 open import MLTT.Spartan
-open import UF.Base
 open import UF.SubtypeClassifier
 open import UF.Logic
-open import UF.Equiv hiding (_■)
 
 open AllCombinators pt fe hiding (_∨_; _∧_)
 

--- a/source/Locales/DistributiveLattice/Resizing.lagda
+++ b/source/Locales/DistributiveLattice/Resizing.lagda
@@ -25,10 +25,7 @@ on `Aᶜ`.
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import Slice.Family
-open import UF.Base
 open import UF.FunExt
-open import UF.ImageAndSurjection
 open import UF.PropTrunc
 open import UF.Size
 open import UF.SubtypeClassifier
@@ -45,12 +42,10 @@ private
  fe : Fun-Ext
  fe {𝓤} {𝓥} = univalence-gives-funext' 𝓤 𝓥 (ua 𝓤) (ua (𝓤 ⊔ 𝓥))
 
-open import Locales.Compactness pt fe
 open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.DistributiveLattice.Isomorphism fe pt
 open import Locales.Frame pt fe
-open import Locales.SmallBasis pt fe sr
 open import UF.Equiv
 open import UF.Logic
 open import UF.Sets-Properties

--- a/source/Locales/DistributiveLattice/Spectrum-Properties.lagda
+++ b/source/Locales/DistributiveLattice/Spectrum-Properties.lagda
@@ -33,7 +33,6 @@ open import Locales.DistributiveLattice.Spectrum fe pe pt
 open import Locales.Frame pt fe
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralLocale pt fe
-open import MLTT.Fin hiding (𝟎; 𝟏)
 open import MLTT.List hiding ([_])
 open import MLTT.Spartan
 open import Slice.Family

--- a/source/Locales/DistributiveLattice/Spectrum.lagda
+++ b/source/Locales/DistributiveLattice/Spectrum.lagda
@@ -26,7 +26,6 @@ open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DistributiveLattice.Ideal pt fe pe
 open import Locales.DistributiveLattice.Properties fe pt
 open import Locales.Frame pt fe hiding (is-directed)
-open import MLTT.Fin hiding (𝟎; 𝟏)
 open import MLTT.List hiding ([_])
 open import MLTT.Spartan
 open import Slice.Family

--- a/source/Locales/GaloisConnection.lagda
+++ b/source/Locales/GaloisConnection.lagda
@@ -17,7 +17,6 @@ module Locales.GaloisConnection
 open import Locales.Frame pt fe
 open import UF.Logic
 open import UF.SubtypeClassifier
-open import UF.SubtypeClassifier-Properties
 open import UF.Subsingletons
 
 open AllCombinators pt fe

--- a/source/Locales/HeytingComplementation.lagda
+++ b/source/Locales/HeytingComplementation.lagda
@@ -2,16 +2,9 @@
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan hiding (𝟚)
-open import Slice.Family
-open import UF.Base
-open import UF.Embeddings
-open import UF.Equiv renaming (_■ to _𝔔𝔈𝔇)
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.PropTrunc
-open import UF.Retracts
 open import UF.Size
 open import UF.SubtypeClassifier
 
@@ -20,7 +13,6 @@ module Locales.HeytingComplementation (pt : propositional-truncations-exist)
                                       (sr : Set-Replacement pt) where
 
 open import Locales.Frame              pt fe
-open import Locales.Compactness        pt fe
 open import Locales.HeytingImplication pt fe
 open import Locales.Complements        pt fe
 open import Locales.Clopen             pt fe sr

--- a/source/Locales/HeytingImplication.lagda
+++ b/source/Locales/HeytingImplication.lagda
@@ -5,7 +5,6 @@
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.PropTrunc
 open import UF.FunExt
 
@@ -18,7 +17,6 @@ open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe
 open import UF.Logic
 open import UF.SubtypeClassifier
-open import UF.Subsingletons
 
 open AllCombinators pt fe
 open PropositionalTruncation pt

--- a/source/Locales/InitialFrame.lagda
+++ b/source/Locales/InitialFrame.lagda
@@ -6,9 +6,7 @@ Based in part on `ayberkt/formal-topology-in-UF`.
 
 {-# OPTIONS --safe --without-K #-}
 
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan hiding (𝟚)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 
@@ -24,7 +22,6 @@ open import Slice.Family
 open import UF.Logic
 open import UF.Sets
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
+++ b/source/Locales/LawsonLocale/CompactElementsOfPoint.lagda
@@ -40,33 +40,23 @@ module Locales.LawsonLocale.CompactElementsOfPoint
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.ScottDomain      pt fe 𝓤
 open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Basics.Pointed pt fe 𝓤
 open import DomainTheory.Basics.WayBelow pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
-open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
-open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.DistributiveLattice.Ideal pt fe pe hiding (is-inhabited)
-open import Locales.DistributiveLattice.Properties fe pt
 open import Locales.Frame pt fe hiding (is-directed)
 open import Locales.InitialFrame pt fe
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
-open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
-open import Locales.SmallBasis pt fe sr
 open import Locales.Point.Definition pt fe
 open import Locales.Point.Properties pt fe 𝓤 pe hiding (𝟏L)
-open import Locales.Spectrality.SpectralMap pt fe
 open import Locales.TerminalLocale.Properties pt fe sr
 open import Slice.Family
 open import UF.Logic
 open import UF.Powerset
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 open import UF.Univalence
 

--- a/source/Locales/LawsonLocale/PointsOfPatch.lagda
+++ b/source/Locales/LawsonLocale/PointsOfPatch.lagda
@@ -14,7 +14,6 @@ points of `Patch(Scott(𝓓))`.
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan
 open import UF.FunExt
 open import UF.PropTrunc
@@ -37,19 +36,9 @@ private
  pe : Prop-Ext
  pe {𝓤} = univalence-gives-propext (ua 𝓤)
 
-open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.CompactBasis pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.ScottDomain pt fe 𝓤
 open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Basics.WayBelow pt fe 𝓤
-open import DomainTheory.Topology.ScottTopology pt fe 𝓤
-open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
-open import Locales.Clopen pt fe sr
-open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
-open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.ContinuousMap.Definition pt fe
-open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
@@ -58,11 +47,7 @@ open import Locales.LawsonLocale.SharpElementsCoincideWithSpectralPoints 𝓤 ua
 open import Locales.PatchLocale pt fe sr
 open import Locales.PatchProperties pt fe sr
 open import Locales.PerfectMaps pt fe
-open import Locales.Point.Definition pt fe
 open import Locales.Point.SpectralPoint-Definition pt fe pe
-open import Locales.ScottLocale.Definition pt fe 𝓤
-open import Locales.ScottLocale.Properties pt fe 𝓤
-open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralMap pt fe
@@ -72,14 +57,9 @@ open import Locales.StoneImpliesSpectral pt fe sr
 open import Locales.TerminalLocale.Properties pt fe sr
 open import Locales.UniversalPropertyOfPatch pt fe sr
 open import Locales.ZeroDimensionality pt fe sr
-open import NotionsOfDecidability.Decidable
-open import NotionsOfDecidability.SemiDecidable fe pe pt
-open import Slice.Family
 open import UF.Base
 open import UF.Equiv
 open import UF.Logic
-open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 
 open AllCombinators pt fe

--- a/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
+++ b/source/Locales/LawsonLocale/SharpElementsCoincideWithSpectralPoints.lagda
@@ -40,37 +40,29 @@ private
  pe {𝓤} = univalence-gives-propext (ua 𝓤)
 
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.CompactBasis pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.ScottDomain pt fe 𝓤
 open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
 open import DomainTheory.Basics.WayBelow pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties pt fe 𝓤
-open import Locales.Clopen pt fe sr
-open import Locales.CompactRegular pt fe using (clopens-are-compact-in-compact-frames)
 open import Locales.Compactness pt fe hiding (is-compact)
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe hiding (_⊑_)
 open import Locales.LawsonLocale.CompactElementsOfPoint 𝓤 fe pe pt sr
-open import Locales.Point.Definition pt fe
 open import Locales.Point.SpectralPoint-Definition pt fe
-open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
-open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralMap pt fe
 open import Locales.TerminalLocale.Properties pt fe sr
 open import NotionsOfDecidability.Decidable
-open import NotionsOfDecidability.SemiDecidable fe pe pt
 open import Slice.Family
 open import UF.Equiv
 open import UF.Logic
 open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier renaming (⊥ to ⊥ₚ)
 
 open AllCombinators pt fe

--- a/source/Locales/NotationalConventions.lagda
+++ b/source/Locales/NotationalConventions.lagda
@@ -7,10 +7,6 @@ Ayberk Tosun, 13 September 2023
 
 open import UF.PropTrunc
 open import UF.FunExt
-open import MLTT.Spartan
-open import UF.Logic
-open import UF.SubtypeClassifier
-open import Slice.Family
 
 module Locales.NotationalConventions (pt : propositional-truncations-exist)
                                      (fe : Fun-Ext) where

--- a/source/Locales/Nucleus.lagda
+++ b/source/Locales/Nucleus.lagda
@@ -7,9 +7,7 @@ Based on `ayberkt/formal-topology-in-UF`.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.FunExt
-open import UF.PropTrunc
 open import UF.PropTrunc
 
 module Locales.Nucleus
@@ -22,7 +20,6 @@ open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import UF.Logic
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/PerfectMaps.lagda
+++ b/source/Locales/PerfectMaps.lagda
@@ -13,11 +13,9 @@ module Locales.PerfectMaps (pt : propositional-truncations-exist)
 open import Locales.AdjointFunctorTheoremForFrames
 open import Locales.Compactness pt fe
 open import Locales.ContinuousMap.Definition pt fe
-open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe
-open import Locales.InitialFrame pt fe
 open import Locales.Spectrality.Properties     pt fe
 open import Locales.Spectrality.SpectralLocale pt fe
 open import Locales.WayBelowRelation.Definition pt fe

--- a/source/Locales/Point/Definition.lagda
+++ b/source/Locales/Point/Definition.lagda
@@ -10,10 +10,8 @@ This module contains the definition of point of a locale.
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.EquivalenceExamples
 open import UF.SubtypeClassifier
 open import UF.Logic
 open import UF.Equiv

--- a/source/Locales/Point/Properties.lagda
+++ b/source/Locales/Point/Properties.lagda
@@ -11,7 +11,6 @@ completely prime filters.
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.PropTrunc
 open import UF.FunExt
 open import UF.Logic

--- a/source/Locales/Point/SpectralPoint-Definition.lagda
+++ b/source/Locales/Point/SpectralPoint-Definition.lagda
@@ -15,14 +15,10 @@ is equivalent to the standard definition.
 
 {-# OPTIONS --safe --without-K #-}
 
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Size
 open import UF.Subsingletons
-open import UF.UA-FunExt
-open import UF.Univalence
 
 module Locales.Point.SpectralPoint-Definition
         (pt : propositional-truncations-exist)

--- a/source/Locales/Regular.lagda
+++ b/source/Locales/Regular.lagda
@@ -8,7 +8,6 @@ open import MLTT.Spartan hiding (𝟚)
 open import MLTT.List hiding ([_])
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.Regular (pt : propositional-truncations-exist)
@@ -22,7 +21,6 @@ Importation of foundational UF stuff.
 \begin{code}
 
 open import Slice.Family
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 open import UF.Logic
 
@@ -38,14 +36,8 @@ Importations of other locale theory modules.
 open import Locales.Frame                         pt fe
 open import Locales.WayBelowRelation.Definition   pt fe
 open import Locales.Compactness                   pt fe
-open import Locales.Complements                   pt fe
-open import Locales.GaloisConnection              pt fe
-open import Locales.InitialFrame                  pt fe
-open import Locales.Spectrality.SpectralLocale    pt fe
-open import Locales.SmallBasis                    pt fe sr
 open import Locales.Clopen                        pt fe sr
 open import Locales.WellInside                    pt fe sr
-open import Locales.ScottContinuity               pt fe sr
 
 open Locale
 

--- a/source/Locales/SIP/DistributiveLatticeSIP.lagda
+++ b/source/Locales/SIP/DistributiveLatticeSIP.lagda
@@ -34,13 +34,10 @@ open import Locales.DistributiveLattice.Definition-SigmaBased fe pt
 open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.DistributiveLattice.Isomorphism fe pt
 open import Locales.Frame pt fe
-open import Slice.Family
 open import UF.Base
 open import UF.Equiv
 open import UF.Logic
 open import UF.SIP
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/SIP/FrameSIP.lagda
+++ b/source/Locales/SIP/FrameSIP.lagda
@@ -45,8 +45,6 @@ open import UF.Base
 open import UF.Equiv
 open import UF.Logic
 open import UF.SIP
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe

--- a/source/Locales/ScottContinuity.lagda
+++ b/source/Locales/ScottContinuity.lagda
@@ -9,7 +9,6 @@ Split out from the `CompactRegular` module.
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.ScottContinuity (pt : propositional-truncations-exist)
@@ -19,15 +18,12 @@ module Locales.ScottContinuity (pt : propositional-truncations-exist)
 open import Locales.Frame pt fe
 open import Slice.Family
 open import UF.SubtypeClassifier
-open import UF.Subsingletons
 
 open import UF.Logic
 
 open AllCombinators pt fe
 open PropositionalTruncation pt
-open import Locales.GaloisConnection pt fe
 
-open import Locales.InitialFrame pt fe
 
 \end{code}
 

--- a/source/Locales/ScottLocale/Definition.lagda
+++ b/source/Locales/ScottLocale/Definition.lagda
@@ -7,20 +7,14 @@ definition of dcpo from the `DomainTheory` development due to Tom de Jong.
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import MLTT.Spartan
 open import Slice.Family
-open import UF.Base
-open import UF.EquivalenceExamples
 open import UF.FunExt
 open import UF.Logic
 open import UF.PropTrunc
 open import UF.SubtypeClassifier
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
-open import UF.UA-FunExt
-open import UF.Univalence
 
 \end{code}
 
@@ -58,7 +52,6 @@ by
 
 module DefnOfScottLocale (𝓓 : DCPO {𝓤} {𝓣}) (𝓦 : Universe) (pe : propext 𝓦) where
 
- open import DomainTheory.Lifting.LiftingSet pt fe 𝓦 pe
  open DefnOfScottTopology 𝓓 𝓦
 
 \end{code}

--- a/source/Locales/ScottLocale/Properties.lagda
+++ b/source/Locales/ScottLocale/Properties.lagda
@@ -9,20 +9,13 @@ dates-updated: [2024-03-16]
 
 {-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import MLTT.Spartan
 open import Slice.Family
-open import UF.Base
-open import UF.EquivalenceExamples
 open import UF.FunExt
 open import UF.Logic
 open import UF.PropTrunc
 open import UF.SubtypeClassifier
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.UA-FunExt
-open import UF.Univalence
 
 \end{code}
 
@@ -36,11 +29,8 @@ module Locales.ScottLocale.Properties (pt : propositional-truncations-exist)
                                       (𝓤  : Universe) where
 
 open import DomainTheory.BasesAndContinuity.Bases            pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.Continuity       pt fe 𝓤
 open import DomainTheory.Basics.Dcpo                         pt fe 𝓤
  renaming (⟨_⟩ to ⟨_⟩∙) hiding   (is-directed)
-open import DomainTheory.Basics.Pointed                      pt fe 𝓤
- renaming (⊥ to ⊥d)
 open import DomainTheory.Basics.WayBelow                     pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology              pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties    pt fe 𝓤

--- a/source/Locales/ScottLocale/ScottLocalesOfAlgebraicDcpos.lagda
+++ b/source/Locales/ScottLocale/ScottLocalesOfAlgebraicDcpos.lagda
@@ -23,8 +23,6 @@ open import UF.Logic
 open import UF.PropTrunc
 open import UF.SubtypeClassifier
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.Powerset-MultiUniverse
 
 \end{code}
 
@@ -75,7 +73,6 @@ module ScottLocaleConstruction (𝓓    : DCPO {𝓤 ⁺} {𝓤})
                                (hscb : has-specified-small-compact-basis 𝓓)
                                (pe   : propext 𝓤)                          where
 
- open import DomainTheory.Lifting.LiftingSet pt fe 𝓤 pe
  open DefnOfScottTopology 𝓓 𝓤
  open DefnOfScottLocale 𝓓 𝓤 pe using (𝒪ₛ-equality; _⊆ₛ_; ⊆ₛ-is-reflexive;
                                       ⊆ₛ-is-transitive; ⊆ₛ-is-antisymmetric;

--- a/source/Locales/ScottLocale/ScottLocalesOfScottDomains.lagda
+++ b/source/Locales/ScottLocale/ScottLocalesOfScottDomains.lagda
@@ -15,11 +15,8 @@ satisfies a certain decidability condition).
 {-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
 
 open import MLTT.List hiding ([_])
-open import MLTT.Negation
 open import MLTT.Spartan hiding (𝟚)
 open import Slice.Family
-open import UF.Classifiers
-open import UF.Embeddings
 open import UF.EquivalenceExamples
 open import UF.FunExt
 open import UF.Logic
@@ -27,7 +24,6 @@ open import UF.Powerset-MultiUniverse
 open import UF.PropTrunc
 open import UF.Size
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 open import UF.Univalence
 
@@ -43,8 +39,6 @@ open import DomainTheory.BasesAndContinuity.Continuity       pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.ScottDomain      pt fe 𝓤
 open import DomainTheory.Basics.Dcpo                         pt fe 𝓤
  renaming (⟨_⟩ to ⟨_⟩∙) hiding   (is-directed)
-open import DomainTheory.Basics.Pointed                      pt fe 𝓤
- renaming (⊥ to ⊥d)
 open import DomainTheory.Basics.WayBelow                     pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology              pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties    pt fe 𝓤

--- a/source/Locales/Sierpinski.lagda
+++ b/source/Locales/Sierpinski.lagda
@@ -3,7 +3,6 @@
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import UF.FunExt
-open import UF.Logic
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.Subsingletons
@@ -20,9 +19,7 @@ open import DomainTheory.Basics.Pointed pt fe 𝓤
 open import DomainTheory.Lifting.LiftingSet pt fe
 open import DomainTheory.Lifting.LiftingSetAlgebraic pt pe fe
 open import Locales.Frame pt fe hiding (𝟚)
-open import Slice.Family
 
-open import UF.SubtypeClassifier
 open import UF.Subsingletons-Properties
 
 \end{code}
@@ -48,7 +45,6 @@ open import Locales.ScottLocale.Definition pt fe 𝓤
 
 open DefnOfScottLocale (𝕊-dcpo ⁻) 𝓤 pe
 open Locale
-open import Lifting.Construction (𝓤 ⁺)
 
 𝕊 : Locale (𝓤 ⁺) (𝓤 ⁺) 𝓤
 𝕊 = ScottLocale

--- a/source/Locales/Sierpinski/Definition.lagda
+++ b/source/Locales/Sierpinski/Definition.lagda
@@ -15,7 +15,6 @@ In the future, other constructions of the Sierpiński locale might be added here
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import UF.FunExt
-open import UF.Logic
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.Subsingletons
@@ -39,18 +38,10 @@ open import DomainTheory.Lifting.LiftingSetAlgebraic pt pe fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import Lifting.Construction 𝓤 hiding (⊥)
 open import Lifting.Miscelanea-PropExt-FunExt 𝓤 pe fe
-open import Lifting.UnivalentPrecategory 𝓤 (𝟙 {𝓤})
 open import Locales.Frame pt fe hiding (𝟚; is-directed)
-open import Locales.InitialFrame pt fe
-open import Locales.SmallBasis pt fe sr
-open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.Spectrality.SpectralMap pt fe
-open import Locales.Stone pt fe sr
-open import Slice.Family
 open import UF.DiscreteAndSeparated
 open import UF.Equiv
 open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier
 
 open Locale

--- a/source/Locales/Sierpinski/Patch.lagda
+++ b/source/Locales/Sierpinski/Patch.lagda
@@ -22,34 +22,14 @@ module Locales.Sierpinski.Patch
         (sr : Set-Replacement pt)
        where
 
-open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
-open import DomainTheory.Basics.Dcpo    pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Basics.Miscelanea pt fe 𝓤
-open import DomainTheory.Basics.Pointed pt fe 𝓤 renaming (⊥ to ⊥∙)
-open import DomainTheory.Basics.WayBelow pt fe 𝓤
-open import DomainTheory.Lifting.LiftingSet pt fe 𝓤 pe
-open import DomainTheory.Lifting.LiftingSetAlgebraic pt pe fe 𝓤
-open import Lifting.Construction 𝓤
-open import Lifting.Miscelanea-PropExt-FunExt 𝓤 pe fe
-open import Lifting.UnivalentPrecategory 𝓤 (𝟙 {𝓤})
 open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe hiding (𝟚; is-directed)
-open import Locales.InitialFrame pt fe
 open import Locales.Sierpinski.Definition 𝓤 pe pt fe sr
 open import Locales.Sierpinski.Properties 𝓤 pe pt fe sr
-open import Locales.SmallBasis pt fe sr
-open import Locales.Spectrality.SpectralLocale pt fe
 open import Locales.Spectrality.SpectralMap pt fe
 open import Locales.Stone pt fe sr
-open import Slice.Family
-open import UF.DiscreteAndSeparated
-open import UF.Equiv
-open import UF.Logic
-open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier
 
 open ContinuousMaps

--- a/source/Locales/Sierpinski/Properties.lagda
+++ b/source/Locales/Sierpinski/Properties.lagda
@@ -23,18 +23,10 @@ module Locales.Sierpinski.Properties
         (sr : Set-Replacement pt)
        where
 
-open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤
-open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
 open import DomainTheory.Basics.Dcpo    pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Basics.Miscelanea pt fe 𝓤
 open import DomainTheory.Basics.Pointed pt fe 𝓤 renaming (⊥ to ⊥∙)
-open import DomainTheory.Basics.WayBelow pt fe 𝓤
-open import DomainTheory.Lifting.LiftingSet pt fe 𝓤 pe
-open import DomainTheory.Lifting.LiftingSetAlgebraic pt pe fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import Lifting.Construction 𝓤
-open import Lifting.Miscelanea-PropExt-FunExt 𝓤 pe fe
-open import Lifting.UnivalentPrecategory 𝓤 (𝟙 {𝓤})
 open import Locales.Frame pt fe hiding (is-directed)
 open import Locales.InitialFrame pt fe
 open import Locales.ScottLocale.Definition pt fe 𝓤
@@ -43,14 +35,9 @@ open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
 open import Locales.Sierpinski.Definition 𝓤 pe pt fe sr
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.Spectrality.SpectralMap pt fe
-open import Locales.Stone pt fe sr
 open import MLTT.List hiding ([_])
 open import Slice.Family
-open import UF.DiscreteAndSeparated
-open import UF.Equiv
 open import UF.Subsingletons-FunExt
-open import UF.Subsingletons-Properties
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe
@@ -163,7 +150,6 @@ principal-filter-on-₁-is-truth = ≤-is-antisymmetric (poset-of (𝒪 𝕊)) �
 𝕊-is-spectralᴰ : spectralᴰ 𝕊
 𝕊-is-spectralᴰ = σᴰ
 
-open import Locales.PatchLocale pt fe sr
 
 𝕊-is-spectral : is-spectral 𝕊 holds
 𝕊-is-spectral = spectralᴰ-gives-spectrality 𝕊 σᴰ

--- a/source/Locales/Sierpinski/UniversalProperty.lagda
+++ b/source/Locales/Sierpinski/UniversalProperty.lagda
@@ -32,30 +32,20 @@ module Locales.Sierpinski.UniversalProperty
         (sr : Set-Replacement pt)
        where
 
-open import DomainTheory.Basics.Dcpo pt fe 𝓤 renaming (⟨_⟩ to ⟨_⟩∙)
-open import DomainTheory.Basics.Pointed pt fe 𝓤
 open import DomainTheory.Topology.ScottTopology pt fe 𝓤
 open import DomainTheory.Topology.ScottTopologyProperties pt fe
 open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
-open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.DistributiveLattice.Ideal pt fe pe
-open import Locales.DistributiveLattice.Properties fe pt
 open import Locales.Frame pt fe hiding (is-directed)
 open import Locales.ScottLocale.Definition pt fe 𝓤
 open import Locales.ScottLocale.Properties pt fe 𝓤
 open import Locales.ScottLocale.ScottLocalesOfAlgebraicDcpos pt fe 𝓤
-open import Locales.ScottLocale.ScottLocalesOfScottDomains pt fe sr 𝓤
 open import Locales.Sierpinski.Definition 𝓤 pe pt fe sr
 open import Locales.Sierpinski.Properties 𝓤 pe pt fe sr
 open import Locales.SmallBasis pt fe sr
-open import MLTT.Fin hiding (𝟎; 𝟏)
-open import MLTT.List hiding ([_])
 open import Slice.Family
 open import UF.Logic
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open AllCombinators pt fe renaming (_∧_ to _∧ₚ_; _∨_ to _∨ₚ_)

--- a/source/Locales/SmallBasis.lagda
+++ b/source/Locales/SmallBasis.lagda
@@ -29,8 +29,6 @@ open import UF.ImageAndSurjection pt
 open import UF.Equiv renaming (_■ to _𝒬ℰ𝒟)
 open import MLTT.List using (List; map; _<$>_; []; _∷_)
 open import UF.Univalence using (Univalence)
-open import UF.Sets using (is-set)
-open import UF.Subsingletons-FunExt
 open import Locales.Spectrality.Properties pt fe
 
 open PropositionalTruncation pt

--- a/source/Locales/Spectrality/BasisDirectification.lagda
+++ b/source/Locales/Spectrality/BasisDirectification.lagda
@@ -4,15 +4,13 @@ Ayberk Tosun, 17 August 2023.
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.Spartan
-open import UF.Base
-open import UF.PropTrunc
-open import UF.FunExt
-open import UF.FunExt
 open import MLTT.List hiding ([_])
+open import MLTT.Spartan
 open import Slice.Family
-open import UF.SubtypeClassifier
+open import UF.FunExt
+open import UF.PropTrunc
 open import UF.Size
+open import UF.SubtypeClassifier
 
 module Locales.Spectrality.BasisDirectification
         (pt : propositional-truncations-exist)
@@ -20,7 +18,6 @@ module Locales.Spectrality.BasisDirectification
         (sr : Set-Replacement pt) where
 
 open import Locales.Frame pt fe
-open import Locales.Compactness pt fe
 open import Locales.SmallBasis pt fe sr
 
 open import UF.Logic

--- a/source/Locales/Spectrality/LatticeOfCompactOpens-Duality.lagda
+++ b/source/Locales/Spectrality/LatticeOfCompactOpens-Duality.lagda
@@ -46,7 +46,6 @@ private
 
 open import Locales.AdjointFunctorTheoremForFrames pt fe
 open import Locales.Compactness pt fe
-open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameIsomorphism-Definition pt fe
 open import Locales.ContinuousMap.Homeomorphism-Definition pt fe
@@ -57,17 +56,14 @@ open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.DistributiveLattice.Ideal pt fe pe
 open import Locales.DistributiveLattice.Ideal-Properties pt fe pe
 open import Locales.DistributiveLattice.Isomorphism fe pt
-open import Locales.DistributiveLattice.Isomorphism-Properties ua pt sr
 open import Locales.DistributiveLattice.Resizing ua pt sr
 open import Locales.DistributiveLattice.Spectrum fe pe pt
 open import Locales.DistributiveLattice.Spectrum-Properties fe pe pt sr
 open import Locales.Frame pt fe
 open import Locales.GaloisConnection pt fe
-open import Locales.SIP.DistributiveLatticeSIP ua pt sr
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.LatticeOfCompactOpens ua pt sr
 open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.Spectrality.SpectralMap pt fe
 open import Slice.Family
 open import UF.Classifiers
 open import UF.Equiv hiding (_■)

--- a/source/Locales/Spectrality/LatticeOfCompactOpens.lagda
+++ b/source/Locales/Spectrality/LatticeOfCompactOpens.lagda
@@ -10,20 +10,11 @@ dates-updated:  [2024-04-30]
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import MLTT.Spartan
-open import Slice.Family
-open import UF.Base
-open import UF.EquivalenceExamples
 open import UF.FunExt
-open import UF.FunExt
-open import UF.ImageAndSurjection
 open import UF.Logic
 open import UF.PropTrunc
 open import UF.Size
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 open import UF.UA-FunExt
 open import UF.Univalence
@@ -40,11 +31,9 @@ private
 
 open import Locales.Compactness pt fe
 open import Locales.DistributiveLattice.Definition fe pt
-open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.Frame pt fe
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralLocale pt fe
-open import Locales.Spectrality.SpectralMap pt fe
 open import UF.Equiv
 
 open AllCombinators pt fe

--- a/source/Locales/Spectrality/Properties.lagda
+++ b/source/Locales/Spectrality/Properties.lagda
@@ -5,19 +5,11 @@ Ayberk Tosun, 13 September 2023
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import UF.Base
-open import UF.PropTrunc
-open import UF.FunExt
-open import UF.Univalence
-open import UF.FunExt
-open import UF.EquivalenceExamples
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import Slice.Family
-open import UF.Subsingletons
-open import UF.SubtypeClassifier
-open import UF.Subsingletons-FunExt
+open import UF.FunExt
 open import UF.Logic
+open import UF.PropTrunc
+open import UF.SubtypeClassifier
 
 module Locales.Spectrality.Properties (pt : propositional-truncations-exist)
                                       (fe : Fun-Ext) where

--- a/source/Locales/Spectrality/SpectralLocale.lagda
+++ b/source/Locales/Spectrality/SpectralLocale.lagda
@@ -10,19 +10,11 @@ will be broken down into smaller modules.
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
 open import MLTT.Spartan
-open import UF.Base
-open import UF.PropTrunc
-open import UF.FunExt
-open import UF.Univalence
-open import UF.FunExt
-open import UF.EquivalenceExamples
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import Slice.Family
-open import UF.Subsingletons
-open import UF.SubtypeClassifier
-open import UF.Subsingletons-FunExt
+open import UF.FunExt
 open import UF.Logic
+open import UF.PropTrunc
+open import UF.SubtypeClassifier
 
 module Locales.Spectrality.SpectralLocale (pt : propositional-truncations-exist)
                                           (fe : Fun-Ext) where

--- a/source/Locales/Spectrality/SpectralMap.lagda
+++ b/source/Locales/Spectrality/SpectralMap.lagda
@@ -20,10 +20,7 @@ open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.Frame pt fe
-open import MLTT.List hiding ([_])
 open import MLTT.Spartan
-open import Slice.Family
-open import UF.Base
 open import UF.Logic
 open import UF.SubtypeClassifier
 

--- a/source/Locales/Spectrality/SpectralMapToLatticeHomomorphism.lagda
+++ b/source/Locales/Spectrality/SpectralMapToLatticeHomomorphism.lagda
@@ -12,18 +12,11 @@ Any spectral map `f : X → Y` of spectral locales gives a lattice homomorphism
 
 {-# OPTIONS --safe --without-K --lossy-unification #-}
 
-open import MLTT.List hiding ([_])
-open import MLTT.Pi
 open import MLTT.Spartan
-open import Slice.Family
-open import UF.Base
 open import UF.FunExt
-open import UF.ImageAndSurjection
 open import UF.Logic
 open import UF.PropTrunc
 open import UF.Size
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 open import UF.UA-FunExt
 open import UF.Univalence
@@ -41,14 +34,12 @@ open import Locales.Compactness pt fe
 open import Locales.ContinuousMap.Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
-open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DistributiveLattice.Homomorphism fe pt
 open import Locales.Frame pt fe
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.LatticeOfCompactOpens ua pt sr
 open import Locales.Spectrality.SpectralLocale pt fe
 open import Locales.Spectrality.SpectralMap pt fe
-open import UF.EquivalenceExamples
 
 open AllCombinators pt fe
 open ContinuousMaps

--- a/source/Locales/Stone.lagda
+++ b/source/Locales/Stone.lagda
@@ -7,7 +7,6 @@ Ayberk Tosun, 11 September 2023
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.Stone (pt : propositional-truncations-exist)
@@ -20,8 +19,6 @@ Importation of foundational UF stuff.
 
 \begin{code}
 
-open import Slice.Family
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 open import UF.Logic
 
@@ -34,13 +31,8 @@ Importations of other locale theory modules.
 
 \begin{code}
 
-open import Locales.AdjointFunctorTheoremForFrames
 open import Locales.Frame            pt fe
-open import Locales.WayBelowRelation.Definition pt fe
 open import Locales.Compactness      pt fe
-open import Locales.Complements      pt fe
-open import Locales.GaloisConnection pt fe
-open import Locales.InitialFrame     pt fe
 open import Locales.ZeroDimensionality pt fe sr
 
 open Locale

--- a/source/Locales/StoneDuality/ForSpectralLocales.lagda
+++ b/source/Locales/StoneDuality/ForSpectralLocales.lagda
@@ -34,7 +34,6 @@ private
  pe : Prop-Ext
  pe {𝓤} = univalence-gives-propext (ua 𝓤)
 
-open import Locales.Compactness pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Definition pt fe
 open import Locales.ContinuousMap.FrameHomomorphism-Properties pt fe
 open import Locales.ContinuousMap.Homeomorphism-Definition pt fe
@@ -42,7 +41,6 @@ open import Locales.ContinuousMap.Homeomorphism-Properties ua pt sr
 open import Locales.DistributiveLattice.Definition fe pt
 open import Locales.DistributiveLattice.Isomorphism fe pt
 open import Locales.DistributiveLattice.Isomorphism-Properties ua pt sr
-open import Locales.DistributiveLattice.Resizing ua pt sr
 open import Locales.DistributiveLattice.Spectrum fe pe pt
 open import Locales.DistributiveLattice.Spectrum-Properties fe pe pt sr
 open import Locales.Frame pt fe
@@ -51,8 +49,6 @@ open import Locales.SIP.FrameSIP
 open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.LatticeOfCompactOpens ua pt sr
 open import Locales.Spectrality.LatticeOfCompactOpens-Duality ua pt sr
-open import Locales.Spectrality.SpectralLocale pt fe
-open import Slice.Family
 open import UF.Equiv
 open import UF.Logic
 open import UF.SubtypeClassifier

--- a/source/Locales/StoneImpliesSpectral.lagda
+++ b/source/Locales/StoneImpliesSpectral.lagda
@@ -7,7 +7,6 @@ Ayberk Tosun, 11 September 2023
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.StoneImpliesSpectral (pt : propositional-truncations-exist)
@@ -21,7 +20,6 @@ Importation of foundational UF stuff.
 \begin{code}
 
 open import Slice.Family
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 open import UF.Logic
 
@@ -34,14 +32,11 @@ Importations of other locale theory modules.
 
 \begin{code}
 
-open import Locales.AdjointFunctorTheoremForFrames
 open import Locales.Clopen             pt fe sr
 open import Locales.Compactness      pt fe
 open import Locales.Complements      pt fe
 open import Locales.ContinuousMap.Definition pt fe
 open import Locales.Frame            pt fe
-open import Locales.GaloisConnection pt fe
-open import Locales.InitialFrame     pt fe
 open import Locales.ScottContinuity    pt fe sr
 open import Locales.SmallBasis         pt fe sr
 open import Locales.Spectrality.SpectralLocale pt fe

--- a/source/Locales/TerminalLocale/Properties.lagda
+++ b/source/Locales/TerminalLocale/Properties.lagda
@@ -20,7 +20,6 @@ Stone spaces.
 
 open import MLTT.List hiding ([_])
 open import MLTT.Spartan hiding (𝟚; ₀; ₁)
-open import UF.Base
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Size
@@ -35,7 +34,6 @@ open import Locales.Clopen pt fe sr
 open import Locales.Compactness pt fe
 open import Locales.Frame pt fe
 open import Locales.InitialFrame pt fe
-open import Locales.SmallBasis pt fe sr
 open import Locales.Spectrality.SpectralityOfOmega pt fe sr
 open import Locales.Stone pt fe sr
 open import Locales.StoneImpliesSpectral pt fe sr
@@ -43,7 +41,6 @@ open import Locales.ZeroDimensionality pt fe sr
 open import Slice.Family
 open import UF.Equiv
 open import UF.Logic
-open import UF.Sets
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier

--- a/source/Locales/WellInside.lagda
+++ b/source/Locales/WellInside.lagda
@@ -9,7 +9,6 @@ Split out from the now-deprecated `CompactRegular` module.
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.WellInside (pt : propositional-truncations-exist)
@@ -22,13 +21,10 @@ Importation of foundational UF stuff.
 
 \begin{code}
 
-open import Slice.Family
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 open import UF.Logic
 
 open import Locales.Frame       pt fe
-open import Locales.Complements pt fe
 
 open AllCombinators pt fe
 open PropositionalTruncation pt

--- a/source/Locales/ZeroDimensionality.lagda
+++ b/source/Locales/ZeroDimensionality.lagda
@@ -7,7 +7,6 @@ Ayberk Tosun, 11 September 2023
 open import MLTT.Spartan hiding (𝟚)
 open import UF.PropTrunc
 open import UF.FunExt
-open import UF.UA-FunExt
 open import UF.Size
 
 module Locales.ZeroDimensionality (pt : propositional-truncations-exist)
@@ -21,7 +20,6 @@ Importation of foundational UF stuff.
 \begin{code}
 
 open import Slice.Family
-open import UF.Subsingletons
 open import UF.SubtypeClassifier
 open import UF.Logic
 
@@ -34,14 +32,9 @@ Importations of other locale theory modules.
 
 \begin{code}
 
-open import Locales.AdjointFunctorTheoremForFrames
 
 open import Locales.Frame            pt fe           hiding (is-directed-basis)
-open import Locales.WayBelowRelation.Definition pt fe
 open import Locales.Compactness      pt fe
-open import Locales.Complements      pt fe
-open import Locales.GaloisConnection pt fe
-open import Locales.InitialFrame     pt fe
 open import Locales.Clopen           pt fe sr
 open import Locales.SmallBasis       pt fe sr
 open import Locales.Regular          pt fe sr

--- a/source/MLTT/Fin.lagda
+++ b/source/MLTT/Fin.lagda
@@ -7,7 +7,6 @@ module MLTT.Fin where
 open import MLTT.Spartan
 open import MLTT.List
 open import MLTT.Bool
-open import Naturals.Properties
 
 
 data Fin : ℕ → 𝓤₀ ̇ where

--- a/source/MLTT/Negation.lagda
+++ b/source/MLTT/Negation.lagda
@@ -6,7 +6,6 @@ Negation (and emptiness).
 
 module MLTT.Negation where
 
-open import MLTT.Universes
 open import MLTT.Empty
 open import MLTT.Id
 open import MLTT.Pi

--- a/source/MLTT/Plus-Properties.lagda
+++ b/source/MLTT/Plus-Properties.lagda
@@ -7,7 +7,6 @@ Properties of the disjoint sum _+_ of types.
 module MLTT.Plus-Properties where
 
 open import MLTT.Plus
-open import MLTT.Universes
 open import MLTT.Negation
 open import MLTT.Id
 open import MLTT.Empty
@@ -57,7 +56,6 @@ Right-fails-gives-left-holds : {P : 𝓤 ̇ } {Q : 𝓥 ̇ } → P + Q → ¬ Q 
 Right-fails-gives-left-holds (inl p) u = p
 Right-fails-gives-left-holds (inr q) u = 𝟘-elim (u q)
 
-open import MLTT.Unit
 open import MLTT.Sigma
 open import Notation.General
 

--- a/source/MLTT/Unit-Properties.lagda
+++ b/source/MLTT/Unit-Properties.lagda
@@ -6,7 +6,6 @@ One-element type properties.
 
 module MLTT.Unit-Properties where
 
-open import MLTT.Universes
 open import MLTT.Unit
 open import MLTT.Empty
 open import MLTT.Id

--- a/source/MetricSpaces/DedekindReals.lagda
+++ b/source/MetricSpaces/DedekindReals.lagda
@@ -20,10 +20,7 @@ open import UF.FunExt
 open import UF.Powerset
 open import UF.PropTrunc
 open import UF.Subsingletons
-open import Naturals.Addition renaming (_+_ to _ℕ+_)
-open import Naturals.Order renaming ( max to ℕmax
-                                    ; max-comm to ℕmax-comm
-                                    ; max-assoc to ℕmax-assoc)
+open import Naturals.Order renaming (max to ℕmax)
 open import Rationals.Addition
 open import Rationals.Type
 open import Rationals.Abs
@@ -41,12 +38,10 @@ module MetricSpaces.DedekindReals
 
 open PropositionalTruncation pt
 
-open import Rationals.Limits fe pe pt
 open import MetricSpaces.Type fe pe pt
 open import MetricSpaces.Rationals fe pe pt
 open import DedekindReals.Type fe pe pt
 open import DedekindReals.Properties fe pe pt
-open import DedekindReals.Order fe pe pt
 
 \end{code}
 

--- a/source/MetricSpaces/Rationals.lagda
+++ b/source/MetricSpaces/Rationals.lagda
@@ -11,7 +11,6 @@ open import MLTT.Spartan renaming (_+_ to _∔_)
 
 open import Notation.Order
 open import UF.FunExt
-open import UF.Base
 open import UF.Subsingletons
 open import UF.PropTrunc
 open import Rationals.Type
@@ -27,7 +26,6 @@ module MetricSpaces.Rationals
   (pt : propositional-truncations-exist)
  where
 
-open import Rationals.MinMax
 open import MetricSpaces.Type fe pe pt
 
 ℚ-zero-dist : (q : ℚ) → abs (q - q) ＝ 0ℚ

--- a/source/MetricSpaces/Type.lagda
+++ b/source/MetricSpaces/Type.lagda
@@ -8,13 +8,11 @@ Cauchy and convergent sequences.
 
 open import MLTT.Spartan renaming (_+_ to _∔_)
 
-open import Naturals.Addition renaming (_+_ to _ℕ+_)
 open import Naturals.Order
 open import Notation.Order
 open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Subsingletons
-open import Rationals.Type
 open import Rationals.Positive
 
 module MetricSpaces.Type

--- a/source/Modal/ReflectiveSubuniverse.lagda
+++ b/source/Modal/ReflectiveSubuniverse.lagda
@@ -7,13 +7,11 @@ Much of this file is based on the proofs from Egbert Rijke's PhD thesis.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Subsingletons
 open import UF.Base
 open import UF.FunExt
 open import UF.Equiv
 open import UF.Retracts
 open import UF.Embeddings
-open import UF.EquivalenceExamples
 import UF.PairFun as PairFun
 import Slice.Construction as Slice
 

--- a/source/Modal/Subuniverse.lagda
+++ b/source/Modal/Subuniverse.lagda
@@ -9,8 +9,6 @@ module Modal.Subuniverse where
 
 open import MLTT.Spartan
 open import UF.Subsingletons
-open import UF.Base
-open import UF.FunExt
 open import UF.Equiv
 open import UF.Univalence
 

--- a/source/Naturals/Division.lagda
+++ b/source/Naturals/Division.lagda
@@ -15,7 +15,6 @@ open import Naturals.Multiplication
 open import Naturals.Properties
 open import Naturals.Order
 open import Notation.Order
-open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Subsingletons
 

--- a/source/Naturals/HCF.lagda
+++ b/source/Naturals/HCF.lagda
@@ -15,7 +15,6 @@ open import Naturals.Multiplication
 open import Naturals.Order
 open import Naturals.Properties
 open import Notation.Order
-open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.FunExt
 open import UF.Subsingletons

--- a/source/Naturals/Multiplication.lagda
+++ b/source/Naturals/Multiplication.lagda
@@ -13,7 +13,6 @@ open import MLTT.Spartan renaming (_+_ to _∔_)
 open import Naturals.Addition
 open import Naturals.Properties
 
-open import UF.Base
 
 module Naturals.Multiplication where
 

--- a/source/Naturals/Order.lagda
+++ b/source/Naturals/Order.lagda
@@ -300,7 +300,6 @@ Added December 2019.
 
 \begin{code}
 
-open import NotionsOfDecidability.Decidable
 open import NotionsOfDecidability.Complemented
 
 ≤-decidable : (m n : ℕ ) → is-decidable (m ≤ n)

--- a/source/Naturals/Sequence.lagda
+++ b/source/Naturals/Sequence.lagda
@@ -9,7 +9,6 @@ open import UF.FunExt
 module Naturals.Sequence (fe : FunExt) where
 
 open import MLTT.Spartan hiding (_+_)
-open import UF.Base
 open import UF.Retracts
 open import Naturals.Addition
 

--- a/source/Naturals/UniversalProperty.lagda
+++ b/source/Naturals/UniversalProperty.lagda
@@ -12,7 +12,6 @@ here from nondependent functions to dependent functions.
 
 module Naturals.UniversalProperty where
 
-open import MLTT.NaturalNumbers
 
 open import MLTT.Spartan
 open import UF.Base

--- a/source/NotionsOfDecidability/DecidableClassifier.lagda
+++ b/source/NotionsOfDecidability/DecidableClassifier.lagda
@@ -15,7 +15,6 @@ module NotionsOfDecidability.DecidableClassifier where
 
 open import MLTT.Spartan
 
-open import MLTT.Plus-Properties
 open import MLTT.Two-Properties
 
 open import UF.DiscreteAndSeparated
@@ -29,7 +28,6 @@ open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
 
 open import NotionsOfDecidability.Decidable
-open import NotionsOfDecidability.Complemented
 
 boolean-value' : {A : 𝓤 ̇ }
                → is-decidable A

--- a/source/NotionsOfDecidability/QuasiDecidable.lagda
+++ b/source/NotionsOfDecidability/QuasiDecidable.lagda
@@ -238,7 +238,6 @@ open import UF.Yoneda
 open import UF.Embeddings
 open import UF.Powerset
 
-open import NotionsOfDecidability.Decidable
 open import Dominance.Definition
 
 \end{code}
@@ -869,7 +868,6 @@ propositional resizing is available:
 
 \begin{code}
 
-open import UF.Size
 
 module quasidecidability-construction-from-resizing
         (𝓣 𝓚 : Universe)


### PR DESCRIPTION
This PR cleans unused imports in `NotionsOfDecidability`—`Locales`.