### PR TITLE
Prove equivalence of untruncated at-most-two lemma for Aut Omega and EM for Aut Omega

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please add yourself the first time you contribute.
 * Fredrik Nordvall Forsberg
 * Ian Ray
 * Igor Arrieta (ii)
-* J.A. Carr
+* J. A. Carr
 * Jon Sterling
 * Kelton OBrien
 * Keri D'Angelo

--- a/source/Higgs/AutomorphismsOfOmegaWEM.lagda
+++ b/source/Higgs/AutomorphismsOfOmegaWEM.lagda
@@ -126,10 +126,21 @@ EM-gives-not-is-automorphism em = ((⇁_ , I) , (⇁_ , I))
   I = DNE-gives-double-negation-equality
        (EM-gives-DNE em)
 
-Ω-automorphism-not-id-iff-equals-not
- : (𝕗 : Aut Ω)
- → (𝕗 ≠ 𝕚𝕕) ↔ (⌜ 𝕗 ⌝ ＝ ⇁_)
-Ω-automorphism-not-id-iff-equals-not 𝕗@(f , f-is-equiv) = (FW , BW)
+⇁' : {𝕗 : Aut Ω} → (𝕗 ≠ 𝕚𝕕) → Aut Ω
+⇁' {𝕗} ν = (⇁_ ,
+        EM-gives-not-is-automorphism
+         (Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (𝕗 , ν)))
+
+not-true-is-false : {𝕗 : Aut Ω}
+                  → (ν : 𝕗 ≠ 𝕚𝕕)
+                  → ⊥ ＝ eval-at-⊤ (⇁' ν)
+not-true-is-false ν = Ω-extensionality pe fe 𝟘-elim (λ f → 𝟘-elim (f ⋆))
+
+not-id-is-not : {𝕗 𝕘 : Aut Ω}
+              → (ν : 𝕗 ≠ 𝕚𝕕)
+              → (χ : 𝕘 ≠ 𝕚𝕕)
+              → 𝕗 ＝ (⇁' χ)
+not-id-is-not {𝕗@(f , f-is-equiv)} ν χ = eval-at-⊤-is-lc (III ν ∙ not-true-is-false χ)
  where
   I : f ⊤ ＝ ⊤ → 𝕗 ＝ 𝕚𝕕
   I = eval-at-⊤-is-lc {𝕗} {𝕚𝕕}
@@ -140,19 +151,14 @@ EM-gives-not-is-automorphism em = ((⇁_ , I) , (⇁_ , I))
   III : (𝕗 ≠ 𝕚𝕕) → f ⊤ ＝ ⊥
   III ν = different-from-⊤-gives-equal-⊥ fe pe (f ⊤) (II ν)
 
-  ⇁' : (𝕗 ≠ 𝕚𝕕) → Aut Ω
-  ⇁' ν = (⇁_ ,
-          EM-gives-not-is-automorphism
-           (Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (𝕗 , ν)))
-
-  not-true-is-false : (ν : 𝕗 ≠ 𝕚𝕕) → ⊥ ＝ eval-at-⊤ (⇁' ν)
-  not-true-is-false ν = Ω-extensionality pe fe 𝟘-elim (λ f → 𝟘-elim (f ⋆))
-
-  IV : (ν : 𝕗 ≠ 𝕚𝕕) → 𝕗 ＝ (⇁' ν)
-  IV ν = eval-at-⊤-is-lc (III ν ∙ not-true-is-false ν)
+Ω-automorphism-not-id-iff-equals-not
+ : (𝕗 : Aut Ω)
+ → (𝕗 ≠ 𝕚𝕕) ↔ (⌜ 𝕗 ⌝ ＝ ⇁_)
+Ω-automorphism-not-id-iff-equals-not 𝕗@(f , f-is-equiv) = (FW , BW)
+ where
 
   FW : (𝕗 ≠ 𝕚𝕕) → ⌜ 𝕗 ⌝ ＝ ⇁_
-  FW ν = ap ⌜_⌝ {𝕗} {⇁' ν} (IV ν)
+  FW ν = ap ⌜_⌝ {𝕗} {⇁' ν} (not-id-is-not ν ν)
 
   not-is-not-id : ⇁_ ≠ id
   not-is-not-id e = ⊥-is-not-⊤

--- a/source/Higgs/AutomorphismsOfOmegaWEM.lagda
+++ b/source/Higgs/AutomorphismsOfOmegaWEM.lagda
@@ -1,4 +1,4 @@
-J.A. Carr 2 July 2025.
+J. A. Carr 2 July 2025.
 
 The type Aut Ω has a sort of weak excluded middle: Every automorphism
 is either equal to not (in which case full LEM holds) or it's not

--- a/source/Higgs/AutomorphismsOfOmegaWEM.lagda
+++ b/source/Higgs/AutomorphismsOfOmegaWEM.lagda
@@ -126,21 +126,18 @@ EM-gives-not-is-automorphism em = ((⇁_ , I) , (⇁_ , I))
   I = DNE-gives-double-negation-equality
        (EM-gives-DNE em)
 
-⇁' : {𝕗 : Aut Ω} → (𝕗 ≠ 𝕚𝕕) → Aut Ω
-⇁' {𝕗} ν = (⇁_ ,
-        EM-gives-not-is-automorphism
-         (Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (𝕗 , ν)))
+⇁' : EM 𝓤 → Aut Ω
+⇁' em = (⇁_ , EM-gives-not-is-automorphism em)
 
-not-true-is-false : {𝕗 : Aut Ω}
-                  → (ν : 𝕗 ≠ 𝕚𝕕)
-                  → ⊥ ＝ eval-at-⊤ (⇁' ν)
+not-true-is-false : (em : EM 𝓤)
+                  → ⊥ ＝ eval-at-⊤ (⇁' em)
 not-true-is-false ν = Ω-extensionality pe fe 𝟘-elim (λ f → 𝟘-elim (f ⋆))
 
-not-id-is-not : {𝕗 𝕘 : Aut Ω}
+not-id-is-not : {𝕗 : Aut Ω}
               → (ν : 𝕗 ≠ 𝕚𝕕)
-              → (χ : 𝕘 ≠ 𝕚𝕕)
-              → 𝕗 ＝ (⇁' χ)
-not-id-is-not {𝕗@(f , f-is-equiv)} ν χ = eval-at-⊤-is-lc (III ν ∙ not-true-is-false χ)
+              → (em : EM 𝓤)
+              → 𝕗 ＝ (⇁' em)
+not-id-is-not {𝕗@(f , f-is-equiv)} ν em = eval-at-⊤-is-lc (III ν ∙ not-true-is-false em)
  where
   I : f ⊤ ＝ ⊤ → 𝕗 ＝ 𝕚𝕕
   I = eval-at-⊤-is-lc {𝕗} {𝕚𝕕}
@@ -158,7 +155,9 @@ not-id-is-not {𝕗@(f , f-is-equiv)} ν χ = eval-at-⊤-is-lc (III ν ∙ not-
  where
 
   FW : (𝕗 ≠ 𝕚𝕕) → ⌜ 𝕗 ⌝ ＝ ⇁_
-  FW ν = ap ⌜_⌝ {𝕗} {⇁' ν} (not-id-is-not ν ν)
+  FW ν = ap ⌜_⌝ {𝕗} {⇁' em} (not-id-is-not ν em)
+   where
+    em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (𝕗 , ν)
 
   not-is-not-id : ⇁_ ≠ id
   not-is-not-id e = ⊥-is-not-⊤

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -130,11 +130,11 @@ almost-constantly-is-constant {_} {_} {X} {Y} X-discrete x' y _ refl = dfunext f
 
 
 at-most-discrete-gives-discrete
-  : {𝓤 𝓥 : Universe}
-  → (X : 𝓤 ̇) (Y : 𝓥 ̇)
-  → is-discrete X
-  → ((f : X → Y) → f has-a-repetition)
-  → is-discrete Y
+ : {𝓤 𝓥 : Universe}
+ → (X : 𝓤 ̇) (Y : 𝓥 ̇)
+ → is-discrete X
+ → ((f : X → Y) → f has-a-repetition)
+ → is-discrete Y
 at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
  where
 
@@ -145,15 +145,15 @@ at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
     (f-ph f)
 
   repeat-is-repeat : (f : X → Y)
-                   → let (x , x') = repeat-indices f in
-                   f x ＝ f x'
+                   → let (x , x') = repeat-indices f
+                     in f x ＝ f x'
   repeat-is-repeat f =
     let (x , x' , _ , pf) = f-ph f
     in pf
 
   repeat-distinct : (f : X → Y)
-                → let (x , x') = repeat-indices f in
-                x ≠ x'
+                  → let (x , x') = repeat-indices f
+                    in x ≠ x'
   repeat-distinct f =
     let (x , x' , pf , _) = f-ph f
     in pf
@@ -165,7 +165,7 @@ at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
 
   I : y ＝ y' → ix₁ ＝ ix₂
   I e = ap repeat-indices
-    (almost-constantly-is-constant X-discrete (pr₁ ix₁) y y' e)
+           (almost-constantly-is-constant X-discrete (pr₁ ix₁) y y' e)
 
   II : (x : X)
      → (pr₁ ix₁ ≠ x)
@@ -177,14 +177,14 @@ at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
 
   IV : ix₁ ＝ ix₂ → y ＝ y'
   IV e =
-    y            ＝⟨ II (pr₂ ix₁) (repeat-distinct f₁) ⟩
-    f₂ (pr₂ ix₁) ＝⟨ ap (f₂ ∘ pr₂) e ⟩
-    f₂ (pr₂ ix₂) ＝⟨ refl ⟩
-    f₂ (pr₂ (repeat-indices f₂)) ＝⟨ repeat-is-repeat f₂ ⁻¹ ⟩
-    f₂ (pr₁ (repeat-indices f₂)) ＝⟨ refl ⟩
-    f₂ (pr₁ ix₂) ＝⟨ ap (f₂ ∘ pr₁) (e ⁻¹) ⟩
-    f₂ (pr₁ ix₁) ＝⟨ III ⟩
-    y' ∎
+   y                            ＝⟨ II (pr₂ ix₁) (repeat-distinct f₁) ⟩
+   f₂ (pr₂ ix₁)                 ＝⟨ ap (f₂ ∘ pr₂) e ⟩
+   f₂ (pr₂ ix₂)                 ＝⟨ refl ⟩
+   f₂ (pr₂ (repeat-indices f₂)) ＝⟨ repeat-is-repeat f₂ ⁻¹ ⟩
+   f₂ (pr₁ (repeat-indices f₂)) ＝⟨ refl ⟩
+   f₂ (pr₁ ix₂)                 ＝⟨ ap (f₂ ∘ pr₁) (e ⁻¹) ⟩
+   f₂ (pr₁ ix₁)                 ＝⟨ III ⟩
+   y'                           ∎
 
   V : is-decidable (ix₁ ＝ ix₂) → is-decidable (y ＝ y')
   V (inl e) = inl (IV e)
@@ -200,11 +200,11 @@ We may write the untruncated form of the at-most-2 lemma in this form
 \begin{code} 
 
 at-most-two-is-pigeonhole
-  : {𝓤 : Universe}
-  → {X : 𝓤 ̇}
-  → ((x y z : X) → (z ＝ x) + (x ＝ y) + (y ＝ z))
-  → (f : Fin 3 → X)
-  → f has-a-repetition
+ : {𝓤 : Universe}
+ → {X : 𝓤 ̇}
+ → ((x y z : X) → (z ＝ x) + (x ＝ y) + (y ＝ z))
+ → (f : Fin 3 → X)
+ → f has-a-repetition
 at-most-two-is-pigeonhole at-most-2 f = II I
  where
   v1 v2 v3 : Fin 3
@@ -244,11 +244,10 @@ at-most-two-is-pigeonhole at-most-2 f = II I
   II (inr (inr e23)) = ( v2 , v3 , v2-not-3 , e23 )
 
 aut-Ω-discrete-has-em
-  : is-discrete (Aut Ω)
-  → (𝕗 : Aut Ω)
-  → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕)
-aut-Ω-discrete-has-em aut-disc 𝕗 =
-  aut-disc 𝕗 𝕚𝕕
+ : is-discrete (Aut Ω)
+ → (𝕗 : Aut Ω)
+ → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕)
+aut-Ω-discrete-has-em aut-disc 𝕗 = aut-disc 𝕗 𝕚𝕕
 
 untruncated-at-most-two-iff-em
  : ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
@@ -258,21 +257,18 @@ untruncated-at-most-two-iff-em = (FW , BW)
   FW : ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
      → ((𝕗 : Aut Ω) → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕))
   FW at-most-two = aut-Ω-discrete-has-em
-    (at-most-discrete-gives-discrete
-      (Fin 3) (Aut Ω)
-      Fin-is-discrete
-      (at-most-two-is-pigeonhole at-most-two)
-    )
+      (at-most-discrete-gives-discrete
+       (Fin 3) (Aut Ω)
+       Fin-is-discrete
+       (at-most-two-is-pigeonhole at-most-two))
 
   I : {f g : Aut Ω}
     → (f ≠ 𝕚𝕕)
     → (g ≠ 𝕚𝕕)
     → (f ＝ g)
-  I {f} f-not g-not =
-    ((not-id-is-not f-not em) ∙
-     (not-id-is-not g-not em) ⁻¹)
+  I {f} f-not g-not = ((not-id-is-not f-not em) ∙ (not-id-is-not g-not em) ⁻¹)
    where
-     em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (f , f-not)
+    em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (f , f-not)
 
   II : {f g h : Aut Ω}
      → ((f ＝ 𝕚𝕕) + (f ≠ 𝕚𝕕))

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -1,0 +1,240 @@
+J.A. Carr 8 July 2025.
+
+The untruncated form of the at-most-two elements is equivalent
+to the statement that Aut Ω has exactly 1 or 2 elements
+(and hence every element is either identity or negation)
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K #-}
+
+open import MLTT.Spartan
+open import MLTT.Plus-Properties
+open import UF.DiscreteAndSeparated
+open import UF.Equiv hiding (_≅_)
+open import UF.FunExt
+open import UF.Logic
+open import UF.PropTrunc
+open import UF.Subsingletons
+open import UF.SubtypeClassifier hiding (Ω)
+open import Fin.Type
+open import Fin.Topology
+open import Fin.Pigeonhole
+
+module Higgs.UntruncatedAtMostTwo
+        {𝓤 : Universe}
+        (fe : Fun-Ext)
+        (pe : propext 𝓤)
+        (pt : propositional-truncations-exist)
+       where
+
+open import Higgs.InvolutionTheorem fe pe
+open import Higgs.AutomorphismsOfOmega fe pe
+open import Higgs.AutomorphismsOfOmegaWEM fe pe pt
+
+open Conjunction
+open Implication fe
+open Universal fe
+
+\end{code}
+
+Assuming function extensionality, having an untruncated pigeonhole principle
+reflects discreteness to the codomain.
+
+The core method is to note that the pidgeonhole function must respect equality
+of functions, so we produce a pair of functions, where equality of their results
+holds if and only if the two elements of the codomain are equal.
+
+\begin{code}
+
+constantly : {𝓤 𝓥 : Universe}
+           → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+           → Y → X → Y
+constantly const-y _ = const-y
+
+almost-constantly : {𝓤 𝓥 : Universe}
+                  → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+                  → is-discrete X
+                  → X → Y → Y → X → Y
+almost-constantly X-discrete pt-x pt-y const-y x' =
+  cases
+   (λ _ → pt-y) (λ _ → const-y)
+   (X-discrete x' pt-x)
+
+almost-constantly-is-constant
+ : {𝓤 𝓥 : Universe}
+ → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+ → (X-discrete : is-discrete X)
+ → (x : X)
+ → (y y' : Y)
+ → y ＝ y'
+ → constantly y ＝ almost-constantly X-discrete x y' y
+almost-constantly-is-constant {_} {_} {X} {Y} X-discrete x y _ refl = dfunext fe I
+ where
+  I : (x' : X)
+    → constantly y x' ＝ almost-constantly X-discrete x y y x'
+  -- possibly rewrite this with dep-cases?
+  -- it's more obvious and spartan but much more awkward
+  I x' with X-discrete x' x
+  ... | inl _ = refl
+  ... | inr _ = refl
+
+at-most-discrete-gives-discrete
+  : {𝓤 𝓥 : Universe}
+  → (X : 𝓤 ̇) (Y : 𝓥 ̇)
+  → is-discrete X
+  → ((f : X → Y) → f has-a-repetition)
+  → is-discrete Y
+at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
+ where
+
+  repeat-indices : (X → Y)
+                 → X × X
+  repeat-indices f =
+    (λ (x , x' , _) → (x , x'))
+    (f-ph f)
+
+  repeat-is-repeat : (f : X → Y)
+                   → let (x , x') = repeat-indices f in
+                   f x ＝ f x'
+  repeat-is-repeat f =
+    let (x , x' , _ , pf) = f-ph f
+    in pf
+
+  repeat-distinct : (f : X → Y)
+                → let (x , x') = repeat-indices f in
+                x ≠ x'
+  repeat-distinct f =
+    let (x , x' , pf , _) = f-ph f
+    in pf
+
+  f₁ = constantly y
+  ix₁ = repeat-indices f₁
+  f₂ = almost-constantly X-discrete (pr₁ ix₁) y' y
+  ix₂ = repeat-indices f₂
+
+  I : y ＝ y' → ix₁ ＝ ix₂
+  I e = ap repeat-indices
+    (almost-constantly-is-constant X-discrete (pr₁ ix₁) y y' e)
+
+  II : (x : X)
+     → (pr₁ ix₁ ≠ x)
+     → y ＝ f₂ x
+  II x ne with X-discrete x (pr₁ ix₁)
+  ... | inl e = 𝟘-elim (ne (e ⁻¹))
+  ... | inr _ = refl
+
+  III : f₂ (pr₁ ix₁) ＝ y'
+  III with X-discrete (pr₁ ix₁) (pr₁ ix₁)
+  ... | inl e = refl
+  ... | inr ne = 𝟘-elim (ne refl)
+
+  IV : ix₁ ＝ ix₂ → y ＝ y'
+  IV e =
+    y            ＝⟨ II (pr₂ ix₁) (repeat-distinct f₁) ⟩
+    f₂ (pr₂ ix₁) ＝⟨ ap (f₂ ∘ pr₂) e ⟩
+    f₂ (pr₂ ix₂) ＝⟨ refl ⟩
+    f₂ (pr₂ (repeat-indices f₂)) ＝⟨ repeat-is-repeat f₂ ⁻¹ ⟩
+    f₂ (pr₁ (repeat-indices f₂)) ＝⟨ refl ⟩
+    f₂ (pr₁ ix₂) ＝⟨ ap (f₂ ∘ pr₁) (e ⁻¹) ⟩
+    f₂ (pr₁ ix₁) ＝⟨ III ⟩
+    y' ∎
+
+  V : is-decidable (ix₁ ＝ ix₂) → is-decidable (y ＝ y')
+  V (inl e) = inl (IV e)
+  V (inr ne) = inr (ne ∘ I)
+
+  VI : is-decidable (ix₁ ＝ ix₂)
+  VI = ×-is-discrete X-discrete X-discrete ix₁ ix₂
+
+\end{code}
+
+We may write the untruncated form of the at-most-2 lemma in this form
+
+\begin{code} 
+
+at-most-two-is-pigeonhole
+  : {𝓤 : Universe}
+  → {X : 𝓤 ̇}
+  → ((x y z : X) → (z ＝ x) + (x ＝ y) + (y ＝ z))
+  → (f : Fin 3 → X)
+  → f has-a-repetition
+at-most-two-is-pigeonhole at-most-2 f = II I
+ where
+  v1 v2 v3 : Fin 3
+  v1 = inr ⋆
+  v2 = inl (inr ⋆)
+  v3 = inl (inl (inr ⋆))
+
+  true-when : Fin 3
+            → Fin 3
+            → 𝓤 ⁺ ̇
+  true-when (inr _) (inr _) = 𝟙
+  true-when (inl (inr _)) (inl (inr _)) = 𝟙
+  true-when (inl (inl (inr _))) (inl (inl (inr _))) = 𝟙
+  {-# CATCHALL #-}
+  true-when _ _ = 𝟘
+
+  v3-not-1 : v3 ≠ v1
+  v3-not-1 e = 𝟘-elim (transport (true-when v3) e ⋆)
+  v1-not-2 : v1 ≠ v2
+  v1-not-2 e = 𝟘-elim (transport (true-when v1) e ⋆)
+  v2-not-3 : v2 ≠ v3
+  v2-not-3 e = 𝟘-elim (transport (true-when v2) e ⋆)
+
+  I : (f v3 ＝ f v1) + (f v1 ＝ f v2) + (f v2 ＝ f v3)
+  I = at-most-2 (f v1) (f v2) (f v3)
+
+  II : (f v3 ＝ f v1) + (f v1 ＝ f v2) + (f v2 ＝ f v3)
+     → f has-a-repetition
+  II (inl e31)       = ( v3 , v1 , v3-not-1 , e31 )
+  II (inr (inl e12)) = ( v1 , v2 , v1-not-2 , e12 )
+  II (inr (inr e23)) = ( v2 , v3 , v2-not-3 , e23 )
+
+aut-Ω-discrete-has-em
+  : is-discrete (Aut Ω)
+  → (𝕗 : Aut Ω)
+  → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕)
+aut-Ω-discrete-has-em aut-disc 𝕗 =
+  aut-disc 𝕗 𝕚𝕕
+
+untruncated-at-most-two-iff-em
+ : ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
+ ↔ ((𝕗 : Aut Ω) → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕))
+untruncated-at-most-two-iff-em = (FW , BW)
+ where
+  FW : ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
+     → ((𝕗 : Aut Ω) → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕))
+  FW at-most-two = aut-Ω-discrete-has-em
+    (at-most-discrete-gives-discrete
+      (Fin 3) (Aut Ω)
+      Fin-is-discrete
+      (at-most-two-is-pigeonhole at-most-two)
+    )
+
+  I : {f g : Aut Ω}
+    → (f ≠ 𝕚𝕕)
+    → (g ≠ 𝕚𝕕)
+    → (f ＝ g)
+  I f-not g-not =
+    ((not-id-is-not f-not g-not) ∙
+     (not-id-is-not g-not g-not) ⁻¹)
+
+  II : {f g h : Aut Ω}
+     → ((f ＝ 𝕚𝕕) + (f ≠ 𝕚𝕕))
+     → ((g ＝ 𝕚𝕕) + (g ≠ 𝕚𝕕))
+     → ((h ＝ 𝕚𝕕) + (h ≠ 𝕚𝕕))
+     → (h ＝ f) + (f ＝ g) + (g ＝ h)
+  II (inl  ef) (inl  eg) (_      ) = inr (inl (ef ∙ eg ⁻¹))
+  II (inl  _ ) (inr neg) (inr neh) = inr (inr (I neg neh))
+  II (inl  ef) (inr neg) (inl  eh) = inl (eh ∙ ef ⁻¹)
+  II (inr  _ ) (inl  eg) (inl  eh) = inr (inr (eg ∙ eh ⁻¹))
+  II (inr nef) (inr neg) (_      ) = inr (inl (I nef neg))
+  II (inr nef) (inl  _ ) (inr neh) = inl (I neh nef)
+
+  BW : ((𝕗 : Aut Ω) → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕))
+     → ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
+  BW em f g h = II (em f) (em g) (em h)
+
+
+\end{code} 

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -11,6 +11,7 @@ to the statement that Aut Ω has exactly 1 or 2 elements
 open import MLTT.Spartan
 open import MLTT.Plus-Properties
 open import UF.DiscreteAndSeparated
+open import TypeTopology.SigmaDiscreteAndTotallySeparated
 open import UF.Equiv hiding (_≅_)
 open import UF.FunExt
 open import UF.Logic

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -221,8 +221,8 @@ untruncated-at-most-two-iff-em = (FW , BW)
   I {f} f-not g-not =
     ((not-id-is-not f-not em) ∙
      (not-id-is-not g-not em) ⁻¹)
-    where
-      em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (f , f-not)
+   where
+     em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (f , f-not)
 
   II : {f g h : Aut Ω}
      → ((f ＝ 𝕚𝕕) + (f ≠ 𝕚𝕕))

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -52,34 +52,82 @@ holds if and only if the two elements of the codomain are equal.
 constantly : {𝓤 𝓥 : Universe}
            → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
            → Y → X → Y
-constantly const-y _ = const-y
+constantly y _ = y
+
+almost-constantly-inner : {𝓤 𝓥 : Universe}
+                  → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+                  → (x' : X) → Y → Y → (x : X)
+                  → ((x' ＝ x) + (x' ≠ x))
+                  → Y
+almost-constantly-inner _ y' y _ (inl _) = y'
+almost-constantly-inner _ y' y _ (inr _) = y
 
 almost-constantly : {𝓤 𝓥 : Universe}
                   → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
                   → is-discrete X
-                  → X → Y → Y → X → Y
-almost-constantly X-discrete pt-x pt-y const-y x' =
-  cases
-   (λ _ → pt-y) (λ _ → const-y)
-   (X-discrete x' pt-x)
+                  → X → Y → Y → X
+                  → Y
+almost-constantly X-discrete x' y' y x =
+ almost-constantly-inner x' y' y x (X-discrete x' x)
+
+almost-constantly-eq : {𝓤 𝓥 : Universe}
+                     → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+                     → (X-discrete : is-discrete X)
+                     → (x : X)
+                     → (y' y : Y)
+                     → almost-constantly X-discrete x y' y x ＝ y'
+almost-constantly-eq X-discrete x y' y =
+ almost-constantly X-discrete x y' y x               ＝⟨ refl ⟩
+ almost-constantly-inner x y' y x (X-discrete x x)   ＝⟨ I ⟩
+ almost-constantly-inner x y' y x (inl refl)         ＝⟨ refl ⟩
+ y'                                                  ∎
+ where
+  I : almost-constantly-inner x y' y x (X-discrete x x) ＝
+      almost-constantly-inner x y' y x (inl refl)
+  I = ap (almost-constantly-inner x y' y x)
+         (discrete-inl-refl X-discrete x)
+
+almost-constantly-neq : {𝓤 𝓥 : Universe}
+                      → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+                      → (X-discrete : is-discrete X)
+                      → (x' x : X)
+                      → (y' y : Y)
+                      → (x' ≠ x)
+                      → almost-constantly X-discrete x' y' y x ＝ y
+almost-constantly-neq X-discrete x' x y' y ν =
+ almost-constantly X-discrete x' y' y x               ＝⟨ refl ⟩
+ almost-constantly-inner x' y' y x (X-discrete x' x)  ＝⟨ I ⟩
+ almost-constantly-inner x' y' y x (inr ν)            ＝⟨ refl ⟩
+ y                                                    ∎
+ where
+  I :  almost-constantly-inner x' y' y x (X-discrete x' x) ＝
+       almost-constantly-inner x' y' y x (inr ν)
+  I = ap (almost-constantly-inner x' y' y x)
+         (discrete-inr fe X-discrete x' x ν)
+
 
 almost-constantly-is-constant
  : {𝓤 𝓥 : Universe}
  → {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
  → (X-discrete : is-discrete X)
- → (x : X)
+ → (x' : X)
  → (y y' : Y)
  → y ＝ y'
- → constantly y ＝ almost-constantly X-discrete x y' y
-almost-constantly-is-constant {_} {_} {X} {Y} X-discrete x y _ refl = dfunext fe I
+ → constantly y ＝ almost-constantly X-discrete x' y' y
+almost-constantly-is-constant {_} {_} {X} {Y} X-discrete x' y _ refl = dfunext fe III
  where
-  I : (x' : X)
-    → constantly y x' ＝ almost-constantly X-discrete x y y x'
-  -- possibly rewrite this with dep-cases?
-  -- it's more obvious and spartan but much more awkward
-  I x' with X-discrete x' x
-  ... | inl _ = refl
-  ... | inr _ = refl
+  I : constantly y x' ＝ y
+  I = refl
+
+  II : (x : X)
+     → ((x' ＝ x) + (x' ≠ x))
+     → almost-constantly X-discrete x' y y x ＝ y
+  II _ (inl refl) = almost-constantly-eq X-discrete x' y y
+  II x (inr ν) = almost-constantly-neq X-discrete x' x y y ν
+
+  III : (x : X) → constantly y x' ＝ almost-constantly X-discrete x' y y x
+  III x = I ∙ II x (X-discrete x' x) ⁻¹
+
 
 at-most-discrete-gives-discrete
   : {𝓤 𝓥 : Universe}
@@ -122,14 +170,10 @@ at-most-discrete-gives-discrete X Y X-discrete f-ph y y' = V VI
   II : (x : X)
      → (pr₁ ix₁ ≠ x)
      → y ＝ f₂ x
-  II x ne with X-discrete x (pr₁ ix₁)
-  ... | inl e = 𝟘-elim (ne (e ⁻¹))
-  ... | inr _ = refl
+  II x ne = almost-constantly-neq X-discrete (pr₁ ix₁) x y' y ne ⁻¹
 
   III : f₂ (pr₁ ix₁) ＝ y'
-  III with X-discrete (pr₁ ix₁) (pr₁ ix₁)
-  ... | inl e = refl
-  ... | inr ne = 𝟘-elim (ne refl)
+  III = almost-constantly-eq X-discrete (pr₁ ix₁) y' y
 
   IV : ix₁ ＝ ix₂ → y ＝ y'
   IV e =

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -215,11 +215,17 @@ at-most-two-is-pigeonhole at-most-2 f = II I
   true-when : Fin 3
             → Fin 3
             → 𝓤 ⁺ ̇
-  true-when (inr _) (inr _) = 𝟙
+  true-when (inl (inl _)) (inl (inl _)) = 𝟙
+  true-when (inl (inl _)) (inl (inr _)) = 𝟘
+  true-when (inl (inl _)) (inr _) = 𝟘
+
+  true-when (inl (inr _)) (inl (inl _)) = 𝟘
   true-when (inl (inr _)) (inl (inr _)) = 𝟙
-  true-when (inl (inl (inr _))) (inl (inl (inr _))) = 𝟙
-  {-# CATCHALL #-}
-  true-when _ _ = 𝟘
+  true-when (inl (inr _)) (inr _) = 𝟘
+
+  true-when (inr _) (inl (inl _)) = 𝟘
+  true-when (inr _) (inl (inr _)) = 𝟘
+  true-when (inr _) (inr _) = 𝟙
 
   v3-not-1 : v3 ≠ v1
   v3-not-1 e = 𝟘-elim (transport (true-when v3) e ⋆)

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -29,6 +29,7 @@ module Higgs.UntruncatedAtMostTwo
         (pt : propositional-truncations-exist)
        where
 
+open import Higgs.Rigidity fe pe
 open import Higgs.InvolutionTheorem fe pe
 open import Higgs.AutomorphismsOfOmega fe pe
 open import Higgs.AutomorphismsOfOmegaWEM fe pe pt
@@ -217,9 +218,11 @@ untruncated-at-most-two-iff-em = (FW , BW)
     → (f ≠ 𝕚𝕕)
     → (g ≠ 𝕚𝕕)
     → (f ＝ g)
-  I f-not g-not =
-    ((not-id-is-not f-not g-not) ∙
-     (not-id-is-not g-not g-not) ⁻¹)
+  I {f} f-not g-not =
+    ((not-id-is-not f-not em) ∙
+     (not-id-is-not g-not em) ⁻¹)
+    where
+      em = Ω-automorphism-distinct-from-𝕚𝕕-gives-EM (f , f-not)
 
   II : {f g h : Aut Ω}
      → ((f ＝ 𝕚𝕕) + (f ≠ 𝕚𝕕))

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -1,4 +1,4 @@
-J.A. Carr 8 July 2025.
+J. A. Carr 8 July 2025.
 
 The untruncated form of the at-most-two elements is equivalent
 to the statement that Aut Ω has exactly 1 or 2 elements

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -82,8 +82,8 @@ almost-constantly-eq X-discrete x y' y =
  almost-constantly-inner x y' y x (inl refl)         ＝⟨ refl ⟩
  y'                                                  ∎
  where
-  I : almost-constantly-inner x y' y x (X-discrete x x) ＝
-      almost-constantly-inner x y' y x (inl refl)
+  I : almost-constantly-inner x y' y x (X-discrete x x)
+      ＝ almost-constantly-inner x y' y x (inl refl)
   I = ap (almost-constantly-inner x y' y x)
          (discrete-inl-refl X-discrete x)
 
@@ -100,8 +100,8 @@ almost-constantly-neq X-discrete x' x y' y ν =
  almost-constantly-inner x' y' y x (inr ν)            ＝⟨ refl ⟩
  y                                                    ∎
  where
-  I :  almost-constantly-inner x' y' y x (X-discrete x' x) ＝
-       almost-constantly-inner x' y' y x (inr ν)
+  I :  almost-constantly-inner x' y' y x (X-discrete x' x)
+       ＝ almost-constantly-inner x' y' y x (inr ν)
   I = ap (almost-constantly-inner x' y' y x)
          (discrete-inr fe X-discrete x' x ν)
 

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -212,27 +212,27 @@ at-most-two-is-pigeonhole at-most-2 f = II I
   v2 = inl (inr ⋆)
   v3 = inl (inl (inr ⋆))
 
-  true-when : Fin 3
-            → Fin 3
-            → 𝓤 ⁺ ̇
-  true-when (inl (inl _)) (inl (inl _)) = 𝟙
-  true-when (inl (inl _)) (inl (inr _)) = 𝟘
-  true-when (inl (inl _)) (inr _) = 𝟘
+  true-when-eq : Fin 3
+               → Fin 3
+               → 𝓤 ⁺ ̇
+  true-when-eq (inl (inl _)) (inl (inl _)) = 𝟙
+  true-when-eq (inl (inl _)) (inl (inr _)) = 𝟘
+  true-when-eq (inl (inl _)) (inr _) = 𝟘
 
-  true-when (inl (inr _)) (inl (inl _)) = 𝟘
-  true-when (inl (inr _)) (inl (inr _)) = 𝟙
-  true-when (inl (inr _)) (inr _) = 𝟘
+  true-when-eq (inl (inr _)) (inl (inl _)) = 𝟘
+  true-when-eq (inl (inr _)) (inl (inr _)) = 𝟙
+  true-when-eq (inl (inr _)) (inr _) = 𝟘
 
-  true-when (inr _) (inl (inl _)) = 𝟘
-  true-when (inr _) (inl (inr _)) = 𝟘
-  true-when (inr _) (inr _) = 𝟙
+  true-when-eq (inr _) (inl (inl _)) = 𝟘
+  true-when-eq (inr _) (inl (inr _)) = 𝟘
+  true-when-eq (inr _) (inr _) = 𝟙
 
   v3-not-1 : v3 ≠ v1
-  v3-not-1 e = 𝟘-elim (transport (true-when v3) e ⋆)
+  v3-not-1 e = 𝟘-elim (transport (true-when-eq v3) e ⋆)
   v1-not-2 : v1 ≠ v2
-  v1-not-2 e = 𝟘-elim (transport (true-when v1) e ⋆)
+  v1-not-2 e = 𝟘-elim (transport (true-when-eq v1) e ⋆)
   v2-not-3 : v2 ≠ v3
-  v2-not-3 e = 𝟘-elim (transport (true-when v2) e ⋆)
+  v2-not-3 e = 𝟘-elim (transport (true-when-eq v2) e ⋆)
 
   I : (f v3 ＝ f v1) + (f v1 ＝ f v2) + (f v2 ＝ f v3)
   I = at-most-2 (f v1) (f v2) (f v3)

--- a/source/Higgs/UntruncatedAtMostTwo.lagda
+++ b/source/Higgs/UntruncatedAtMostTwo.lagda
@@ -257,10 +257,10 @@ untruncated-at-most-two-iff-em = (FW , BW)
   FW : ((f g h : Aut Ω) → (h ＝ f) + (f ＝ g) + (g ＝ h))
      → ((𝕗 : Aut Ω) → (𝕗 ＝ 𝕚𝕕) + (𝕗 ≠ 𝕚𝕕))
   FW at-most-two = aut-Ω-discrete-has-em
-      (at-most-discrete-gives-discrete
-       (Fin 3) (Aut Ω)
-       Fin-is-discrete
-       (at-most-two-is-pigeonhole at-most-two))
+   (at-most-discrete-gives-discrete
+    (Fin 3) (Aut Ω)
+    Fin-is-discrete
+    (at-most-two-is-pigeonhole at-most-two))
 
   I : {f g : Aut Ω}
     → (f ≠ 𝕚𝕕)

--- a/source/Higgs/index.lagda
+++ b/source/Higgs/index.lagda
@@ -18,5 +18,6 @@ import Higgs.Rigidity
 import Higgs.AutomorphismsOfOmega
 import Higgs.AtMostTwoAutomorphismsOfOmega
 import Higgs.AutomorphismsOfOmegaWEM       -- By J. A. Carr
+import Higgs.UntruncatedAtMostTwo          -- By J. A. Carr
 
 \end{code}

--- a/source/Higgs/index.lagda
+++ b/source/Higgs/index.lagda
@@ -17,6 +17,6 @@ import Higgs.GroupStructureOnOmega
 import Higgs.Rigidity
 import Higgs.AutomorphismsOfOmega
 import Higgs.AtMostTwoAutomorphismsOfOmega
-import Higgs.AutomorphismsOfOmegaWEM       -- By J.A. Carr
+import Higgs.AutomorphismsOfOmegaWEM       -- By J. A. Carr
 
 \end{code}

--- a/source/UF/DiscreteAndSeparated.lagda
+++ b/source/UF/DiscreteAndSeparated.lagda
@@ -129,6 +129,26 @@ inr-is-isolated {𝓤} {𝓥} {X} {Y} y i = γ
 
 \end{code}
 
+Added by J. A. Carr on 8 July 2025.
+\begin{code}
+
+×-is-discrete : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
+              → is-discrete X
+              → is-discrete Y
+              → is-discrete (X × Y)
+×-is-discrete {_} {_} {X} {Y} d e (x1 , y1) (x2 , y2) = I (d x1 x2) (e y1 y2)
+ where
+  I : {x1 x2 : X} {y1 y2 : Y}
+    → ((x1 ＝ x2) + (x1 ≠ x2))
+    → ((y1 ＝ y2) + (y1 ≠ y2))
+    → ((x1 , y1) ＝ (x2 , y2)) + ((x1 , y1) ≠ (x2 , y2))
+  I (inl ex) (inl ey) = inl (to-×-＝ ex ey)
+  I (inr nx) (inl _ ) = inr (λ e → nx (ap pr₁ e))
+  I (inl _)  (inr ny) = inr (λ e → ny (ap pr₂ e))
+  I (inr _)  (inr ny) = inr (λ e → ny (ap pr₂ e))
+
+\end{code}
+
 Added by Tom de Jong on 15 December 2024.
 Note that we could also derive this from Σ-is-discrete (see the comment below)
 and props-are-discrete (as above).

--- a/source/UF/DiscreteAndSeparated.lagda
+++ b/source/UF/DiscreteAndSeparated.lagda
@@ -129,26 +129,6 @@ inr-is-isolated {𝓤} {𝓥} {X} {Y} y i = γ
 
 \end{code}
 
-Added by J. A. Carr on 8 July 2025.
-\begin{code}
-
-×-is-discrete : {X : 𝓤 ̇ } {Y : 𝓥 ̇ }
-              → is-discrete X
-              → is-discrete Y
-              → is-discrete (X × Y)
-×-is-discrete {_} {_} {X} {Y} d e (x1 , y1) (x2 , y2) = I (d x1 x2) (e y1 y2)
- where
-  I : {x1 x2 : X} {y1 y2 : Y}
-    → ((x1 ＝ x2) + (x1 ≠ x2))
-    → ((y1 ＝ y2) + (y1 ≠ y2))
-    → ((x1 , y1) ＝ (x2 , y2)) + ((x1 , y1) ≠ (x2 , y2))
-  I (inl ex) (inl ey) = inl (to-×-＝ ex ey)
-  I (inr nx) (inl _ ) = inr (λ e → nx (ap pr₁ e))
-  I (inl _)  (inr ny) = inr (λ e → ny (ap pr₂ e))
-  I (inr _)  (inr ny) = inr (λ e → ny (ap pr₂ e))
-
-\end{code}
-
 Added by Tom de Jong on 15 December 2024.
 Note that we could also derive this from Σ-is-discrete (see the comment below)
 and props-are-discrete (as above).


### PR DESCRIPTION
The lemma used to prove this probably could serve to be moved somewhere else. I think a section for different notions of cardinality comparisons would be nice.

It implies also that a truncated form of the has-a-repetition would be very reasonable.

The proof is novel as far as I know, although the idea is inspired by Diaconescu's theorem. When we have a function whose domain is extensional, we can force it to make commitments on things which we later learn are equal.