### PR TITLE
Compact types are closed under dense covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Please add yourself the first time you contribute.
 * Cory Knapp
 * Ettore Aldrovandi
 * Evan Cavallo
+* Fredrik Bakke
 * Fredrik Nordvall Forsberg
 * Ian Ray
 * Igor Arrieta (ii)

--- a/source/MLTT/Plus.lagda
+++ b/source/MLTT/Plus.lagda
@@ -54,3 +54,14 @@ cases₃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {Z : 𝓦 ̇ } {A : 𝓣 ̇ }
 cases₃ = dep-cases₃
 
 \end{code}
+
+Added 26 March 2025 by Fredrik Bakke.
+
+\begin{code}
+
+cases-map : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {A : 𝓦 ̇ } {B : 𝓣 ̇ }
+          → (X → A) → (Y → B) → X + Y → A + B
+cases-map f g (inl x) = inl (f x)
+cases-map f g (inr y) = inr (g y)
+
+\end{code}

--- a/source/MLTT/Plus.lagda
+++ b/source/MLTT/Plus.lagda
@@ -59,9 +59,9 @@ Added 26 March 2025 by Fredrik Bakke.
 
 \begin{code}
 
-cases-map : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {A : 𝓦 ̇ } {B : 𝓣 ̇ }
-          → (X → A) → (Y → B) → X + Y → A + B
-cases-map f g (inl x) = inl (f x)
-cases-map f g (inr y) = inr (g y)
+map-+ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {A : 𝓦 ̇ } {B : 𝓣 ̇ }
+      → (X → A) → (Y → B) → X + Y → A + B
+map-+ f g (inl x) = inl (f x)
+map-+ f g (inr y) = inr (g y)
 
 \end{code}

--- a/source/MLTT/Plus.lagda
+++ b/source/MLTT/Plus.lagda
@@ -54,14 +54,3 @@ cases₃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {Z : 𝓦 ̇ } {A : 𝓣 ̇ }
 cases₃ = dep-cases₃
 
 \end{code}
-
-Added 26 March 2025 by Fredrik Bakke.
-
-\begin{code}
-
-map-+ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {A : 𝓦 ̇ } {B : 𝓣 ̇ }
-      → (X → A) → (Y → B) → X + Y → A + B
-map-+ f g (inl x) = inl (f x)
-map-+ f g (inr y) = inr (g y)
-
-\end{code}

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -845,7 +845,7 @@ Compact-closed-under-≃ e = Compact-closed-under-retracts (≃-gives-▷ e)
 
 \end{code}
 
-The following was added 26 March 2025 by Fredrik Bakke. It gives a
+The following was added on 26 March 2025 by Fredrik Bakke. It gives a
 generalization of the fact that compact types are closed under covers that also
 avoids function extensionality and propositional truncations.
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -861,23 +861,30 @@ dense-map-Compact f i c A δ =
   negative-case = λ nxpf yp →
    i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂)))
  in
- cases-map positive-case negative-case (c (A ∘ f) (δ ∘ f))
+ map-+ positive-case negative-case (c (A ∘ f) (δ ∘ f))
 
 dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                     → is-dense f
                     → is-Π-Compact X {𝓦}
                     → is-Π-Compact Y {𝓦}
-dense-map-Π-Compact f i c A δ =
- let
-  positive-case = λ p y →
-   let
-    negative-positive-case = λ np →
-     𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))
-   in
-    Cases (δ y) id negative-positive-case
-  negative-case = λ nph p → nph (p ∘ f)
- in
- cases-map positive-case negative-case (c (A ∘ f) (δ ∘ f))
+dense-map-Π-Compact {𝓤} {𝓥} {𝓦} {X} {Y} f i c A δ = tada
+ where
+ positive-case : Π (A ∘ f) → (y : Y) → A y
+ positive-case p y =
+  let
+   negative-positive-case = λ np →
+    𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))
+  in
+  Cases (δ y) id negative-positive-case
+
+ negative-case : ¬ Π (A ∘ f) → ¬ Π A
+ negative-case nph p = nph (p ∘ f)
+
+ dΠAf : is-decidable (Π (A ∘ f))
+ dΠAf = c (A ∘ f) (δ ∘ f)
+
+ tada : is-decidable (Π A)
+ tada = map-+ positive-case negative-case dΠAf
 
 \end{code}
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -845,9 +845,9 @@ Compact-closed-under-≃ e = Compact-closed-under-retracts (≃-gives-▷ e)
 
 \end{code}
 
-The following was added 26 March 2025 by Fredrik Bakke, giving a generalization
-of the fact that compact types are closed under covers, avoiding function
-extensionality and propositional truncations.
+The following was added 26 March 2025 by Fredrik Bakke. It gives a
+generalization of the fact that compact types are closed under covers that also
+avoids function extensionality and propositional truncations.
 
 \begin{code}
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -869,7 +869,7 @@ dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                     → is-Π-Compact Y {𝓦}
 dense-map-Π-Compact {𝓤} {𝓥} {𝓦} {X} {Y} f i c A δ = tada
  where
- positive-case : Π (A ∘ f) → (y : Y) → A y
+ positive-case : Π (A ∘ f) → Π A
  positive-case p y =
   let
    negative-positive-case = λ np →
@@ -880,11 +880,11 @@ dense-map-Π-Compact {𝓤} {𝓥} {𝓦} {X} {Y} f i c A δ = tada
  negative-case : ¬ Π (A ∘ f) → ¬ Π A
  negative-case nph p = nph (p ∘ f)
 
- dΠAf : is-decidable (Π (A ∘ f))
- dΠAf = c (A ∘ f) (δ ∘ f)
+ dΠA∘f : is-decidable (Π (A ∘ f))
+ dΠA∘f = c (A ∘ f) (δ ∘ f)
 
  tada : is-decidable (Π A)
- tada = map-+ positive-case negative-case dΠAf
+ tada = map-+ positive-case negative-case dΠA∘f
 
 \end{code}
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -843,81 +843,43 @@ Compact-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                        → is-Compact Y {𝓦}
 Compact-closed-under-≃ e = Compact-closed-under-retracts (≃-gives-▷ e)
 
-\end{code}
-
-The following was added on 26 March 2025 by Fredrik Bakke. It gives a
-generalization of the fact that compact types are closed under covers that also
-avoids function extensionality and propositional truncations.
-
-\begin{code}
-
-dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                  → is-dense f
-                  → is-Compact X {𝓦}
-                  → is-Compact Y {𝓦}
-dense-map-Compact f i c A δ =
- let
-  positive-case = λ xp → f (xp .pr₁) , xp .pr₂
-  negative-case = λ nxpf yp →
-   i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂)))
- in
- map-+ positive-case negative-case (c (A ∘ f) (δ ∘ f))
-
-dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                    → is-dense f
-                    → is-Π-Compact X {𝓦}
-                    → is-Π-Compact Y {𝓦}
-dense-map-Π-Compact {𝓤} {𝓥} {𝓦} {X} {Y} f i c A δ = tada
- where
- positive-case : Π (A ∘ f) → Π A
- positive-case p y =
-  let
-   negative-positive-case = λ np →
-    𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))
-  in
-  Cases (δ y) id negative-positive-case
-
- negative-case : ¬ Π (A ∘ f) → ¬ Π A
- negative-case nph p = nph (p ∘ f)
-
- dΠA∘f : is-decidable (Π (A ∘ f))
- dΠA∘f = c (A ∘ f) (δ ∘ f)
-
- tada : is-decidable (Π A)
- tada = map-+ positive-case negative-case dΠA∘f
-
-\end{code}
-
-\begin{code}
 
 module CompactTypesPT (pt : propositional-truncations-exist) where
 
  open import UF.ImageAndSurjection pt
 
  surjection-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                    → funext 𝓥 𝓤₀
                     → is-surjection f
-                    → is-Compact X {𝓦}
-                    → is-Compact Y {𝓦}
- surjection-Compact f i = dense-map-Compact f (surjections-are-dense f i)
+                    → is-Compact X {𝓥}
+                    → is-Compact Y {𝓥}
+ surjection-Compact {𝓤} {𝓥} {X} {Y} f fe i c A δ = γ (c B ε)
+  where
+   B : X → 𝓥 ̇
+   B = A ∘ f
 
- image-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-               → is-Compact X {𝓦}
-               → is-Compact (image f) {𝓦}
- image-Compact f c = surjection-Compact (corestriction f)
-                      (corestrictions-are-surjections f) c
+   ε : is-complemented B
+   ε = δ ∘ f
 
- surjection-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                      → is-surjection f
-                      → is-Π-Compact X {𝓦}
-                      → is-Π-Compact Y {𝓦}
- surjection-Π-Compact f i =
-  dense-map-Π-Compact f (surjections-are-dense f i)
+   γ : is-decidable (Σ B) → is-decidable (Σ A)
+   γ (inl (x , a)) = inl (f x , a)
+   γ (inr u)       = inr v
+    where
+     u' : (x : X) → ¬ A (f x)
+     u' x a = u (x , a)
 
- image-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                 → is-Π-Compact X {𝓦}
-                 → is-Π-Compact (image f) {𝓦}
- image-Π-Compact f c = surjection-Π-Compact (corestriction f)
-                        (corestrictions-are-surjections f) c
+     v' : (y : Y) → ¬ A y
+     v' = surjection-induction f i (λ y → ¬ A y) (λ y → negations-are-props fe) u'
+
+     v : ¬ Σ A
+     v (y , a) = v' y a
+
+ image-Compact : funext (𝓤 ⊔ 𝓥) 𝓤₀
+               → {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+               → is-Compact X {𝓤 ⊔ 𝓥}
+               → is-Compact (image f) {𝓤 ⊔ 𝓥}
+ image-Compact fe f c = surjection-Compact (corestriction f) fe
+                         (corestrictions-are-surjections f) c
 
  open PropositionalTruncation pt
 
@@ -1271,6 +1233,82 @@ Compact-gives-Compact' : {X : 𝓤 ̇ } → is-Compact X {𝓥} → Compact' X {
 Compact-gives-Compact' C A _ = C A
 
 \end{code}
+
+The following was added by Fredrik Bakke on the 26th of March 2025.
+
+We give a generalization of the fact that compact types are closed under covers
+that also avoids function extensionality and propositional truncations.
+
+\begin{code}
+
+dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                  → is-dense f
+                  → is-Compact X {𝓦}
+                  → is-Compact Y {𝓦}
+dense-map-Compact f i c A δ = +functor positive-case negative-case d
+ where
+  positive-case : Σ (A ∘ f) → Σ A
+  positive-case (x , p) = (f x , p)
+
+  negative-case : ¬  Σ (A ∘ f) → ¬ Σ A
+  negative-case nf (y , p) = i (y , λ (x , r) → nf (x , transport A (r ⁻¹) p))
+
+  d : is-decidable (Σ (A ∘ f))
+  d = c (A ∘ f) (δ ∘ f)
+
+dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                    → is-dense f
+                    → is-Π-Compact X {𝓦}
+                    → is-Π-Compact Y {𝓦}
+dense-map-Π-Compact {𝓤} {𝓥} {𝓦} {X} {Y} f i c A δ = claim
+ where
+  positive-case : Π (A ∘ f) → Π A
+  positive-case g y = Cases (δ y) id negative-positive-case
+   where
+    negative-positive-case : ¬ A y → A y
+    negative-positive-case np =
+     𝟘-elim (i (y , λ (x , r) → np (transport A r (g x))))
+
+  negative-case : ¬ Π (A ∘ f) → ¬ Π A
+  negative-case nph p = nph (p ∘ f)
+
+ claim : is-decidable (Π A)
+ claim = +functor positive-case negative-case (c (A ∘ f) (δ ∘ f))
+
+\end{code}
+
+\begin{code}
+
+module _ (pt : propositional-truncations-exist) where
+
+ open import UF.ImageAndSurjection pt
+
+ surjection-Compact' : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                     → is-surjection f
+                     → is-Compact X {𝓦}
+                     → is-Compact Y {𝓦}
+ surjection-Compact' f i = dense-map-Compact f (surjections-are-dense f i)
+
+ image-Compact' : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                → is-Compact X {𝓦}
+                → is-Compact (image f) {𝓦}
+ image-Compact' f = surjection-Compact' (corestriction f)
+                     (corestrictions-are-surjections f)
+
+ surjection-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                      → is-surjection f
+                      → is-Π-Compact X {𝓦}
+                      → is-Π-Compact Y {𝓦}
+ surjection-Π-Compact f i = dense-map-Π-Compact f (surjections-are-dense f i)
+
+ image-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                 → is-Π-Compact X {𝓦}
+                 → is-Π-Compact (image f) {𝓦}
+ image-Π-Compact f c = surjection-Π-Compact (corestriction f)
+                        (corestrictions-are-surjections f) c
+
+\end{code}
+
 
 TODO. (1) is-Compact' X ≃ is-compact X.
       (2) is-Compact' X is a retract of is-Compact X.

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -853,8 +853,8 @@ extensionality and propositional truncations.
 
 dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                   → is-dense f
-                  → is-Compact X {𝓥}
-                  → is-Compact Y {𝓥}
+                  → is-Compact X {𝓦}
+                  → is-Compact Y {𝓦}
 dense-map-Compact f i c A δ =
  let
   positive-case = λ xp → f (xp .pr₁) , xp .pr₂
@@ -865,8 +865,8 @@ dense-map-Compact f i c A δ =
 
 dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                     → is-dense f
-                    → is-Π-Compact X {𝓥}
-                    → is-Π-Compact Y {𝓥}
+                    → is-Π-Compact X {𝓦}
+                    → is-Π-Compact Y {𝓦}
 dense-map-Π-Compact f i c A δ =
  let
   positive-case = λ p y →
@@ -889,27 +889,26 @@ module CompactTypesPT (pt : propositional-truncations-exist) where
 
  surjection-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                     → is-surjection f
-                    → is-Compact X {𝓥}
-                    → is-Compact Y {𝓥}
- surjection-Compact {𝓤} {𝓥} {X} {Y} f i =
-  dense-map-Compact f (surjections-are-dense f i)
+                    → is-Compact X {𝓦}
+                    → is-Compact Y {𝓦}
+ surjection-Compact f i = dense-map-Compact f (surjections-are-dense f i)
 
  image-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-               → is-Compact X {𝓤 ⊔ 𝓥}
-               → is-Compact (image f) {𝓤 ⊔ 𝓥}
+               → is-Compact X {𝓦}
+               → is-Compact (image f) {𝓦}
  image-Compact f c = surjection-Compact (corestriction f)
                       (corestrictions-are-surjections f) c
 
  surjection-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                       → is-surjection f
-                      → is-Π-Compact X {𝓥}
-                      → is-Π-Compact Y {𝓥}
- surjection-Π-Compact {𝓤} {𝓥} {X} {Y} f i =
+                      → is-Π-Compact X {𝓦}
+                      → is-Π-Compact Y {𝓦}
+ surjection-Π-Compact f i =
   dense-map-Π-Compact f (surjections-are-dense f i)
 
  image-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                 → is-Π-Compact X {𝓤 ⊔ 𝓥}
-                 → is-Π-Compact (image f) {𝓤 ⊔ 𝓥}
+                 → is-Π-Compact X {𝓦}
+                 → is-Π-Compact (image f) {𝓦}
  image-Π-Compact f c = surjection-Π-Compact (corestriction f)
                         (corestrictions-are-surjections f) c
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -843,7 +843,6 @@ Compact-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                        → is-Compact Y {𝓦}
 Compact-closed-under-≃ e = Compact-closed-under-retracts (≃-gives-▷ e)
 
-
 module CompactTypesPT (pt : propositional-truncations-exist) where
 
  open import UF.ImageAndSurjection pt
@@ -880,6 +879,7 @@ module CompactTypesPT (pt : propositional-truncations-exist) where
                → is-Compact (image f) {𝓤 ⊔ 𝓥}
  image-Compact fe f c = surjection-Compact (corestriction f) fe
                          (corestrictions-are-surjections f) c
+
 
  open PropositionalTruncation pt
 
@@ -1234,7 +1234,7 @@ Compact-gives-Compact' C A _ = C A
 
 \end{code}
 
-The following was added by Fredrik Bakke on the 26th of March 2025.
+Added by Fredrik Bakke on the 26th of March 2025.
 
 We give a generalization of the fact that compact types are closed under covers
 that also avoids function extensionality and propositional truncations.
@@ -1308,7 +1308,6 @@ module _ (pt : propositional-truncations-exist) where
                         (corestrictions-are-surjections f) c
 
 \end{code}
-
 
 TODO. (1) is-Compact' X ≃ is-compact X.
       (2) is-Compact' X is a retract of is-Compact X.

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -855,24 +855,29 @@ dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                   → is-dense f
                   → is-Compact X {𝓥}
                   → is-Compact Y {𝓥}
-dense-map-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
- cases-map
-  (λ z → f (z .pr₁) , z .pr₂)
-  (λ nxpf yp →
-   i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂))))
-  (c (A ∘ f) (δ ∘ f))
+dense-map-Compact f i c A δ =
+ let
+  positive-case = λ xp → f (xp .pr₁) , xp .pr₂
+  negative-case = λ nxpf yp →
+   i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂)))
+ in
+ cases-map positive-case negative-case (c (A ∘ f) (δ ∘ f))
 
 dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                     → is-dense f
                     → is-Π-Compact X {𝓥}
                     → is-Π-Compact Y {𝓥}
-dense-map-Π-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
- cases-map
-  (λ p y →
-   Cases (δ y) id
-    (λ np → 𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))))
-  (λ nph p → nph (p ∘ f))
-  (c (A ∘ f) (δ ∘ f))
+dense-map-Π-Compact f i c A δ =
+ let
+  positive-case = λ p y →
+   let
+    negative-positive-case = λ np →
+     𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))
+   in
+    Cases (δ y) id negative-positive-case
+  negative-case = λ nph p → nph (p ∘ f)
+ in
+ cases-map positive-case negative-case (c (A ∘ f) (δ ∘ f))
 
 \end{code}
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -83,6 +83,7 @@ open import MLTT.Spartan
 open import MLTT.Two-Properties
 open import NotionsOfDecidability.Complemented
 open import NotionsOfDecidability.Decidable
+open import TypeTopology.Density
 open import UF.Base
 open import UF.DiscreteAndSeparated
 open import UF.Equiv
@@ -842,43 +843,66 @@ Compact-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                        → is-Compact Y {𝓦}
 Compact-closed-under-≃ e = Compact-closed-under-retracts (≃-gives-▷ e)
 
+\end{code}
+
+The following was added 26 March 2025 by Fredrik Bakke, giving a generalization
+of the fact that compact types are closed under covers, avoiding function
+extensionality and propositional truncations.
+
+\begin{code}
+
+dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                  → is-dense f
+                  → is-Compact X {𝓥}
+                  → is-Compact Y {𝓥}
+dense-map-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
+  cases-map
+    ( λ z → f (z .pr₁) , z .pr₂)
+    ( λ nxpf yp →
+      i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂))))
+    ( c (A ∘ f) (δ ∘ f))
+
+dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                  → is-dense f
+                  → is-Π-Compact X {𝓥}
+                  → is-Π-Compact Y {𝓥}
+dense-map-Π-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
+  cases-map
+    ( λ p y → Cases (δ y) id (λ np → unique-from-𝟘 (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))))
+    ( λ nph p → nph (p ∘ f))
+    ( c (A ∘ f) (δ ∘ f))
+
+\end{code}
+
+\begin{code}
+
 module CompactTypesPT (pt : propositional-truncations-exist) where
 
  open import UF.ImageAndSurjection pt
 
  surjection-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                    → funext 𝓥 𝓤₀
                     → is-surjection f
                     → is-Compact X {𝓥}
                     → is-Compact Y {𝓥}
- surjection-Compact {𝓤} {𝓥} {X} {Y} f fe i c A δ = γ (c B ε)
-  where
-   B : X → 𝓥 ̇
-   B = A ∘ f
+ surjection-Compact {𝓤} {𝓥} {X} {Y} f i = dense-map-Compact f (surjections-are-dense f i)
 
-   ε : is-complemented B
-   ε = δ ∘ f
-
-   γ : is-decidable (Σ B) → is-decidable (Σ A)
-   γ (inl (x , a)) = inl (f x , a)
-   γ (inr u)       = inr v
-    where
-     u' : (x : X) → ¬ A (f x)
-     u' x a = u (x , a)
-
-     v' : (y : Y) → ¬ A y
-     v' = surjection-induction f i (λ y → ¬ A y) (λ y → negations-are-props fe) u'
-
-     v : ¬ Σ A
-     v (y , a) = v' y a
-
- image-Compact : funext (𝓤 ⊔ 𝓥) 𝓤₀
-               → {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+ image-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                → is-Compact X {𝓤 ⊔ 𝓥}
                → is-Compact (image f) {𝓤 ⊔ 𝓥}
- image-Compact fe f c = surjection-Compact (corestriction f) fe
-                         (corestrictions-are-surjections f) c
+ image-Compact f c = surjection-Compact (corestriction f)
+                      (corestrictions-are-surjections f) c
 
+ surjection-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                      → is-surjection f
+                      → is-Π-Compact X {𝓥}
+                      → is-Π-Compact Y {𝓥}
+ surjection-Π-Compact {𝓤} {𝓥} {X} {Y} f i = dense-map-Π-Compact f (surjections-are-dense f i)
+
+ image-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                 → is-Π-Compact X {𝓤 ⊔ 𝓥}
+                 → is-Π-Compact (image f) {𝓤 ⊔ 𝓥}
+ image-Π-Compact f c = surjection-Π-Compact (corestriction f)
+                        (corestrictions-are-surjections f) c
 
  open PropositionalTruncation pt
 

--- a/source/TypeTopology/CompactTypes.lagda
+++ b/source/TypeTopology/CompactTypes.lagda
@@ -856,21 +856,23 @@ dense-map-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                   → is-Compact X {𝓥}
                   → is-Compact Y {𝓥}
 dense-map-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
-  cases-map
-    ( λ z → f (z .pr₁) , z .pr₂)
-    ( λ nxpf yp →
-      i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂))))
-    ( c (A ∘ f) (δ ∘ f))
+ cases-map
+  (λ z → f (z .pr₁) , z .pr₂)
+  (λ nxpf yp →
+   i (yp .pr₁ , λ xr → nxpf (xr .pr₁ , transport A ((xr .pr₂)⁻¹) (yp .pr₂))))
+  (c (A ∘ f) (δ ∘ f))
 
 dense-map-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
-                  → is-dense f
-                  → is-Π-Compact X {𝓥}
-                  → is-Π-Compact Y {𝓥}
+                    → is-dense f
+                    → is-Π-Compact X {𝓥}
+                    → is-Π-Compact Y {𝓥}
 dense-map-Π-Compact {𝓤} {𝓥} {X} {Y} f i c A δ =
-  cases-map
-    ( λ p y → Cases (δ y) id (λ np → unique-from-𝟘 (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))))
-    ( λ nph p → nph (p ∘ f))
-    ( c (A ∘ f) (δ ∘ f))
+ cases-map
+  (λ p y →
+   Cases (δ y) id
+    (λ np → 𝟘-elim (i (y , λ xp → np (transport A (xp .pr₂) (p (xp .pr₁)))))))
+  (λ nph p → nph (p ∘ f))
+  (c (A ∘ f) (δ ∘ f))
 
 \end{code}
 
@@ -884,7 +886,8 @@ module CompactTypesPT (pt : propositional-truncations-exist) where
                     → is-surjection f
                     → is-Compact X {𝓥}
                     → is-Compact Y {𝓥}
- surjection-Compact {𝓤} {𝓥} {X} {Y} f i = dense-map-Compact f (surjections-are-dense f i)
+ surjection-Compact {𝓤} {𝓥} {X} {Y} f i =
+  dense-map-Compact f (surjections-are-dense f i)
 
  image-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                → is-Compact X {𝓤 ⊔ 𝓥}
@@ -896,7 +899,8 @@ module CompactTypesPT (pt : propositional-truncations-exist) where
                       → is-surjection f
                       → is-Π-Compact X {𝓥}
                       → is-Π-Compact Y {𝓥}
- surjection-Π-Compact {𝓤} {𝓥} {X} {Y} f i = dense-map-Π-Compact f (surjections-are-dense f i)
+ surjection-Π-Compact {𝓤} {𝓥} {X} {Y} f i =
+  dense-map-Π-Compact f (surjections-are-dense f i)
 
  image-Π-Compact : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                  → is-Π-Compact X {𝓤 ⊔ 𝓥}

--- a/source/UF/ImageAndSurjection.lagda
+++ b/source/UF/ImageAndSurjection.lagda
@@ -9,6 +9,7 @@ open import UF.PropTrunc
 module UF.ImageAndSurjection (pt : propositional-truncations-exist) where
 
 open import MLTT.Spartan
+open import TypeTopology.Density
 open import UF.Base
 open import UF.Embeddings
 open import UF.Equiv
@@ -461,5 +462,16 @@ equivs-are-surjections : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } {f : X → Y}
                        → is-equiv f
                        → is-surjection f
 equivs-are-surjections ((ρ , η) , (σ , ε)) y = ∣ ρ y , η y ∣
+
+\end{code}
+
+Added 26 March 2025 by Fredrik Bakke.
+
+\begin{code}
+
+surjections-are-dense : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
+                      → is-surjection f
+                      → is-dense f
+surjections-are-dense {𝓤} {𝓥} {X} {Y} f s (y , q) = ∥∥-rec 𝟘-is-prop q (s y)
 
 \end{code}

--- a/source/UF/ImageAndSurjection.lagda
+++ b/source/UF/ImageAndSurjection.lagda
@@ -472,6 +472,6 @@ Added 26 March 2025 by Fredrik Bakke.
 surjections-are-dense : {X : 𝓤 ̇ } {Y : 𝓥 ̇ } (f : X → Y)
                       → is-surjection f
                       → is-dense f
-surjections-are-dense {𝓤} {𝓥} {X} {Y} f s (y , q) = ∥∥-rec 𝟘-is-prop q (s y)
+surjections-are-dense f s (y , q) = ∥∥-rec 𝟘-is-prop q (s y)
 
 \end{code}

--- a/source/UF/ImageAndSurjection.lagda
+++ b/source/UF/ImageAndSurjection.lagda
@@ -465,7 +465,7 @@ equivs-are-surjections ((ρ , η) , (σ , ε)) y = ∣ ρ y , η y ∣
 
 \end{code}
 
-Added 26 March 2025 by Fredrik Bakke.
+Added by Fredrik Bakke on the 26th of March 2025.
 
 \begin{code}
 


### PR DESCRIPTION
This PR gives a straightforward generalization of the proposition that compact types are closed under covers that doesn't need function extensionality or propositional truncations.

Apologies if I'm not following best practices; any advice is appreciated!