### PR TITLE
Strong preunivalence and equivalence extensionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Please add yourself the first time you contribute.
 * Todd Waugh Ambridge
 * Tom de Jong
 * Vincent Rahli
+* Evan Cavallo
 
 (i) These authors didn't write any single line of Agda code here, but
 they contributed to constructions, theorems and proofs via the hands

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Please add yourself the first time you contribute.
 * Chuangjie Xu
 * Cory Knapp
 * Ettore Aldrovandi
+* Evan Cavallo
 * Fredrik Nordvall Forsberg
 * Ian Ray
 * Igor Arrieta (ii)
@@ -66,7 +67,6 @@ Please add yourself the first time you contribute.
 * Todd Waugh Ambridge
 * Tom de Jong
 * Vincent Rahli
-* Evan Cavallo
 
 (i) These authors didn't write any single line of Agda code here, but
 they contributed to constructions, theorems and proofs via the hands

--- a/source/UF/FunExt-Properties.lagda
+++ b/source/UF/FunExt-Properties.lagda
@@ -1,5 +1,4 @@
 Martin Escardo, 19th May 2018.
-Evan Cavallo, 13th March 2025.
 
 Properties of function extensionality.
 
@@ -75,6 +74,8 @@ naive-funext-gives-funext₀ fe = naive-funext-gives-funext' fe fe
 
 \end{code}
 
+Added by Evan Cavallo on 13th March 2025.
+
 The equivalence extensionality axiom is the restriction of function
 extensionality to equivalences. By an argument similar to the proof of function
 extensionality from univalence, it implies full function extensionality.
@@ -83,58 +84,60 @@ extensionality from univalence, it implies full function extensionality.
 
 equivext : ∀ 𝓤 𝓥 → 𝓤 ⁺ ⊔ 𝓥 ⁺ ̇
 equivext 𝓤 𝓥 =
-  {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (α β : X ≃ Y)
-  → is-equiv (λ (p : α ＝ β) → happly (ap ⌜_⌝ p))
+ {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (α β : X ≃ Y)
+ → is-equiv (λ (p : α ＝ β) → happly (ap ⌜_⌝ p))
 
 equivext-gives-funext : equivext 𝓤 𝓤 → funext 𝓤 𝓤
 equivext-gives-funext {𝓤} ee =
-  funext-via-singletons main
-  where
+ funext-via-singletons main
+ where
   promote : (A : 𝓤 ̇ ) {X Y : 𝓤 ̇ } → X ≃ Y → (A ≃ X) ≃ (A ≃ Y)
   promote A α =
-    qinveq
-      (_● α)
-      ( (_● ≃-sym α)
-      , (λ β → inverse _ (ee _ _) (inverses-are-retractions _ (pr₂ α) ∘ ⌜ β ⌝))
-      , (λ γ → inverse _ (ee _ _) (inverses-are-sections _ (pr₂ α) ∘ ⌜ γ ⌝)))
+   qinveq
+    (_● α)
+    ( (_● ≃-sym α)
+    , (λ β → inverse _ (ee _ _) (inverses-are-retractions _ (pr₂ α) ∘ ⌜ β ⌝))
+    , (λ γ → inverse _ (ee _ _) (inverses-are-sections _ (pr₂ α) ∘ ⌜ γ ⌝)))
 
   module _ (X : 𝓤 ̇ ) (Y : X → 𝓤 ̇ ) (cY : (x : X) → is-singleton (Y x)) where
-    π : (Σ Y) ≃ X
-    π =
-      qinveq
-        pr₁
-        ( (λ x → x , pr₁ (cY x))
-        , (λ (x , y) → to-Σ-＝ (refl , pr₂ (cY x) y))
-        , ∼-refl)
+   π : (Σ Y) ≃ X
+   π =
+    qinveq
+     pr₁
+     ( (λ x → x , pr₁ (cY x))
+     , (λ (x , y) → to-Σ-＝ (refl , pr₂ (cY x) y))
+     , ∼-refl)
 
-    sec : Π Y → fiber ⌜ promote X π ⌝ 𝕚𝕕
-    sec f =
-      ( qinveq
-          (λ x → x , f x)
-          ( pr₁
-          , ∼-refl
-          , (λ (x , y) → to-Σ-＝ (refl , singletons-are-props (cY x) _ _)))
-      , inverse _ (ee _ _) ∼-refl)
+   sec : Π Y → fiber ⌜ promote X π ⌝ 𝕚𝕕
+   sec f =
+    ( qinveq
+       (λ x → x , f x)
+       ( pr₁
+       , ∼-refl
+       , (λ (x , y) → to-Σ-＝ (refl , singletons-are-props (cY x) _ _)))
+    , inverse _ (ee _ _) ∼-refl)
 
-    ret : fiber ⌜ promote X π ⌝ 𝕚𝕕 → Π Y
-    ret (α , p) x = transport Y (happly (ap ⌜_⌝ p) x) (pr₂ (pr₁ α x))
+   ret : fiber ⌜ promote X π ⌝ 𝕚𝕕 → Π Y
+   ret (α , p) x = transport Y (happly (ap ⌜_⌝ p) x) (pr₂ (pr₁ α x))
 
-    inv : ret ∘ sec ∼ id
-    inv f =
-      ap (λ h → λ x → transport Y (h x) (pr₂ (pr₁ α x))) cancel
-      where
+   inv : ret ∘ sec ∼ id
+   inv f =
+    ap (λ h → λ x → transport Y (h x) (pr₂ (pr₁ α x))) cancel
+     where
       α = pr₁ (sec f)
       p = pr₂ (sec f)
 
       cancel : happly (ap ⌜_⌝ p) ＝ ∼-refl
       cancel = inverses-are-sections _ (ee _ _) (∼-refl)
 
-    main : is-singleton (Π Y)
-    main =
-      singleton-closed-under-retract
-        (Π Y)
-        (fiber ⌜ promote X π ⌝ 𝕚𝕕)
-        (ret , sec , inv)
-        (equivs-are-vv-equivs _ (pr₂ (promote X π)) 𝕚𝕕)
+   main : is-singleton (Π Y)
+   main =
+    singleton-closed-under-retract
+     (Π Y)
+     (fiber ⌜ promote X π ⌝ 𝕚𝕕)
+     (ret , sec , inv)
+     (equivs-are-vv-equivs _ (pr₂ (promote X π)) 𝕚𝕕)
 
 \end{code}
+
+End of addition.

--- a/source/UF/FunExt-Properties.lagda
+++ b/source/UF/FunExt-Properties.lagda
@@ -1,4 +1,5 @@
 Martin Escardo, 19th May 2018.
+Evan Cavallo, 13th March 2025.
 
 Properties of function extensionality.
 
@@ -72,9 +73,18 @@ naive-funext-gives-funext fe = naive-funext-gives-funext' fe fe
 naive-funext-gives-funext₀ : naive-funext 𝓤 𝓤 → funext 𝓤 𝓤₀
 naive-funext-gives-funext₀ fe = naive-funext-gives-funext' fe fe
 
+\end{code}
+
+The equivalence extensionality axiom is the restriction of function
+extensionality to equivalences. By an argument similar to the proof of function
+extensionality from univalence, it implies full function extensionality.
+
+\begin{code}
+
 equivext : ∀ 𝓤 𝓥 → 𝓤 ⁺ ⊔ 𝓥 ⁺ ̇
 equivext 𝓤 𝓥 =
-  {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (α β : X ≃ Y) → is-equiv (λ (p : α ＝ β) → happly (ap ⌜_⌝ p))
+  {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (α β : X ≃ Y)
+  → is-equiv (λ (p : α ＝ β) → happly (ap ⌜_⌝ p))
 
 equivext-gives-funext : equivext 𝓤 𝓤 → funext 𝓤 𝓤
 equivext-gives-funext {𝓤} ee =
@@ -85,18 +95,25 @@ equivext-gives-funext {𝓤} ee =
     qinveq
       (_● α)
       ( (_● ≃-sym α)
-      , (λ β → inverse _ (ee _ _) λ a → inverses-are-retractions _ (pr₂ α) (⌜ β ⌝ a))
-      , (λ γ → inverse _ (ee _ _) λ a → inverses-are-sections _ (pr₂ α) (⌜ γ ⌝ a)))
+      , (λ β → inverse _ (ee _ _) (inverses-are-retractions _ (pr₂ α) ∘ ⌜ β ⌝))
+      , (λ γ → inverse _ (ee _ _) (inverses-are-sections _ (pr₂ α) ∘ ⌜ γ ⌝)))
 
   module _ (X : 𝓤 ̇ ) (Y : X → 𝓤 ̇ ) (cY : (x : X) → is-singleton (Y x)) where
     π : (Σ Y) ≃ X
-    π = qinveq pr₁ ((λ x → x , pr₁ (cY x)) , (λ (x , y) → to-Σ-＝ (refl , pr₂ (cY x) y)) , ∼-refl)
+    π =
+      qinveq
+        pr₁
+        ( (λ x → x , pr₁ (cY x))
+        , (λ (x , y) → to-Σ-＝ (refl , pr₂ (cY x) y))
+        , ∼-refl)
 
     sec : Π Y → fiber ⌜ promote X π ⌝ 𝕚𝕕
     sec f =
       ( qinveq
           (λ x → x , f x)
-          (pr₁ , ∼-refl , (λ (x , y) → to-Σ-＝ (refl , singletons-are-props (cY x) _ _)))
+          ( pr₁
+          , ∼-refl
+          , (λ (x , y) → to-Σ-＝ (refl , singletons-are-props (cY x) _ _)))
       , inverse _ (ee _ _) ∼-refl)
 
     ret : fiber ⌜ promote X π ⌝ 𝕚𝕕 → Π Y

--- a/source/UF/FunExt-Properties.lagda
+++ b/source/UF/FunExt-Properties.lagda
@@ -14,6 +14,7 @@ open import UF.FunExt
 open import UF.Equiv
 open import UF.Equiv-FunExt
 open import UF.Yoneda
+open import UF.Singleton-Properties
 open import UF.Subsingletons
 open import UF.Retracts
 
@@ -70,5 +71,53 @@ naive-funext-gives-funext fe = naive-funext-gives-funext' fe fe
 
 naive-funext-gives-funext₀ : naive-funext 𝓤 𝓤 → funext 𝓤 𝓤₀
 naive-funext-gives-funext₀ fe = naive-funext-gives-funext' fe fe
+
+equivext : ∀ 𝓤 𝓥 → 𝓤 ⁺ ⊔ 𝓥 ⁺ ̇
+equivext 𝓤 𝓥 =
+  {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (α β : X ≃ Y) → is-equiv (λ (p : α ＝ β) → happly (ap ⌜_⌝ p))
+
+equivext-gives-funext : equivext 𝓤 𝓤 → funext 𝓤 𝓤
+equivext-gives-funext {𝓤} ee =
+  funext-via-singletons main
+  where
+  promote : (A : 𝓤 ̇ ) {X Y : 𝓤 ̇ } → X ≃ Y → (A ≃ X) ≃ (A ≃ Y)
+  promote A α =
+    qinveq
+      (_● α)
+      ( (_● ≃-sym α)
+      , (λ β → inverse _ (ee _ _) λ a → inverses-are-retractions _ (pr₂ α) (⌜ β ⌝ a))
+      , (λ γ → inverse _ (ee _ _) λ a → inverses-are-sections _ (pr₂ α) (⌜ γ ⌝ a)))
+
+  module _ (X : 𝓤 ̇ ) (Y : X → 𝓤 ̇ ) (cY : (x : X) → is-singleton (Y x)) where
+    π : (Σ Y) ≃ X
+    π = qinveq pr₁ ((λ x → x , pr₁ (cY x)) , (λ (x , y) → to-Σ-＝ (refl , pr₂ (cY x) y)) , ∼-refl)
+
+    sec : Π Y → fiber ⌜ promote X π ⌝ 𝕚𝕕
+    sec f =
+      ( qinveq
+          (λ x → x , f x)
+          (pr₁ , ∼-refl , (λ (x , y) → to-Σ-＝ (refl , singletons-are-props (cY x) _ _)))
+      , inverse _ (ee _ _) ∼-refl)
+
+    ret : fiber ⌜ promote X π ⌝ 𝕚𝕕 → Π Y
+    ret (α , p) x = transport Y (happly (ap ⌜_⌝ p) x) (pr₂ (pr₁ α x))
+
+    inv : ret ∘ sec ∼ id
+    inv f =
+      ap (λ h → λ x → transport Y (h x) (pr₂ (pr₁ α x))) cancel
+      where
+      α = pr₁ (sec f)
+      p = pr₂ (sec f)
+
+      cancel : happly (ap ⌜_⌝ p) ＝ ∼-refl
+      cancel = inverses-are-sections _ (ee _ _) (∼-refl)
+
+    main : is-singleton (Π Y)
+    main =
+      singleton-closed-under-retract
+        (Π Y)
+        (fiber ⌜ promote X π ⌝ 𝕚𝕕)
+        (ret , sec , inv)
+        (equivs-are-vv-equivs _ (pr₂ (promote X π)) 𝕚𝕕)
 
 \end{code}

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -85,18 +85,19 @@ funext-and-preunivalence-give-strong-preunivalence
  retract-of-prop
   (to-Σ-＝ , from-Σ-＝ , tofrom-Σ-＝)
    (equiv-to-prop
-    (Σ-cong λ p → (_ , ∙-is-equiv-left (expand-transport p)) ● shift-equiv α (idtoeq _ _ p) α')
-     (preua _ _ (≃-sym α ● α')))
+    (Σ-cong λ p →
+     (_ , ∙-is-equiv-left (transport-eq p)) ● shift-equiv α (idtoeq _ _ p) α')
+    (preua _ _ (≃-sym α ● α')))
  where
-  expand-transport : (p : Y ＝ Y') → α ● idtoeq Y Y' p ＝ transport (X ≃_) p α
-  expand-transport refl = ≃-refl-right' fevu fevv feuu α
+  transport-eq : (p : Y ＝ Y') → α ● idtoeq Y Y' p ＝ transport (X ≃_) p α
+  transport-eq refl = ≃-refl-right' fevu fevv feuu α
 
   shift-equiv : {A : 𝓤 ̇ } {B : 𝓥 ̇ } {C : 𝓥 ̇ }
               → (e : A ≃ B) (e' : B ≃ C) (e'' : A ≃ C)
               → (e ● e' ＝ e'') ≃ (e' ＝ ≃-sym e ● e'')
   shift-equiv e e' e'' =
    (e ● e' ＝ e'')
-    ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left' fevu fevv feuu fevv fevv e)) ⟩
+    ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ q) ⟩
    (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'')
     ≃⟨ ＝-cong-l _ _ (≃-assoc' fevv fevv fevv (≃-sym e) e e') ⟩
    ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'')
@@ -104,5 +105,7 @@ funext-and-preunivalence-give-strong-preunivalence
    (≃-refl _ ● e' ＝ ≃-sym e ● e'')
     ≃⟨ ＝-cong-l _ _ (≃-refl-left' fevv fevv fevv e') ⟩
    (e' ＝ ≃-sym e ● e'') ■
+   where
+    q = ≃-cong-left' fevu fevv feuu fevv fevv e
 
 \end{code}

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -50,6 +50,9 @@ K-gives-preunivalence {𝓤} k k' X Y e (p , _) (p' , _) =
 K-gives-Preunivalence : K-Axiom → Preunivalence
 K-gives-Preunivalence k 𝓤 = K-gives-preunivalence (k 𝓤) (k (𝓤 ⁺))
 
+-- Fredrik Bakke's strong pre-univalence axiom (restricted to one universe):
+-- https://unimath.github.io/agda-unimath/foundation.strong-preunivalence.html
+-- https://mathstodon.xyz/@FredrikBakke/113980401059186473
 is-strong-preunivalent : ∀ 𝓤 → 𝓤 ⁺ ̇
 is-strong-preunivalent 𝓤 = (X : 𝓤 ̇ ) → is-set (Σ Y ꞉ 𝓤 ̇  , X ≃ Y)
 

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -18,6 +18,10 @@ module UF.PreUnivalence where
 open import MLTT.Spartan
 open import UF.Embeddings
 open import UF.Equiv
+open import UF.Equiv-FunExt
+open import UF.EquivalenceExamples
+open import UF.FunExt
+open import UF.Retracts
 open import UF.Sets
 open import UF.Subsingletons
 open import UF.Univalence
@@ -45,5 +49,30 @@ K-gives-preunivalence {𝓤} k k' X Y e (p , _) (p' , _) =
 
 K-gives-Preunivalence : K-Axiom → Preunivalence
 K-gives-Preunivalence k 𝓤 = K-gives-preunivalence (k 𝓤) (k (𝓤 ⁺))
+
+is-strong-preunivalent : ∀ 𝓤 → 𝓤 ⁺ ̇
+is-strong-preunivalent 𝓤 = (X : 𝓤 ̇ ) → is-set (Σ Y ꞉ 𝓤 ̇  , X ≃ Y)
+
+funext-and-preunivalence-give-strong-preunivalence : ∀ {𝓤}
+  → funext 𝓤 𝓤 → is-preunivalent 𝓤 → is-strong-preunivalent 𝓤
+funext-and-preunivalence-give-strong-preunivalence {𝓤} fe preua X {Y , α} {Y' , α'} =
+  retract-of-prop
+    (to-Σ-＝ , from-Σ-＝ , tofrom-Σ-＝)
+    (equiv-to-prop
+      (Σ-cong λ p → (_ , ∙-is-equiv-left (expand-transport p)) ● shift-equiv α (idtoeq _ _ p) α')
+      (preua _ _ (≃-sym α ● α')))
+  where
+  expand-transport : (p : Y ＝ Y') → α ● idtoeq Y Y' p ＝ transport (X ≃_) p α
+  expand-transport refl = ≃-refl-right' fe fe fe α
+
+  shift-equiv : {A B C : 𝓤 ̇ }
+    (e : A ≃ B) (e' : B ≃ C) (e'' : A ≃ C)
+    → (e ● e' ＝ e'') ≃ (e' ＝ ≃-sym e ● e'')
+  shift-equiv e e' e'' =
+    (e ● e' ＝ e'')                       ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left'' fe e)) ⟩
+    (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'') ≃⟨ ＝-cong-l _ _ (≃-assoc' fe fe fe (≃-sym e) e e') ⟩
+    ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'') ≃⟨ ＝-cong-l _ _ (ap (_● e') (≃-sym-left-inverse' fe e)) ⟩
+    (≃-refl _ ● e' ＝ ≃-sym e ● e'')      ≃⟨ ＝-cong-l _ _ (≃-refl-left' fe fe fe e') ⟩
+    (e' ＝ ≃-sym e ● e'') ■
 
 \end{code}

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -1,5 +1,4 @@
 Martin Escardo 23 February 2023
-Evan Cavallo 13 March 2025
 
 The pre-univalence axiom, first suggested by Evan Cavallo in November
 2017 [1] and then again by Peter Lumsdaine in August 2022
@@ -59,7 +58,7 @@ K-gives-Preunivalence k 𝓤 = K-gives-preunivalence (k 𝓤) (k (𝓤 ⁺))
 
 \end{code}
 
-Added 13th March 2025 by Evan Cavallo. The strong preunivalence axiom and the
+Added by Evan Cavallo on 13th March 2025. The strong preunivalence axiom and the
 fact that it implies the preunivalence axiom are due to Fredrik Bakke.
 
 \begin{code}
@@ -70,11 +69,11 @@ is-strong-preunivalent 𝓤 𝓥 = (X : 𝓤 ̇ ) → is-set (Σ Y ꞉ 𝓥 ̇  
 strong-preunivalence-gives-preunivalence : is-strong-preunivalent 𝓤 𝓤
                                          → is-preunivalent 𝓤
 strong-preunivalence-gives-preunivalence spua X =
-  NatΣ-is-embedding-converse (X ＝_) (X ≃_) (idtoeq X)
-    (maps-of-props-into-sets-are-embeddings
-      (NatΣ (idtoeq X))
-      (singleton-types-are-props X)
-      (spua X))
+ NatΣ-is-embedding-converse (X ＝_) (X ≃_) (idtoeq X)
+  (maps-of-props-into-sets-are-embeddings
+   (NatΣ (idtoeq X))
+    (singleton-types-are-props X)
+     (spua X))
 
 funext-and-preunivalence-give-strong-preunivalence : funext 𝓤 𝓤
                                                    → funext 𝓥 𝓤
@@ -82,13 +81,13 @@ funext-and-preunivalence-give-strong-preunivalence : funext 𝓤 𝓤
                                                    → is-preunivalent 𝓥
                                                    → is-strong-preunivalent 𝓤 𝓥
 funext-and-preunivalence-give-strong-preunivalence
-  {𝓤} {𝓥} feuu fevu fevv preua X {Y , α} {Y' , α'} =
-  retract-of-prop
-    (to-Σ-＝ , from-Σ-＝ , tofrom-Σ-＝)
-    (equiv-to-prop
-      (Σ-cong λ p → (_ , ∙-is-equiv-left (expand-transport p)) ● shift-equiv α (idtoeq _ _ p) α')
-      (preua _ _ (≃-sym α ● α')))
-  where
+ {𝓤} {𝓥} feuu fevu fevv preua X {Y , α} {Y' , α'} =
+ retract-of-prop
+  (to-Σ-＝ , from-Σ-＝ , tofrom-Σ-＝)
+   (equiv-to-prop
+    (Σ-cong λ p → (_ , ∙-is-equiv-left (expand-transport p)) ● shift-equiv α (idtoeq _ _ p) α')
+     (preua _ _ (≃-sym α ● α')))
+ where
   expand-transport : (p : Y ＝ Y') → α ● idtoeq Y Y' p ＝ transport (X ≃_) p α
   expand-transport refl = ≃-refl-right' fevu fevv feuu α
 
@@ -96,14 +95,14 @@ funext-and-preunivalence-give-strong-preunivalence
               → (e : A ≃ B) (e' : B ≃ C) (e'' : A ≃ C)
               → (e ● e' ＝ e'') ≃ (e' ＝ ≃-sym e ● e'')
   shift-equiv e e' e'' =
-    (e ● e' ＝ e'')
-      ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left' fevu fevv feuu fevv fevv e)) ⟩
-    (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'')
-      ≃⟨ ＝-cong-l _ _ (≃-assoc' fevv fevv fevv (≃-sym e) e e') ⟩
-    ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'')
-      ≃⟨ ＝-cong-l _ _ (ap (_● e') (≃-sym-left-inverse' fevv e)) ⟩
-    (≃-refl _ ● e' ＝ ≃-sym e ● e'')
-      ≃⟨ ＝-cong-l _ _ (≃-refl-left' fevv fevv fevv e') ⟩
-    (e' ＝ ≃-sym e ● e'') ■
+   (e ● e' ＝ e'')
+    ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left' fevu fevv feuu fevv fevv e)) ⟩
+   (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'')
+    ≃⟨ ＝-cong-l _ _ (≃-assoc' fevv fevv fevv (≃-sym e) e e') ⟩
+   ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'')
+    ≃⟨ ＝-cong-l _ _ (ap (_● e') (≃-sym-left-inverse' fevv e)) ⟩
+   (≃-refl _ ● e' ＝ ≃-sym e ● e'')
+    ≃⟨ ＝-cong-l _ _ (≃-refl-left' fevv fevv fevv e') ⟩
+   (e' ＝ ≃-sym e ● e'') ■
 
 \end{code}

--- a/source/UF/PreUnivalence.lagda
+++ b/source/UF/PreUnivalence.lagda
@@ -1,4 +1,5 @@
 Martin Escardo 23 February 2023
+Evan Cavallo 13 March 2025
 
 The pre-univalence axiom, first suggested by Evan Cavallo in November
 2017 [1] and then again by Peter Lumsdaine in August 2022
@@ -9,6 +10,11 @@ verbally to me.
 The preunivalence axiom is a common generalization of the univalence
 axiom and the K axiom.
 
+The strong preunivalence axiom is a variant that was stated by Fredrik Bakke
+in the agda-unimath in February 2025 [2].
+
+[2] https://unimath.github.io/agda-unimath/foundation.strong-preunivalence.html
+
 \begin{code}
 
 {-# OPTIONS --safe --without-K #-}
@@ -16,6 +22,7 @@ axiom and the K axiom.
 module UF.PreUnivalence where
 
 open import MLTT.Spartan
+open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
 open import UF.Equiv-FunExt
@@ -50,15 +57,32 @@ K-gives-preunivalence {𝓤} k k' X Y e (p , _) (p' , _) =
 K-gives-Preunivalence : K-Axiom → Preunivalence
 K-gives-Preunivalence k 𝓤 = K-gives-preunivalence (k 𝓤) (k (𝓤 ⁺))
 
--- Fredrik Bakke's strong pre-univalence axiom (restricted to one universe):
--- https://unimath.github.io/agda-unimath/foundation.strong-preunivalence.html
--- https://mathstodon.xyz/@FredrikBakke/113980401059186473
-is-strong-preunivalent : ∀ 𝓤 → 𝓤 ⁺ ̇
-is-strong-preunivalent 𝓤 = (X : 𝓤 ̇ ) → is-set (Σ Y ꞉ 𝓤 ̇  , X ≃ Y)
+\end{code}
 
-funext-and-preunivalence-give-strong-preunivalence : ∀ {𝓤}
-  → funext 𝓤 𝓤 → is-preunivalent 𝓤 → is-strong-preunivalent 𝓤
-funext-and-preunivalence-give-strong-preunivalence {𝓤} fe preua X {Y , α} {Y' , α'} =
+Added 13th March 2025 by Evan Cavallo. The strong preunivalence axiom and the
+fact that it implies the preunivalence axiom are due to Fredrik Bakke.
+
+\begin{code}
+
+is-strong-preunivalent : ∀ 𝓤 𝓥 → Set (𝓤 ⁺ ⊔ 𝓥 ⁺)
+is-strong-preunivalent 𝓤 𝓥 = (X : 𝓤 ̇ ) → is-set (Σ Y ꞉ 𝓥 ̇  , X ≃ Y)
+
+strong-preunivalence-gives-preunivalence : is-strong-preunivalent 𝓤 𝓤
+                                         → is-preunivalent 𝓤
+strong-preunivalence-gives-preunivalence spua X =
+  NatΣ-is-embedding-converse (X ＝_) (X ≃_) (idtoeq X)
+    (maps-of-props-into-sets-are-embeddings
+      (NatΣ (idtoeq X))
+      (singleton-types-are-props X)
+      (spua X))
+
+funext-and-preunivalence-give-strong-preunivalence : funext 𝓤 𝓤
+                                                   → funext 𝓥 𝓤
+                                                   → funext 𝓥 𝓥
+                                                   → is-preunivalent 𝓥
+                                                   → is-strong-preunivalent 𝓤 𝓥
+funext-and-preunivalence-give-strong-preunivalence
+  {𝓤} {𝓥} feuu fevu fevv preua X {Y , α} {Y' , α'} =
   retract-of-prop
     (to-Σ-＝ , from-Σ-＝ , tofrom-Σ-＝)
     (equiv-to-prop
@@ -66,16 +90,20 @@ funext-and-preunivalence-give-strong-preunivalence {𝓤} fe preua X {Y , α} {Y
       (preua _ _ (≃-sym α ● α')))
   where
   expand-transport : (p : Y ＝ Y') → α ● idtoeq Y Y' p ＝ transport (X ≃_) p α
-  expand-transport refl = ≃-refl-right' fe fe fe α
+  expand-transport refl = ≃-refl-right' fevu fevv feuu α
 
-  shift-equiv : {A B C : 𝓤 ̇ }
-    (e : A ≃ B) (e' : B ≃ C) (e'' : A ≃ C)
-    → (e ● e' ＝ e'') ≃ (e' ＝ ≃-sym e ● e'')
+  shift-equiv : {A : 𝓤 ̇ } {B : 𝓥 ̇ } {C : 𝓥 ̇ }
+              → (e : A ≃ B) (e' : B ≃ C) (e'' : A ≃ C)
+              → (e ● e' ＝ e'') ≃ (e' ＝ ≃-sym e ● e'')
   shift-equiv e e' e'' =
-    (e ● e' ＝ e'')                       ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left'' fe e)) ⟩
-    (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'') ≃⟨ ＝-cong-l _ _ (≃-assoc' fe fe fe (≃-sym e) e e') ⟩
-    ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'') ≃⟨ ＝-cong-l _ _ (ap (_● e') (≃-sym-left-inverse' fe e)) ⟩
-    (≃-refl _ ● e' ＝ ≃-sym e ● e'')      ≃⟨ ＝-cong-l _ _ (≃-refl-left' fe fe fe e') ⟩
+    (e ● e' ＝ e'')
+      ≃⟨ _ , ap-is-equiv (≃-sym e ●_) (pr₂ (≃-cong-left' fevu fevv feuu fevv fevv e)) ⟩
+    (≃-sym e ● (e ● e') ＝ ≃-sym e ● e'')
+      ≃⟨ ＝-cong-l _ _ (≃-assoc' fevv fevv fevv (≃-sym e) e e') ⟩
+    ((≃-sym e ● e) ● e' ＝ ≃-sym e ● e'')
+      ≃⟨ ＝-cong-l _ _ (ap (_● e') (≃-sym-left-inverse' fevv e)) ⟩
+    (≃-refl _ ● e' ＝ ≃-sym e ● e'')
+      ≃⟨ ＝-cong-l _ _ (≃-refl-left' fevv fevv fevv e') ⟩
     (e' ＝ ≃-sym e ● e'') ■
 
 \end{code}


### PR DESCRIPTION
This PR contains two unrelated things (sorry):

- A statement of Fredrik Bakke's "strong preunivalence axiom", a proof that strong preunivalence implies preunivalence, and a proof that preunivalence + funext implies strong preunivalence.
- A statement of "equivalence extensionality" (identity of equivalences is pointwise equality of the underlying functions) and a proof that equivalence extensionality implies function extensionality.