### PR TITLE
Unused imports

### DIFF
--- a/source/BinarySystems/InitialBinarySystem.lagda
+++ b/source/BinarySystems/InitialBinarySystem.lagda
@@ -1151,7 +1151,6 @@ We now need to assume function extensionality.
 
 open import UF.Base
 open import UF.FunExt
-open import UF.Subsingletons-FunExt
 
 module _ (fe  : Fun-Ext) where
 

--- a/source/BinarySystems/InitialBinarySystem2.lagda
+++ b/source/BinarySystems/InitialBinarySystem2.lagda
@@ -773,7 +773,6 @@ We now need to assume function extensionality.
 
 open import UF.Base
 open import UF.FunExt
-open import UF.Subsingletons-FunExt
 
 module _ (fe  : Fun-Ext) where
 

--- a/source/CantorSchroederBernstein/CSB-TheoryLabLunch.lagda
+++ b/source/CantorSchroederBernstein/CSB-TheoryLabLunch.lagda
@@ -167,7 +167,6 @@ module CantorSchroederBernstein.CSB-TheoryLabLunch where
 open import CoNaturals.Type
 open import MLTT.Plus-Properties
 open import MLTT.Spartan
-open import NotionsOfDecidability.Decidable
 open import TypeTopology.CompactTypes
 open import TypeTopology.GenericConvergentSequenceCompactness
 open import UF.Embeddings

--- a/source/CantorSchroederBernstein/CSB.lagda
+++ b/source/CantorSchroederBernstein/CSB.lagda
@@ -49,7 +49,6 @@ open import CoNaturals.Type
 open import MLTT.Plus-Properties
 open import MLTT.Spartan
 open import Naturals.Properties
-open import NotionsOfDecidability.Decidable
 open import TypeTopology.CompactTypes
 open import TypeTopology.GenericConvergentSequenceCompactness
 open import UF.Base

--- a/source/Cardinals/Preorder.lagda
+++ b/source/Cardinals/Preorder.lagda
@@ -6,14 +6,10 @@ Jon Sterling, 25th March 2023.
 
 open import MLTT.Spartan
 open import UF.Base
-open import UF.Equiv
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Retracts
 open import UF.SetTrunc
-open import UF.Size
 open import UF.Subsingletons
-import Various.LawvereFPT as LFTP
 
 module Cardinals.Preorder
  (fe : FunExt)

--- a/source/Cardinals/Preorder.lagda
+++ b/source/Cardinals/Preorder.lagda
@@ -23,7 +23,12 @@ module Cardinals.Preorder
  where
 
 open import UF.Embeddings
+open import UF.Sets
+open import UF.Sets-Properties
 open import UF.Subsingletons-FunExt
+open import UF.Subsingletons-Properties
+open import UF.SubtypeClassifier
+open import UF.SubtypeClassifier-Properties
 open import Cardinals.Type st
 
 import UF.Logic
@@ -118,12 +123,8 @@ module _ {A : hSet 𝓤} {B : hSet 𝓥} where
 
 
 module _ {𝓤} where
- ⊥ : Ω 𝓤
- pr₁ ⊥ = 𝟘
- pr₂ ⊥ = 𝟘-is-prop
-
  Ω¬_ : Ω 𝓤 → Ω 𝓤
- Ω¬ ϕ = ϕ ⇒ ⊥
+ Ω¬ ϕ = ϕ ⇒ ⊥ {𝓤}
 
 _<_ : Card 𝓤 → Card 𝓥 → Ω (𝓤 ⊔ 𝓥)
 α < β = (α ≤ β) ∧ (Ω¬ (β ≤ α))

--- a/source/Cardinals/Successor.lagda
+++ b/source/Cardinals/Successor.lagda
@@ -1,7 +1,7 @@
 Jon Sterling, 25th March 2023.
 
 The HoTT book shows that under excluded middle, there are weak successor
-cardinals.  I show that under suitable propositional resizing assumptions, this
+cardinals. I show that under suitable propositional resizing assumptions, this
 holds constructively.
 
 \begin{code}
@@ -29,9 +29,15 @@ module Cardinals.Successor
  where
 
 open import UF.Embeddings
+open import UF.Sets
+open import UF.Sets-Properties
 open import UF.Subsingletons-FunExt
+open import UF.Subsingletons-Properties
+open import UF.SubtypeClassifier
+open import UF.SubtypeClassifier-Properties
 open import Cardinals.Type st
 open import Cardinals.Preorder fe pe st pt
+open import Various.CantorTheoremForEmbeddings
 
 import UF.Logic
 
@@ -114,7 +120,7 @@ pr₂ (pr₂ ([weak-successor] A)) H =
  where
   main : ((underlying-set A → Ω 𝓤) ↪ underlying-set A) → 𝟘
   main ι =
-   LFTP.retract-version.cantor-theorem-for-embeddings fe pe psz
+   cantor-theorem-for-embeddings fe pe psz
     (underlying-set A)
     ι'
     ι'-emb

--- a/source/Cardinals/Successor.lagda
+++ b/source/Cardinals/Successor.lagda
@@ -11,14 +11,11 @@ holds constructively.
 open import MLTT.Spartan
 open import UF.Base
 open import UF.Equiv
-open import UF.Equiv-FunExt
 open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Retracts
 open import UF.SetTrunc
 open import UF.Size
 open import UF.Subsingletons
-import Various.LawvereFPT as LFTP
 
 module Cardinals.Successor
  (fe : FunExt)

--- a/source/Cardinals/Type.lagda
+++ b/source/Cardinals/Type.lagda
@@ -11,6 +11,7 @@ open import UF.Subsingletons
 module Cardinals.Type (st : set-truncations-exist) where
 
 open import UF.Embeddings
+open import UF.Sets
 open import UF.Subsingletons-FunExt
 
 import UF.Logic

--- a/source/Cardinals/Type.lagda
+++ b/source/Cardinals/Type.lagda
@@ -6,13 +6,10 @@ Jon Sterling, 25th March 2023.
 
 open import MLTT.Spartan
 open import UF.SetTrunc
-open import UF.Subsingletons
 
 module Cardinals.Type (st : set-truncations-exist) where
 
-open import UF.Embeddings
 open import UF.Sets
-open import UF.Subsingletons-FunExt
 
 import UF.Logic
 

--- a/source/Categories/Adjunction.lagda
+++ b/source/Categories/Adjunction.lagda
@@ -9,12 +9,7 @@ open import UF.FunExt
 module Categories.Adjunction (fe : Fun-Ext) where
 
 open import MLTT.Spartan
-open import UF.Base
-open import UF.Equiv
-open import UF.Retracts
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
-open import UF.Equiv-FunExt
 
 open import Categories.Category fe
 open import Categories.Functor fe

--- a/source/Categories/Functor.lagda
+++ b/source/Categories/Functor.lagda
@@ -9,11 +9,9 @@ open import UF.FunExt
 module Categories.Functor (fe : Fun-Ext) where
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Equiv
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
-open import UF.Equiv-FunExt
 
 open import Categories.Category fe
 

--- a/source/Circle/Integers-Properties.lagda
+++ b/source/Circle/Integers-Properties.lagda
@@ -9,7 +9,6 @@ Earlier version: 18 September 2020
 open import Circle.Integers
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Equiv
 open import UF.Sets

--- a/source/Circle/Integers-SymmetricInduction.lagda
+++ b/source/Circle/Integers-SymmetricInduction.lagda
@@ -18,7 +18,6 @@ open import Circle.Integers
 open import Circle.Integers-Properties
 
 open import MLTT.Spartan
-open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
 open import UF.EquivalenceExamples

--- a/source/Circle/Integers.lagda
+++ b/source/Circle/Integers.lagda
@@ -15,7 +15,6 @@ the type of integers.
 {-# OPTIONS --safe --without-K #-}
 
 open import MLTT.Spartan
-open import UF.Base
 
 module Circle.Integers where
 

--- a/source/CoNaturals/Arithmetic.lagda
+++ b/source/CoNaturals/Arithmetic.lagda
@@ -37,7 +37,6 @@ open import CoNaturals.Type renaming (min to min')
 open import CoNaturals.UniversalProperty fe
 open import Notation.Order
 open import Notation.CanonicalMap
-open import UF.Base
 
 \end{code}
 

--- a/source/CoNaturals/GenericConvergentSequence.lagda
+++ b/source/CoNaturals/GenericConvergentSequence.lagda
@@ -16,7 +16,6 @@ module CoNaturals.GenericConvergentSequence where
 
 open import MLTT.Spartan
 open import MLTT.Two-Properties
-open import Naturals.Order hiding (max ; max-idemp ; max-comm)
 open import Notation.CanonicalMap
 open import Notation.Order
 open import Ordinals.Notions

--- a/source/CoNaturals/GenericConvergentSequence2.lagda
+++ b/source/CoNaturals/GenericConvergentSequence2.lagda
@@ -11,10 +11,7 @@ module CoNaturals.GenericConvergentSequence2 where
 
 open import MLTT.Spartan
 open import MLTT.Two-Properties
-open import Naturals.Order hiding (max)
-open import Naturals.Properties
 open import Notation.CanonicalMap
-open import Notation.Order
 open import TypeTopology.Cantor
 open import UF.DiscreteAndSeparated
 open import UF.FunExt

--- a/source/CoNaturals/Sharp.lagda
+++ b/source/CoNaturals/Sharp.lagda
@@ -44,7 +44,6 @@ open import NotionsOfDecidability.Decidable
 open import UF.DiscreteAndSeparated
 open import UF.Embeddings
 open import UF.Equiv
-open import UF.FunExt
 open import UF.PropTrunc
 open import UF.Subsingletons-FunExt
 

--- a/source/CoNaturals/Type2Properties.lagda
+++ b/source/CoNaturals/Type2Properties.lagda
@@ -11,19 +11,12 @@ open import CoNaturals.GenericConvergentSequence2
 open import CoNaturals.Equivalence
 open import MLTT.Spartan
 open import MLTT.Two-Properties
-open import Naturals.Order hiding (max)
-open import Naturals.Properties
 open import Notation.CanonicalMap
-open import Notation.Order
 open import TypeTopology.Cantor
-open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Equiv
 open import UF.FunExt
-open import UF.NotNotStablePropositions
-open import UF.Sets
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 private
  T = T-cantor

--- a/source/ContinuityAxiom/ExitingTruncations.lagda
+++ b/source/ContinuityAxiom/ExitingTruncations.lagda
@@ -28,7 +28,6 @@ open import MLTT.Spartan
 open import UF.Base
 open import UF.FunExt
 open import UF.Subsingletons
-open import Naturals.Order using (course-of-values-induction)
 \end{code}
 
 For any P : ℕ → U and n : ℕ, if P(m) is decidable for all m ≤ n, then

--- a/source/ContinuityAxiom/FalseWithoutIdentityTypes.lagda
+++ b/source/ContinuityAxiom/FalseWithoutIdentityTypes.lagda
@@ -14,7 +14,6 @@ module ContinuityAxiom.FalseWithoutIdentityTypes where
 
 open import MLTT.Sigma
 open import MLTT.NaturalNumbers
-open import MLTT.Universes
 open import MLTT.Unit
 open import MLTT.Empty
 

--- a/source/ContinuityAxiom/Preliminaries.lagda
+++ b/source/ContinuityAxiom/Preliminaries.lagda
@@ -8,7 +8,6 @@ module ContinuityAxiom.Preliminaries where
 
 open import MLTT.Plus-Properties
 open import MLTT.Spartan
-open import NotionsOfDecidability.Decidable
 open import UF.Subsingletons
 
 \end{code}

--- a/source/ContinuityAxiom/UniformContinuity.lagda
+++ b/source/ContinuityAxiom/UniformContinuity.lagda
@@ -21,8 +21,6 @@ open import ContinuityAxiom.ExitingTruncations
 open import ContinuityAxiom.Preliminaries
 open import MLTT.Spartan
 open import MLTT.Two-Properties
-open import Naturals.Properties
-open import NotionsOfDecidability.Decidable
 open import UF.DiscreteAndSeparated
 open import UF.FunExt
 open import UF.Subsingletons

--- a/source/CrossedModules/CrossedModules.lagda
+++ b/source/CrossedModules/CrossedModules.lagda
@@ -13,14 +13,12 @@ Revision July 1, 2022
 
 open import MLTT.Spartan hiding ( ₀ ; ₁)
 open import UF.PropTrunc
-open import UF.ImageAndSurjection
 open import UF.FunExt
 open import UF.Subsingletons
 
 open import Groups.Type
 open import Groups.Homomorphisms
 open import Groups.Kernel
-open import Groups.Image
 open import Groups.Cokernel
 
 open import Quotient.Type

--- a/source/DedekindReals/Addition.lagda
+++ b/source/DedekindReals/Addition.lagda
@@ -28,7 +28,6 @@ module DedekindReals.Addition
        where
 
 open import DedekindReals.Type fe pe pt
-open import DedekindReals.Order fe pe pt
 open PropositionalTruncation pt
 
 _+_ : ℝ → ℝ → ℝ
@@ -356,7 +355,6 @@ infixl 35 _+_
         III : (a ℚ+ c) < (x + y)
         III = ∣ (a , c) , a<x , c<y , refl ∣
 
-open import Rationals.Multiplication renaming (_*_ to _ℚ*_)
 
 -_ : ℝ → ℝ
 -_ x = (L , R) , inhabited-left-z , inhabited-right-z , rounded-left-z , rounded-right-z , disjoint-z , located-z

--- a/source/DedekindReals/Functions.lagda
+++ b/source/DedekindReals/Functions.lagda
@@ -31,7 +31,6 @@ module DedekindReals.Functions
 
 open PropositionalTruncation pt
 
-open import DedekindReals.Properties fe pe pt
 open import DedekindReals.Type fe pe pt
 open import DedekindReals.Extension fe pe pt
 

--- a/source/DedekindReals/Multiplication.lagda
+++ b/source/DedekindReals/Multiplication.lagda
@@ -3,16 +3,11 @@ Andrew Sneap
 \begin{code}
 {-# OPTIONS --safe --without-K #-}
 
-open import MLTT.Spartan renaming (_+_ to _∔_)
 
-open import Notation.Order
 open import UF.PropTrunc
 open import UF.Subsingletons
 open import UF.FunExt
-open import UF.Powerset
 
-open import Rationals.Type
-open import Rationals.Order
 
 module DedekindReals.Multiplication
          (fe : Fun-Ext)
@@ -20,9 +15,6 @@ module DedekindReals.Multiplication
          (pt : propositional-truncations-exist)
        where
 
-open import Rationals.Multiplication renaming (_*_ to _ℚ*_)
-open import Rationals.MinMax
-open import DedekindReals.Type fe pe pt
 open PropositionalTruncation pt
 
 

--- a/source/DedekindReals/Properties.lagda
+++ b/source/DedekindReals/Properties.lagda
@@ -9,16 +9,11 @@ In this file, I prove that the Reals are arithmetically located.
 open import MLTT.Spartan renaming (_+_ to _∔_)
 
 open import Notation.Order
-open import UF.Base
 open import UF.PropTrunc
 open import UF.FunExt
 open import UF.Powerset
 open import UF.Subsingletons
-open import Naturals.Properties
-open import Naturals.Order
 open import Rationals.Type
-open import Rationals.Abs
-open import Rationals.Addition
 open import Rationals.Multiplication
 open import Rationals.Negation
 open import Rationals.Order
@@ -30,7 +25,6 @@ module DedekindReals.Properties
   (pt : propositional-truncations-exist)
  where
 open import DedekindReals.Type fe pe pt
-open import MetricSpaces.Rationals fe pe pt
 open import Rationals.Limits fe pe pt
 
 open PropositionalTruncation pt

--- a/source/DedekindReals/Type.lagda
+++ b/source/DedekindReals/Type.lagda
@@ -21,7 +21,6 @@ open import UF.Powerset
 open import UF.PropTrunc
 open import UF.Sets
 open import UF.Sets-Properties
-open import UF.SubtypeClassifier-Properties
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 open import UF.Subsingletons-Properties
@@ -179,7 +178,6 @@ disjoint-from-real ((L , R) , _ , _ , _ , _ , disjoint , _) = disjoint
 ℚ-rounded-right₂ : (y : ℚ) (x : ℚ) → Σ q ꞉ ℚ , (q < x) × (y < q) → y < x
 ℚ-rounded-right₂ y x (q , l₁ , l₂) = ℚ<-trans y q x l₂ l₁
 
-open import Notation.Order
 
 _ℚ<ℝ_  : ℚ → ℝ → 𝓤₀ ̇
 p ℚ<ℝ x = p ∈ lower-cut-of x

--- a/source/DiscreteGraphicMonoids/ListsWithoutRepetitions.lagda
+++ b/source/DiscreteGraphicMonoids/ListsWithoutRepetitions.lagda
@@ -21,7 +21,6 @@ open import MLTT.Spartan
 open import Naturals.Order
 open import Notation.CanonicalMap
 open import Notation.Order
-open import NotionsOfDecidability.Decidable
 open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Embeddings

--- a/source/DiscreteGraphicMonoids/Monad.lagda
+++ b/source/DiscreteGraphicMonoids/Monad.lagda
@@ -19,7 +19,6 @@ open import DiscreteGraphicMonoids.LWRDGM fe
 open import DiscreteGraphicMonoids.ListsWithoutRepetitions fe
 open import DiscreteGraphicMonoids.Type
 open import MLTT.Spartan
-open import Notation.CanonicalMap
 open import UF.DiscreteAndSeparated
 
 module _ {X : 𝓤 ̇ }

--- a/source/DomainTheory/BasesAndContinuity/Bases.lagda
+++ b/source/DomainTheory/BasesAndContinuity/Bases.lagda
@@ -37,7 +37,6 @@ module DomainTheory.BasesAndContinuity.Bases
 
 open PropositionalTruncation pt
 
-open import UF.Base
 open import UF.Equiv
 open import UF.EquivalenceExamples
 open import UF.Size hiding (is-small ; is-locally-small)

--- a/source/DomainTheory/BasesAndContinuity/Continuity.lagda
+++ b/source/DomainTheory/BasesAndContinuity/Continuity.lagda
@@ -24,7 +24,6 @@ module DomainTheory.BasesAndContinuity.Continuity
 
 open PropositionalTruncation pt
 
-open import UF.Base hiding (_≈_)
 open import UF.Equiv
 open import UF.EquivalenceExamples
 

--- a/source/DomainTheory/BasesAndContinuity/ContinuityImpredicative.lagda
+++ b/source/DomainTheory/BasesAndContinuity/ContinuityImpredicative.lagda
@@ -27,7 +27,6 @@ module DomainTheory.BasesAndContinuity.ContinuityImpredicative
 
 open PropositionalTruncation pt
 
-open import UF.Base hiding (_≈_)
 open import UF.Equiv
 
 open import UF.Size hiding (is-locally-small; is-small)

--- a/source/DomainTheory/BasesAndContinuity/IndCompletion.lagda
+++ b/source/DomainTheory/BasesAndContinuity/IndCompletion.lagda
@@ -29,7 +29,6 @@ module DomainTheory.BasesAndContinuity.IndCompletion
 
 open PropositionalTruncation pt
 
-open import UF.Base hiding (_≈_)
 open import UF.Equiv
 open import UF.EquivalenceExamples
 open import UF.Subsingletons

--- a/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
+++ b/source/DomainTheory/BasesAndContinuity/ScottDomain.lagda
@@ -17,7 +17,6 @@ open import UF.FunExt
 open import UF.Logic
 open import UF.PropTrunc
 open import UF.SubtypeClassifier
-open import UF.Subsingletons
 
 module DomainTheory.BasesAndContinuity.ScottDomain
         (pt : propositional-truncations-exist)
@@ -28,7 +27,6 @@ module DomainTheory.BasesAndContinuity.ScottDomain
 open import Slice.Family
 
 open import DomainTheory.Basics.Dcpo                   pt fe 𝓥
-open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
 open import DomainTheory.BasesAndContinuity.Bases      pt fe 𝓥
 
 open import Locales.Frame hiding (⟨_⟩)

--- a/source/DomainTheory/BasesAndContinuity/StepFunctions.lagda
+++ b/source/DomainTheory/BasesAndContinuity/StepFunctions.lagda
@@ -21,7 +21,6 @@ open import MLTT.Spartan hiding (J)
 open import UF.FunExt
 open import UF.PropTrunc
 
-open import UF.Subsingletons
 
 module DomainTheory.BasesAndContinuity.StepFunctions
         (pt : propositional-truncations-exist)
@@ -31,12 +30,8 @@ module DomainTheory.BasesAndContinuity.StepFunctions
 
 open PropositionalTruncation pt hiding (_∨_)
 
-open import UF.Base hiding (_≈_)
 open import UF.Equiv
-open import UF.EquivalenceExamples
-
 open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 open import DomainTheory.Basics.Dcpo pt fe 𝓥
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓥

--- a/source/DomainTheory/Basics/Curry.lagda
+++ b/source/DomainTheory/Basics/Curry.lagda
@@ -22,7 +22,6 @@ open import DomainTheory.Basics.Dcpo pt fe 𝓥
 open import DomainTheory.Basics.Exponential pt fe 𝓥
 open import DomainTheory.Basics.Miscelanea pt fe 𝓥
 open import DomainTheory.Basics.Pointed pt fe 𝓥
-open import DomainTheory.Basics.FunctionComposition pt fe 𝓥
 open import DomainTheory.Basics.Products pt fe
 open import DomainTheory.Basics.ProductsContinuity pt fe 𝓥
 open import UF.Subsingletons

--- a/source/DomainTheory/Basics/Dcpo.lagda
+++ b/source/DomainTheory/Basics/Dcpo.lagda
@@ -30,7 +30,6 @@ open PropositionalTruncation pt
 open import UF.Subsingletons
 open import UF.Subsingletons-FunExt
 
-open import Naturals.Properties
 open import Naturals.Addition renaming (_+_ to _+'_)
 open import Naturals.Order
 open import Notation.Order

--- a/source/DomainTheory/Basics/LeastFixedPoint.lagda
+++ b/source/DomainTheory/Basics/LeastFixedPoint.lagda
@@ -24,11 +24,7 @@ module DomainTheory.Basics.LeastFixedPoint
 open PropositionalTruncation pt
 
 open import UF.UniverseEmbedding
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
-open import Naturals.Properties
-open import Naturals.Addition renaming (_+_ to _+'_)
 open import Naturals.Order
 open import Notation.Order
 

--- a/source/DomainTheory/Basics/ProductsContinuity.lagda
+++ b/source/DomainTheory/Basics/ProductsContinuity.lagda
@@ -19,8 +19,6 @@ open PropositionalTruncation pt
 open import DomainTheory.Basics.Dcpo pt fe 𝓥
 open import DomainTheory.Basics.Miscelanea pt fe 𝓥
 open import DomainTheory.Basics.Products pt fe
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 open DcpoProductsGeneral 𝓥
 

--- a/source/DomainTheory/Examples/IdlDyadics.lagda
+++ b/source/DomainTheory/Examples/IdlDyadics.lagda
@@ -31,7 +31,6 @@ open import DomainTheory.Basics.WayBelow pt fe 𝓤₀
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤₀
 open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤₀
 
-open import DomainTheory.IdealCompletion.IdealCompletion pt fe pe 𝓤₀
 open import DomainTheory.IdealCompletion.Properties pt fe pe 𝓤₀
 
 open Ideals-of-small-abstract-basis

--- a/source/DomainTheory/Examples/Omega.lagda
+++ b/source/DomainTheory/Examples/Omega.lagda
@@ -26,19 +26,14 @@ module DomainTheory.Examples.Omega
 open PropositionalTruncation pt
 
 open import MLTT.Plus-Properties
-open import NotionsOfDecidability.Decidable
 
 open import UF.Equiv
-open import UF.EquivalenceExamples
 open import UF.ImageAndSurjection pt
 open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier renaming (⊥ to ⊥Ω ; ⊤ to ⊤Ω)
 open import UF.SubtypeClassifier-Properties
-open import UF.Sets
-open import OrderedTypes.Poset fe
 
 open import DomainTheory.Basics.Dcpo pt fe 𝓤
-open import DomainTheory.Basics.Miscelanea pt fe 𝓤
 open import DomainTheory.Basics.Pointed pt fe 𝓤
 open import DomainTheory.Basics.WayBelow pt fe 𝓤
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤

--- a/source/DomainTheory/Examples/Ordinals.lagda
+++ b/source/DomainTheory/Examples/Ordinals.lagda
@@ -25,7 +25,6 @@ open PropositionalTruncation pt
 
 open import MLTT.List
 
-open import UF.Base
 open import UF.FunExt
 open import UF.Subsingletons
 open import UF.UA-FunExt

--- a/source/DomainTheory/Examples/Powerset.lagda
+++ b/source/DomainTheory/Examples/Powerset.lagda
@@ -33,11 +33,8 @@ open import UF.Equiv
 open import UF.ImageAndSurjection pt
 open import UF.Powerset
 open import UF.Powerset-Fin pt
-open import UF.Subsingletons-FunExt
 open import UF.SubtypeClassifier
-open import UF.SubtypeClassifier-Properties
 
-open import OrderedTypes.Poset fe
 
 open binary-unions-of-subsets pt
 open canonical-map-from-lists-to-subsets X-is-set

--- a/source/DomainTheory/IdealCompletion/IdealCompletion.lagda
+++ b/source/DomainTheory/IdealCompletion/IdealCompletion.lagda
@@ -30,7 +30,6 @@ open import UF.Powerset
 open import UF.Sets
 open import UF.Sets-Properties
 open import UF.SubtypeClassifier
-open import UF.SubtypeClassifier-Properties
 open import UF.Subsingletons-FunExt
 
 open PosetAxioms

--- a/source/DomainTheory/IdealCompletion/Retracts.lagda
+++ b/source/DomainTheory/IdealCompletion/Retracts.lagda
@@ -53,7 +53,6 @@ open import DomainTheory.Basics.WayBelow pt fe 𝓥
 open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓥
 open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
 
-open import DomainTheory.IdealCompletion.IdealCompletion pt fe pe 𝓥
 open import DomainTheory.IdealCompletion.Properties pt fe pe 𝓥
 
 open PropositionalTruncation pt

--- a/source/DomainTheory/Lifting/LiftingDcpo.lagda
+++ b/source/DomainTheory/Lifting/LiftingDcpo.lagda
@@ -28,7 +28,6 @@ open PropositionalTruncation pt
 
 open import UF.Equiv
 open import UF.EquivalenceExamples
-open import UF.ImageAndSurjection pt
 open import UF.Sets
 open import UF.Subsingletons-FunExt
 

--- a/source/DomainTheory/Lifting/LiftingSet.lagda
+++ b/source/DomainTheory/Lifting/LiftingSet.lagda
@@ -27,7 +27,6 @@ module DomainTheory.Lifting.LiftingSet
         (pe : propext 𝓣)
        where
 
-open import UF.Base
 open import UF.Equiv
 open import UF.Hedberg
 open import UF.ImageAndSurjection pt

--- a/source/DomainTheory/Lifting/LiftingSetAlgebraic.lagda
+++ b/source/DomainTheory/Lifting/LiftingSetAlgebraic.lagda
@@ -23,7 +23,6 @@ module DomainTheory.Lifting.LiftingSetAlgebraic
 open import UF.Equiv
 open import UF.ImageAndSurjection pt
 open import UF.Sets
-open import UF.Subsingletons-FunExt
 
 open PropositionalTruncation pt
 
@@ -31,7 +30,6 @@ open import Lifting.Construction 𝓤 hiding (⊥)
 open import Lifting.EmbeddingDirectly 𝓤 hiding (κ)
 open import Lifting.Miscelanea 𝓤
 open import Lifting.Miscelanea-PropExt-FunExt 𝓤 pe fe
-open import Lifting.Monad 𝓤
 
 open import DomainTheory.Basics.Dcpo pt fe 𝓤
 open import DomainTheory.Basics.Miscelanea pt fe 𝓤
@@ -43,7 +41,6 @@ open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤
 
 open import DomainTheory.Lifting.LiftingSet pt fe 𝓤 pe
 
-open import OrderedTypes.Poset fe
 
 module _
         {X : 𝓤 ̇ }

--- a/source/DomainTheory/Part-I.lagda
+++ b/source/DomainTheory/Part-I.lagda
@@ -37,7 +37,6 @@ open PropositionalTruncation pt
 open import MLTT.Spartan
 
 open import Naturals.Order hiding (subtraction')
-open import Naturals.Addition renaming (_+_ to _+'_)
 open import Notation.Order hiding (_⊑_ ; _≼_)
 
 open import UF.Base
@@ -321,7 +320,6 @@ Section 5
 
 module _ where
  open import DomainTheory.Basics.Dcpo pt fe 𝓤₀
- open import DomainTheory.Basics.Miscelanea pt fe 𝓤₀
  open import DomainTheory.Taboos.ClassicalLiftingOfNaturalNumbers pt fe
  open import Taboos.LPO
 
@@ -501,7 +499,6 @@ module _ (𝓥 : Universe) where
 
  open import DomainTheory.Basics.Curry pt fe 𝓥
  open import DomainTheory.Basics.Dcpo pt fe 𝓥
- open import DomainTheory.Basics.FunctionComposition pt fe 𝓥
  open import DomainTheory.Basics.Pointed pt fe 𝓥
  open import DomainTheory.Basics.Products pt fe
  open DcpoProductsGeneral 𝓥
@@ -617,7 +614,6 @@ module _ (𝓥 : Universe) where
 
  open import DomainTheory.Basics.Dcpo pt fe 𝓥
  open import DomainTheory.Basics.Exponential pt fe 𝓥
- open import DomainTheory.Basics.FunctionComposition pt fe 𝓥
  open import DomainTheory.Basics.Miscelanea pt fe 𝓥
 
  Definition-7-1 : (𝓓 : DCPO {𝓤} {𝓣}) → DCPO[ 𝓓 , 𝓓 ] → 𝓤 ⊔ 𝓣 ̇
@@ -766,7 +762,6 @@ open import DomainTheory.Basics.Miscelanea pt fe 𝓤₀
 open import DomainTheory.Basics.Pointed pt fe 𝓤₀
 
 open import DomainTheory.Bilimits.Dinfinity pt fe pe
-open import DomainTheory.Bilimits.Sequential pt fe 𝓤₁ 𝓤₁
 
 Definition-8-1 : (n : ℕ) → DCPO⊥ {𝓤₁} {𝓤₁}
 Definition-8-1 = 𝓓⊥

--- a/source/DomainTheory/Part-II.lagda
+++ b/source/DomainTheory/Part-II.lagda
@@ -36,10 +36,8 @@ module DomainTheory.Part-II
 open PropositionalTruncation pt
 
 open import MLTT.List
-open import MLTT.Plus-Properties
 open import MLTT.Spartan hiding (J)
 
-open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Equiv
 open import UF.EquivalenceExamples
@@ -581,7 +579,6 @@ Section 5.2
 
  module _ where
 
-  open import Lifting.Construction 𝓥 renaming (⊥ to ⊥𝓛)
   open import DomainTheory.Lifting.LiftingSet pt fe 𝓥 pe
   open import DomainTheory.Lifting.LiftingSetAlgebraic pt pe fe 𝓥
 
@@ -691,7 +688,6 @@ Section 6
 
 \begin{code}
 
- open import DomainTheory.IdealCompletion.IdealCompletion pt fe pe 𝓥
  open import DomainTheory.IdealCompletion.Properties pt fe pe 𝓥
 
  Definition-6-1 : 𝓥 ⁺ ̇
@@ -822,7 +818,6 @@ module _ where
  open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓤₀
  open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓤₀
  open import DomainTheory.Examples.IdlDyadics pt fe pe
- open import DomainTheory.IdealCompletion.IdealCompletion pt fe pe 𝓤₀
  open import DomainTheory.IdealCompletion.Properties pt fe pe 𝓤₀
 
  Definition-6-17 : (𝓤₀ ̇ ) × (𝔻 → 𝔻 → 𝓤₀ ̇ )
@@ -878,7 +873,6 @@ module _ (𝓥 : Universe) where
  open import DomainTheory.Basics.WayBelow pt fe 𝓥
  open import DomainTheory.BasesAndContinuity.Continuity pt fe 𝓥
  open import DomainTheory.BasesAndContinuity.Bases pt fe 𝓥
- open import DomainTheory.IdealCompletion.IdealCompletion pt fe pe 𝓥
  open import DomainTheory.IdealCompletion.Properties pt fe pe 𝓥
  open import DomainTheory.IdealCompletion.Retracts pt fe pe 𝓥
 

--- a/source/DomainTheory/Taboos/ClassicalLiftingOfNaturalNumbers.lagda
+++ b/source/DomainTheory/Taboos/ClassicalLiftingOfNaturalNumbers.lagda
@@ -26,12 +26,10 @@ module DomainTheory.Taboos.ClassicalLiftingOfNaturalNumbers
 open PropositionalTruncation pt
 
 open import DomainTheory.Basics.Dcpo pt fe 𝓤₀
-open import DomainTheory.Basics.Miscelanea pt fe 𝓤₀
 
 open import CoNaturals.Type renaming (ℕ∞-to-ℕ→𝟚 to ε)
 open import MLTT.Two-Properties
 open import MLTT.Plus-Properties
-open import Notation.CanonicalMap
 open import Taboos.LPO
 
 \end{code}

--- a/source/DomainTheory/Topology/ScottTopology.lagda
+++ b/source/DomainTheory/Topology/ScottTopology.lagda
@@ -16,14 +16,11 @@ module DomainTheory.Topology.ScottTopology
 
 open PropositionalTruncation pt
 
-open import OrderedTypes.Poset fe
 open import Slice.Family
 open import UF.ImageAndSurjection pt
 open import UF.Logic
 open import UF.Powerset-MultiUniverse
 open import UF.SubtypeClassifier
-open import UF.Subsingletons
-open import UF.Subsingletons-FunExt
 
 open Universal fe
 open Existential pt

--- a/source/index.lagda
+++ b/source/index.lagda
@@ -129,6 +129,7 @@ module index where
 import Apartness.index
 import BinarySystems.index
 import CantorSchroederBernstein.index
+import Cardinals.index
 import Categories.index
 import Circle.index
 import CoNaturals.index


### PR DESCRIPTION
This completes the removal of unused imports in TypeTopology.

Whilst cleaning up, I found that `Cardinals/index.lagda` was not included in the overall index. I added it and repaired the (outdated—as they were left untypechecked for a while) files in `Cardinals`.

Please wait for the CI to complete.