### PR TITLE
More on ordinal arithmetic

### DIFF
--- a/source/Ordinals/AdditionProperties.lagda
+++ b/source/Ordinals/AdditionProperties.lagda
@@ -40,6 +40,7 @@ open import Ordinals.Equivalence
 open import Ordinals.Maps
 open import Ordinals.Notions
 open import Ordinals.OrdinalOfOrdinals ua
+open import Ordinals.Propositions ua
 open import Ordinals.Type
 open import Ordinals.Underlying
 
@@ -1063,50 +1064,51 @@ as a single supremum by indexing over 𝟙 + I instead, sending inl ⋆ to α.
 
 \begin{code}
 
- +ₒ-preserves-suprema
-  : (α : Ordinal 𝓤) {I : 𝓤 ̇ } (β : I → Ordinal 𝓤)
+ +ₒ-preserves-suprema-up-to-join
+  : (α : Ordinal 𝓤) (I : 𝓤 ̇ ) (β : I → Ordinal 𝓤)
   → α +ₒ sup β ＝ sup (cases (λ ⋆ → α) (λ i → α +ₒ β i))
- +ₒ-preserves-suprema {𝓤} α {I} β = ⊴-antisym (α +ₒ sup β) (sup F) ⦅1⦆ ⦅2⦆
-  where
-   F : 𝟙 {𝓤} + I → Ordinal 𝓤
-   F = cases (λ _ → α) (λ i → α +ₒ β i)
+ +ₒ-preserves-suprema-up-to-join {𝓤} α I β =
+  ⊴-antisym (α +ₒ sup β) (sup F) ⦅1⦆ ⦅2⦆
+   where
+    F : 𝟙 {𝓤} + I → Ordinal 𝓤
+    F = cases (λ _ → α) (λ i → α +ₒ β i)
 
-   ⦅1⦆ : α +ₒ sup β ⊴ sup F
-   ⦅1⦆ = to-⊴ (α +ₒ sup β) (sup F) h
-    where
-     h : (z : ⟨ α +ₒ sup β ⟩)
-       → (α +ₒ sup β) ↓ z ⊲ sup F
-     h (inl a) = (s , (α +ₒ sup β ↓ inl a ＝⟨ (+ₒ-↓-left a) ⁻¹ ⟩
-                       α ↓ a              ＝⟨ e ⟩
-                       sup F ↓ s          ∎))
-      where
-       s : ⟨ sup F ⟩
-       s = [ α , sup F ]⟨ sup-is-upper-bound F (inl ⋆) ⟩ a
-       e = (initial-segment-of-sup-at-component F (inl ⋆) a) ⁻¹
-     h (inr y) =
-      ∥∥-rec
-       (⊲-is-prop-valued (α +ₒ sup β ↓ inr y) (sup F))
-       g
-       (initial-segment-of-sup-is-initial-segment-of-some-component β y)
-      where
-       g : (Σ i ꞉ I , Σ x ꞉ ⟨ β i ⟩ , sup β ↓ y ＝ β i ↓ x)
-         → α +ₒ sup β ↓ inr y ⊲ sup F
-       g (i , x , e) = s , ((α +ₒ sup β) ↓ inr y ＝⟨ (+ₒ-↓-right y) ⁻¹ ⟩
-                            α +ₒ (sup β ↓ y)     ＝⟨ ap (α +ₒ_) e ⟩
-                            α +ₒ (β i ↓ x)       ＝⟨ +ₒ-↓-right x ⟩
-                            (α +ₒ β i) ↓ inr x   ＝⟨ e' ⟩
-                            sup F ↓ s            ∎)
-        where
-         s : ⟨ sup F ⟩
-         s = [ F (inr i) , sup F ]⟨ sup-is-upper-bound F (inr i) ⟩ (inr x)
-         e' = (initial-segment-of-sup-at-component F (inr i) (inr x)) ⁻¹
+    ⦅1⦆ : α +ₒ sup β ⊴ sup F
+    ⦅1⦆ = to-⊴ (α +ₒ sup β) (sup F) h
+     where
+      h : (z : ⟨ α +ₒ sup β ⟩)
+        → (α +ₒ sup β) ↓ z ⊲ sup F
+      h (inl a) = (s , (α +ₒ sup β ↓ inl a ＝⟨ (+ₒ-↓-left a) ⁻¹ ⟩
+                        α ↓ a              ＝⟨ e ⟩
+                        sup F ↓ s          ∎))
+       where
+        s : ⟨ sup F ⟩
+        s = [ α , sup F ]⟨ sup-is-upper-bound F (inl ⋆) ⟩ a
+        e = (initial-segment-of-sup-at-component F (inl ⋆) a) ⁻¹
+      h (inr y) =
+       ∥∥-rec
+        (⊲-is-prop-valued (α +ₒ sup β ↓ inr y) (sup F))
+        g
+        (initial-segment-of-sup-is-initial-segment-of-some-component β y)
+       where
+        g : (Σ i ꞉ I , Σ x ꞉ ⟨ β i ⟩ , sup β ↓ y ＝ β i ↓ x)
+          → α +ₒ sup β ↓ inr y ⊲ sup F
+        g (i , x , e) = s , ((α +ₒ sup β) ↓ inr y ＝⟨ (+ₒ-↓-right y) ⁻¹ ⟩
+                             α +ₒ (sup β ↓ y)     ＝⟨ ap (α +ₒ_) e ⟩
+                             α +ₒ (β i ↓ x)       ＝⟨ +ₒ-↓-right x ⟩
+                             (α +ₒ β i) ↓ inr x   ＝⟨ e' ⟩
+                             sup F ↓ s            ∎)
+         where
+          s : ⟨ sup F ⟩
+          s = [ F (inr i) , sup F ]⟨ sup-is-upper-bound F (inr i) ⟩ (inr x)
+          e' = (initial-segment-of-sup-at-component F (inr i) (inr x)) ⁻¹
 
-   ⦅2⦆ : sup F ⊴ α +ₒ sup β
-   ⦅2⦆ = sup-is-lower-bound-of-upper-bounds F (α +ₒ sup β) h
-    where
-     h : (x : 𝟙 + I) → F x ⊴ α +ₒ sup β
-     h (inl ⋆) = +ₒ-left-⊴ α (sup β)
-     h (inr i) = +ₒ-right-monotone-⊴ α (β i) (sup β) (sup-is-upper-bound β i)
+    ⦅2⦆ : sup F ⊴ α +ₒ sup β
+    ⦅2⦆ = sup-is-lower-bound-of-upper-bounds F (α +ₒ sup β) h
+     where
+      h : (x : 𝟙 + I) → F x ⊴ α +ₒ sup β
+      h (inl ⋆) = +ₒ-left-⊴ α (sup β)
+      h (inr i) = +ₒ-right-monotone-⊴ α (β i) (sup β) (sup-is-upper-bound β i)
 
 
 \end{code}
@@ -1126,5 +1128,68 @@ no-greatest-ordinal {𝓤} (α , α-greatest) = irrefl (OO 𝓤) α IV
   III = ⊴-antisym (α +ₒ 𝟙ₒ) α I II
   IV : α ⊲ α
   IV = transport (α ⊲_) III (successor-increasing α)
+
+\end{code}
+
+Added 15 July 2025 by Tom de Jong after discussions with Nicolai Kraus, Fredrik
+Nordvall Forsberg and Chuangjie Xu a year earlier.
+
+\begin{code}
+
++ₒ-as-large-as-right-summand-implies-EM : ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
+                                        → EM 𝓤
++ₒ-as-large-as-right-summand-implies-EM hyp P P-is-prop = IV
+ where
+  α = prop-ordinal P P-is-prop
+  β = 𝟙ₒ
+  𝕗 : β ⊴ α +ₒ β
+  𝕗 = hyp α β
+  f = [ β , α +ₒ β ]⟨ 𝕗 ⟩
+  I : (p : P) → f ⋆ ＝ inl p → P
+  I p _ = p
+  II : (p : P) → f ⋆ ＝ inl p
+  II p = simulations-preserve-least β (α +ₒ β) ⋆ (inl p) f
+                                    [ β , α +ₒ β ]⟨ 𝕗 ⟩-is-simulation
+                                    𝟙ₒ-least
+                                    l
+   where
+    l : is-least (α +ₒ β) (inl p)
+    l = minimal-is-least (α +ₒ β) (inl p) m
+     where
+      m : is-minimal (α +ₒ β) (inl p)
+      m (inl p') = 𝟘-elim
+      m (inr ⋆ ) = 𝟘-elim
+  III : f ⋆ ＝ inr ⋆ → ¬ P
+  III e p = +disjoint ((II p) ⁻¹ ∙ e)
+  IV : P + ¬ P
+  IV = equality-cases (f ⋆) (λ p → inl ∘ I p) (λ _ → inr ∘ III)
+
+EM-implies-+ₒ-as-large-as-right-summand : EM 𝓤
+                                        → ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
+EM-implies-+ₒ-as-large-as-right-summand em α β =
+ ≼-gives-⊴ β (α +ₒ β)
+           (EM-implies-order-preserving-gives-≼ em β (α +ₒ β) (f , I))
+  where
+   f : ⟨ β ⟩ → ⟨ α +ₒ β ⟩
+   f = inr
+   I : is-order-preserving β (α +ₒ β) f
+   I y y' l = l
+
+\end{code}
+
+Added 15 July 2025 by Tom de Jong.
+
+\begin{code}
+
++ₒ-minimal : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
+           → is-minimal α a₀ → is-minimal (α +ₒ β) (inl a₀)
++ₒ-minimal α β a₀ a₀-minimal (inl a) = a₀-minimal a
++ₒ-minimal α β a₀ a₀-minimal (inr b) = 𝟘-elim
+
++ₒ-least : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
+         → is-least α a₀ → is-least (α +ₒ β) (inl a₀)
++ₒ-least α β  a₀ a₀-least =
+ minimal-is-least (α +ₒ β) (inl a₀)
+                  (+ₒ-minimal α β a₀ (least-is-minimal α a₀ a₀-least))
 
 \end{code}

--- a/source/Ordinals/AdditionProperties.lagda
+++ b/source/Ordinals/AdditionProperties.lagda
@@ -234,6 +234,12 @@ open import Ordinals.Underlying
   ϕ : (x : ⟨ α +ₒ β ⟩) → ((α +ₒ β) ↓ x) ⊲ (α +ₒ γ)
   ϕ = dep-cases l r
 
++ₒ-right-monotone-⊴ : (α β γ : Ordinal 𝓤)
+                    → β ⊴ γ
+                    → (α +ₒ β) ⊴ (α +ₒ γ)
++ₒ-right-monotone-⊴ α β γ l =
+ ≼-gives-⊴ (α +ₒ β) (α +ₒ γ) (+ₒ-right-monotone α β γ (⊴-gives-≼ β γ l))
+
 \end{code}
 
 TODO. Find better names for the following lemmas.
@@ -953,9 +959,7 @@ module _ (pt : propositional-truncations-exist)
     ⦅2⦆ = sup-is-lower-bound-of-upper-bounds (λ i → α +ₒ β i) (α +ₒ sup β) ⦅2⦆'
      where
       ⦅2⦆' : (i : I) → (α +ₒ β i) ⊴ (α +ₒ sup β)
-      ⦅2⦆' i = ≼-gives-⊴ (α +ₒ β i) (α +ₒ sup β)
-                (+ₒ-right-monotone α (β i) (sup β)
-                 (⊴-gives-≼ _ _ (sup-is-upper-bound β i)))
+      ⦅2⦆' i = +ₒ-right-monotone-⊴ α (β i) (sup β) (sup-is-upper-bound β i)
 
     ⦅1⦆ : I → (α +ₒ sup β) ≼ sup (λ i → α +ₒ β i)
     ⦅1⦆ i₀ _ (inl a , refl) =
@@ -1049,6 +1053,61 @@ Every ordinal is the supremum of the successors of its initial segments.
     II : s ⊴ α
     II = sup-is-lower-bound-of-upper-bounds F α
           (upper-bound-of-successors-of-initial-segments α)
+
+\end{code}
+
+Added 14 July 2024.
+
+We prove that α +ₒ (sup β) ＝ α ∨ sup (λ i → α +ₒ β i), but we formulate the RHS
+as a single supremum by indexing over 𝟙 + I instead, sending inl ⋆ to α.
+
+\begin{code}
+
+ +ₒ-preserves-suprema
+  : (α : Ordinal 𝓤) {I : 𝓤 ̇ } (β : I → Ordinal 𝓤)
+  → α +ₒ sup β ＝ sup (cases (λ ⋆ → α) (λ i → α +ₒ β i))
+ +ₒ-preserves-suprema {𝓤} α {I} β = ⊴-antisym (α +ₒ sup β) (sup F) ⦅1⦆ ⦅2⦆
+  where
+   F : 𝟙 {𝓤} + I → Ordinal 𝓤
+   F = cases (λ _ → α) (λ i → α +ₒ β i)
+
+   ⦅1⦆ : α +ₒ sup β ⊴ sup F
+   ⦅1⦆ = to-⊴ (α +ₒ sup β) (sup F) h
+    where
+     h : (z : ⟨ α +ₒ sup β ⟩)
+       → (α +ₒ sup β) ↓ z ⊲ sup F
+     h (inl a) = (s , (α +ₒ sup β ↓ inl a ＝⟨ (+ₒ-↓-left a) ⁻¹ ⟩
+                       α ↓ a              ＝⟨ e ⟩
+                       sup F ↓ s          ∎))
+      where
+       s : ⟨ sup F ⟩
+       s = [ α , sup F ]⟨ sup-is-upper-bound F (inl ⋆) ⟩ a
+       e = (initial-segment-of-sup-at-component F (inl ⋆) a) ⁻¹
+     h (inr y) =
+      ∥∥-rec
+       (⊲-is-prop-valued (α +ₒ sup β ↓ inr y) (sup F))
+       g
+       (initial-segment-of-sup-is-initial-segment-of-some-component β y)
+      where
+       g : (Σ i ꞉ I , Σ x ꞉ ⟨ β i ⟩ , sup β ↓ y ＝ β i ↓ x)
+         → α +ₒ sup β ↓ inr y ⊲ sup F
+       g (i , x , e) = s , ((α +ₒ sup β) ↓ inr y ＝⟨ (+ₒ-↓-right y) ⁻¹ ⟩
+                            α +ₒ (sup β ↓ y)     ＝⟨ ap (α +ₒ_) e ⟩
+                            α +ₒ (β i ↓ x)       ＝⟨ +ₒ-↓-right x ⟩
+                            (α +ₒ β i) ↓ inr x   ＝⟨ e' ⟩
+                            sup F ↓ s            ∎)
+        where
+         s : ⟨ sup F ⟩
+         s = [ F (inr i) , sup F ]⟨ sup-is-upper-bound F (inr i) ⟩ (inr x)
+         e' = (initial-segment-of-sup-at-component F (inr i) (inr x)) ⁻¹
+
+   ⦅2⦆ : sup F ⊴ α +ₒ sup β
+   ⦅2⦆ = sup-is-lower-bound-of-upper-bounds F (α +ₒ sup β) h
+    where
+     h : (x : 𝟙 + I) → F x ⊴ α +ₒ sup β
+     h (inl ⋆) = +ₒ-left-⊴ α (sup β)
+     h (inr i) = +ₒ-right-monotone-⊴ α (β i) (sup β) (sup-is-upper-bound β i)
+
 
 \end{code}
 

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -128,6 +128,35 @@ approximate-subtraction {𝓤} α β β-above-α = γ , γ-greatest-satisfying-P
 approximate-division
  : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β
  → Σ γ ꞉ Ordinal 𝓤 ,
+    γ greatest-satisfying (λ - → (β ×ₒ - ⊴ α) × (- ⊴ α))
+approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
+ where
+  b₀ : ⟨ β ⟩
+  b₀ = pr₁ β-pos
+  b₀-eq : β ↓ b₀ ＝ 𝟘ₒ
+  b₀-eq = (pr₂ β-pos) ⁻¹
+  fact : (δ : Ordinal 𝓤) → β ×ₒ δ +ₒ (β ↓ b₀) ＝ β ×ₒ δ
+  fact δ = ap (β ×ₒ δ +ₒ_) b₀-eq ∙ 𝟘ₒ-right-neutral (β ×ₒ δ)
+
+  P : Ordinal 𝓤 → 𝓤 ̇
+  P δ = (β ×ₒ δ ⊴ α) × (δ ⊴ α)
+  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → ((i : I) → P (F i))
+                         → P (sup F)
+  P-closed-under-suprema {I} F ρ =
+     transport⁻¹ (_⊴ α) (×ₒ-preserves-suprema pt sr β F) (sup-is-lower-bound-of-upper-bounds (λ i → β ×ₒ F i) α (λ i → pr₁ (ρ i)))
+   , sup-is-lower-bound-of-upper-bounds F α (λ i → pr₂ (ρ i))
+  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
+  P-antitone α₁ α₂ k (l , m) = ⊴-trans (β ×ₒ α₁) (β ×ₒ α₂) α (×ₒ-right-monotone-⊴ β α₁ α₂ k) l , ⊴-trans α₁ α₂ α k m
+  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
+  P-bounded = α , (λ δ p → pr₂ p)
+  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+
+{-
+Original silly version
+approximate-division
+ : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β
+ → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → Σ b ꞉ ⟨ β ⟩ , (β ×ₒ - +ₒ (β ↓ b) ⊴ α) × (- ⊴ α))
 approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
  where
@@ -164,5 +193,38 @@ approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
   P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
   P-bounded = α , (λ δ p → pr₂ (pr₂ p))
   open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+-}
+
+{-
+open import UF.Subsingletons-FunExt
+experiment : (P : 𝓤 ̇ ) → is-prop P → Ordinal 𝓤
+experiment {𝓤} P P-is-prop = γ
+ where
+  Pₒ ¬Pₒ α β : Ordinal 𝓤
+  Pₒ = prop-ordinal P P-is-prop
+  ¬Pₒ = prop-ordinal (¬ P) (negations-are-props fe')
+  α = 𝟚ₒ{𝓤} ×ₒ Pₒ +ₒ ¬Pₒ
+  β = 𝟚ₒ{𝓤}
+  β-pos : 𝟘ₒ ⊲ β
+  β-pos = inl ⋆ , (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆)
+  γ =  pr₁ (approximate-division α β β-pos)
+  bit : 𝟙 + 𝟙
+  bit = pr₁ (pr₁ (pr₂ (approximate-division α β β-pos)))
+  I : ¬ P → bit ＝ inr ⋆
+  I ν = {!!}
+   where
+    e : α ＝ 𝟙ₒ
+    e = {!!}
+    fact : 𝟘ₒ greatest-satisfying (λ - → Σ b ꞉ ⟨ β ⟩ , (β ×ₒ - +ₒ (β ↓ b) ⊴ α) × (- ⊴ α))
+    fact = ((inr ⋆) , ({!-- OK using e!} , {!-- OK using e!})) , fact'
+     where
+      fact' : (α₁ : Ordinal 𝓤) →
+                Sigma (Underlying.⟨ underlying-type-of-ordinal ⟩ β)
+                (λ b → β ×ₒ α₁ +ₒ (β ↓ b) ⊴ α × α₁ ⊴ α) →
+                α₁ ⊴ 𝟘ₒ
+      fact' δ (b , k , l) = {!-- OK as δ must be empty by k and e!}
+    foo : γ ⊴ 𝟘ₒ
+    foo = pr₂ fact γ (pr₁ ((pr₂ (approximate-division α β β-pos))))
+-}
 
 \end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -101,6 +101,27 @@ module greatest-element-satisfying-predicate
 -- Note that we can't quite assume continuity, but we can assume something like
 -- t (sup F) ＝ c ∨ sup (t ∘ F) for some suitable c
 
+module Enderton
+        (t : Ordinal 𝓤 → Ordinal 𝓤)
+        (γ : Ordinal 𝓤)
+        (t-is-continuous : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → γ) (λ i → t (F i))))
+       where
+
+ private
+  t-is-monotone : (α β : Ordinal 𝓤) → α ⊴ β → t α ⊴ t β
+  t-is-monotone α β l = {!!}
+   where
+    F : 𝟙{𝓤} + 𝟙{𝓤} → Ordinal 𝓤
+    F (inl ⋆) = α
+    F (inr ⋆) = β
+    I : sup F ＝ β
+    I = {!!}
+    II : t (sup F) ＝ sup (cases (λ _ → γ) (λ i → t (F i)))
+    II = t-is-continuous F
+    III : t α ⊴ t β
+    III = {!!} -- t α ⊴ sup (cases (λ _ → γ) (λ i → t (F i))) ⊴ t (sup F) ＝ t (sup β)
+
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -47,7 +47,7 @@ open PropositionalTruncation pt
 open suprema pt sr
 
 _greatest-satisfying_ : Ordinal 𝓤 → (Ordinal 𝓤 → 𝓥 ̇ ) → 𝓤 ⁺ ⊔ 𝓥 ̇
-_greatest-satisfying_ {𝓤} γ P = (α : Ordinal 𝓤) → P α → α ⊴ γ
+_greatest-satisfying_ {𝓤} γ P = P γ × ((α : Ordinal 𝓤) → P α → α ⊴ γ)
 
 module greatest-element-satisfying-predicate
         (P : Ordinal 𝓤 → 𝓤 ̇ )
@@ -73,8 +73,8 @@ module greatest-element-satisfying-predicate
  γ-satisfies-P : P γ
  γ-satisfies-P = P-closed-under-suprema (λ (b , _) → S β b) (λ (b , p) → p)
 
- γ-greatest-satisfying-P : γ greatest-satisfying P
- γ-greatest-satisfying-P α p = to-⊴ α γ I
+ γ-greatest : (α : Ordinal 𝓤) → P α → α ⊴ γ
+ γ-greatest α p = to-⊴ α γ I
   where
    II : (a : ⟨ α ⟩) → Σ bₐ ꞉ ⟨ β ⟩ , α ↓ a ＝ β ↓ bₐ
    II = from-≼ (⊴-gives-≼ α β (β-is-bound α p))
@@ -93,6 +93,9 @@ module greatest-element-satisfying-predicate
        p'' = P-antitone _ _ (upper-bound-of-successors-of-initial-segments α a) p
      c : ⟨ γ ⟩
      c = [ S β bₐ , γ ]⟨ sup-is-upper-bound _ (bₐ , p') ⟩ (inr ⋆)
+
+ γ-greatest-satisfying-P : γ greatest-satisfying P
+ γ-greatest-satisfying-P = γ-satisfies-P , γ-greatest
 
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -1,9 +1,14 @@
-Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, Chuangjie Xu.
-14-15 July 2025.
+Tom de Jong, 14 and 15 July 2025.
+In collaboration with Nicolai Kraus, Fredrik Nordvall Forsberg and Chuangjie Xu.
+
+Following sketches from July 2024.
+
+We consider the construction of certain bounded operations. The comments in the
+file offer more explanation as the development continues.
 
 \begin{code}
 
-{-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
+{-# OPTIONS --safe --without-K --exact-split #-}
 
 open import UF.Univalence
 open import UF.PropTrunc
@@ -15,6 +20,9 @@ module Ordinals.BoundedOperations
        (sr : Set-Replacement pt)
        where
 
+open import MLTT.Plus-Properties
+open import MLTT.Spartan
+open import UF.ClassicalLogic
 open import UF.FunExt
 open import UF.UA-FunExt
 
@@ -25,16 +33,10 @@ private
  fe' : Fun-Ext
  fe' {𝓤} {𝓥} = fe 𝓤 𝓥
 
-open import MLTT.Spartan
-
-open import UF.Base
--- open import UF.ImageAndSurjection pt
-open import UF.Subsingletons
--- open import UF.UniverseEmbedding
-
 open import Ordinals.AdditionProperties ua
 open import Ordinals.Arithmetic fe
-open import Ordinals.Exponentiation.Specification ua pt sr
+open import Ordinals.Exponentiation.Supremum ua pt sr
+open import Ordinals.Exponentiation.Taboos ua pt sr
 open import Ordinals.Maps
 open import Ordinals.MultiplicationProperties ua
 open import Ordinals.OrdinalOfOrdinals ua
@@ -46,66 +48,128 @@ open import Ordinals.Underlying
 open PropositionalTruncation pt
 open suprema pt sr
 
+\end{code}
+
+We start by proving that every bounded and antitone predicate that is closed
+under suprema has a greatest element satisfying it.
+
+Usually, we would reserve the words "satisfying" and "predicate" for a
+proposition valued type family, but the formulation below is convenient in our
+applications. Similarly we simply formulate boundedness using Σ rather than ∃.
+
+\begin{code}
+
+_is-upper-bound-for_ : (γ : Ordinal 𝓤) → (Ordinal 𝓤 → 𝓥 ̇ ) → 𝓤 ⁺ ⊔ 𝓥 ̇
+_is-upper-bound-for_ {𝓤} γ P = (α : Ordinal 𝓤) → P α → α ⊴ γ
+
 _greatest-satisfying_ : Ordinal 𝓤 → (Ordinal 𝓤 → 𝓥 ̇ ) → 𝓤 ⁺ ⊔ 𝓥 ̇
-_greatest-satisfying_ {𝓤} γ P = P γ × ((α : Ordinal 𝓤) → P α → α ⊴ γ)
+_greatest-satisfying_ {𝓤} γ P = P γ × γ is-upper-bound-for P
 
-module greatest-element-satisfying-predicate
-        (P : Ordinal 𝓤 → 𝓤 ̇ )
-        (P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                                → ((i : I) → P (F i))
-                                → P (sup F))
-        (P-antitone : (α β : Ordinal 𝓤) → α ⊴ β → P β → P α)
-        (P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β))
+greatest-satisfies : (γ : Ordinal 𝓤) {P : Ordinal 𝓤 → 𝓥 ̇ }
+                   → γ greatest-satisfying P
+                   → P γ
+greatest-satisfies γ {P} = pr₁
+
+greatest-is-upper-bound : (γ : Ordinal 𝓤) {P : Ordinal 𝓤 → 𝓥 ̇ }
+                        → γ greatest-satisfying P
+                        → γ is-upper-bound-for P
+greatest-is-upper-bound γ {P} = pr₂
+
+module _ (P : Ordinal 𝓤  → 𝓥 ̇ ) where
+
+ bounded antitone closed-under-suprema : 𝓤 ⁺ ⊔ 𝓥 ̇
+
+ bounded = Σ δ ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ δ)
+ antitone = (α β : Ordinal 𝓤) → α ⊴ β → P β → P α
+ closed-under-suprema =
+  (I : 𝓤 ̇ ) (F : I → Ordinal 𝓤) → ((i : I) → P (F i)) → P (sup F)
+
+greatest-ordinal-satisfying-predicate : (P : Ordinal 𝓤 → 𝓤 ̇ )
+                                      → bounded P
+                                      → antitone P
+                                      → closed-under-suprema P
+                                      → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying P
+greatest-ordinal-satisfying-predicate
+ {𝓤} P (δ , δ-bound) P-antitone P-closed-under-sup =
+  γ , γ-satisfies-P , γ-is-upper-bound
+   where
+    S : (α : Ordinal 𝓤) → ⟨ α ⟩ → Ordinal 𝓤
+    S α a = (α ↓ a) +ₒ 𝟙ₒ
+
+    γ : Ordinal 𝓤
+    γ = sup {𝓤} {Σ x ꞉ ⟨ δ ⟩ , P (S δ x)} (λ (x , _) → S δ x)
+
+    γ-satisfies-P : P γ
+    γ-satisfies-P = P-closed-under-sup _ (λ (x , _) → S δ x) (λ (_ , p) → p)
+
+    γ-is-upper-bound : γ is-upper-bound-for P
+    γ-is-upper-bound α p = to-⊴ α γ II
+     where
+      I : (a : ⟨ α ⟩) → Σ bₐ ꞉ ⟨ δ ⟩ , α ↓ a ＝ δ ↓ bₐ
+      I = from-≼ (⊴-gives-≼ α δ (δ-bound α p))
+      II : (a : ⟨ α ⟩) → α ↓ a ⊲ γ
+      II a = c , (α ↓ a         ＝⟨ II₁ ⟩
+                 δ ↓ bₐ         ＝⟨ II₂ ⟩
+                 S δ bₐ ↓ inr ⋆ ＝⟨ II₃ ⟩
+                 γ ↓ c          ∎)
        where
+        bₐ = pr₁ (I a)
+        II₁ = pr₂ (I a)
+        II₂ = (successor-lemma-right (δ ↓ bₐ)) ⁻¹
 
- private
-  β : Ordinal 𝓤
-  β = pr₁ P-bounded
-  β-is-bound : (α : Ordinal 𝓤) → P α → α ⊴ β
-  β-is-bound = pr₂ P-bounded
+        p' : P (S δ bₐ)
+        p' = transport P (ap (_+ₒ 𝟙ₒ) II₁) p''
+         where
+          p'' : P (S α a)
+          p'' = P-antitone (S α a) α
+                 (upper-bound-of-successors-of-initial-segments α a) p
+        c : ⟨ γ ⟩
+        c = [ S δ bₐ , γ ]⟨ sup-is-upper-bound _ (bₐ , p') ⟩ (inr ⋆)
 
-  S : (α : Ordinal 𝓤) → ⟨ α ⟩ → Ordinal 𝓤
-  S α a = (α ↓ a) +ₒ 𝟙ₒ
+        II₃ = (initial-segment-of-sup-at-component _ (bₐ , p') (inr ⋆)) ⁻¹
 
- γ : Ordinal 𝓤
- γ = sup {𝓤} {Σ b ꞉ ⟨ β ⟩ , P (S β b)} (λ (b , _) → S β b)
+\end{code}
 
- γ-satisfies-P : P γ
- γ-satisfies-P = P-closed-under-suprema (λ (b , _) → S β b) (λ (b , p) → p)
+Now we consider an endofunction t on ordinals and assume that it preserves
+suprema up to a binary join in the following sense:
+   t (sup F) ＝ δ₀ ∨ sup (t ∘ F)             (†)
+for some fixed ordinal δ₀.
 
- γ-greatest : (α : Ordinal 𝓤) → P α → α ⊴ γ
- γ-greatest α p = to-⊴ α γ I
-  where
-   II : (a : ⟨ α ⟩) → Σ bₐ ꞉ ⟨ β ⟩ , α ↓ a ＝ β ↓ bₐ
-   II = from-≼ (⊴-gives-≼ α β (β-is-bound α p))
-   I : (a : ⟨ α ⟩) → α ↓ a ⊲ γ
-   I a = c , (α ↓ a ＝⟨ eq ⟩
-              β ↓ bₐ ＝⟨ (successor-lemma-right (β ↓ bₐ)) ⁻¹ ⟩
-              S β bₐ ↓ inr ⋆ ＝⟨ (initial-segment-of-sup-at-component _ (bₐ , p') (inr ⋆)) ⁻¹ ⟩
-              γ ↓ c ∎)
-    where
-     bₐ = pr₁ (II a)
-     eq = pr₂ (II a)
-     p' : P (S β bₐ)
-     p' = transport P (ap (_+ₒ 𝟙ₒ) eq) p''
-      where
-       p'' : P (S α a)
-       p'' = P-antitone _ _ (upper-bound-of-successors-of-initial-segments α a) p
-     c : ⟨ γ ⟩
-     c = [ S β bₐ , γ ]⟨ sup-is-upper-bound _ (bₐ , p') ⟩ (inr ⋆)
+Examples of such endofunctions are
+* addition by α with δ₀ ＝ α,
+* multiplication by α with δ₀ ＝ 𝟘ₒ,
+* and exponentiation by α with δ₀ ＝ 𝟙ₒ (for α ⊵ 𝟙ₒ).
 
- γ-greatest-satisfying-P : γ greatest-satisfying P
- γ-greatest-satisfying-P = γ-satisfies-P , γ-greatest
+Then for any bound δ with δ₀ ⊴ δ, we have a greatest ordinal γ such that
+γ ⊴ δ and t γ ⊴ δ.
 
--- Note that we can't quite assume continuity, but we can assume something like
--- t (sup F) ＝ c ∨ sup (t ∘ F) for some suitable c
+This is close to [Theorem Schema 8D, End77] but with a few differences:
+(1) loc. cit. restricts to "normal" operations, i.e. endomaps t such that
+    (a) t preserves ⊲ and
+    (b) t λ = sup_{β ⊲ γ} t β for all limit ordinals λ;
+(2) loc. cit proves: for any bound δ with δ₀ ⊴ δ, we have a greatest ordinal γ
+    such that t γ ⊴ δ (so the condition γ ⊴ δ is absent).
 
-module Enderton
+(Note that Eq. (†) forces t 𝟘ₒ to be δ₀, which is why [End77] mentions t 𝟘ₒ.)
+
+We will see that in several examples of t and δ, excluded middle is equivalent
+to the existence of γ such that γ ⊴ δ and γ is the greatest such that t γ ⊴ δ.
+
+[End77] Herbert B. Enderton
+        Elements of Set Theory
+        Academic Press
+        1977
+        doi:10.1016/c2009-0-22079-4
+
+\begin{code}
+
+module Enderton-like
         (t : Ordinal 𝓤 → Ordinal 𝓤)
         (δ₀ δ : Ordinal 𝓤)
         (δ₀-below-δ : δ₀ ⊴ δ)
-        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤) -- TODO: rename
-                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
+        (t-preserves-suprema-up-to-join
+          : (I : 𝓤 ̇ ) (F : I → Ordinal 𝓤)
+          → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
        where
 
  private
@@ -124,27 +188,30 @@ module Enderton
       ub (inl ⋆) = l
       ub (inr ⋆) = ⊴-refl β
     II : t (sup F) ＝ sup (cases (λ _ → δ₀) (t ∘ F))
-    II = t-preserves-suprema F
+    II = t-preserves-suprema-up-to-join _ F
     III : t α ⊴ t β
     III = transport⁻¹
            (t α ⊴_)
            (ap t I ⁻¹ ∙ II)
            (sup-is-upper-bound (cases (λ _ → δ₀) (t ∘ F)) (inr (inl ⋆)))
 
- enderton : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (t - ⊴ δ) × (- ⊴ δ))
- enderton = γ , γ-greatest-satisfying-P
+ enderton-like
+  : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (t - ⊴ δ) × (- ⊴ δ))
+ enderton-like = greatest-ordinal-satisfying-predicate
+                  P
+                  P-bounded
+                  P-antitone
+                  P-closed-under-suprema
   where
    P : Ordinal 𝓤 → 𝓤 ̇
    P α = (t α ⊴ δ) × (α ⊴ δ)
-   P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                          → ((i : I) → P (F i))
-                          → P (sup F)
-   P-closed-under-suprema {I} F ρ =
-    transport⁻¹ (_⊴ δ) (t-preserves-suprema F) σ ,
+   P-closed-under-suprema : closed-under-suprema P
+   P-closed-under-suprema I F ρ =
+    transport⁻¹ (_⊴ δ) (t-preserves-suprema-up-to-join _ F) l ,
     sup-is-lower-bound-of-upper-bounds F δ (λ i → pr₂ (ρ i))
      where
-      σ : sup (cases (λ ⋆ → δ₀) (λ i → t (F i))) ⊴ δ
-      σ = sup-is-lower-bound-of-upper-bounds _ δ h
+      l : sup (cases (λ ⋆ → δ₀) (λ i → t (F i))) ⊴ δ
+      l = sup-is-lower-bound-of-upper-bounds _ δ h
        where
         h : (x : 𝟙 + I) → cases (λ ⋆ → δ₀) (λ i → t (F i)) x ⊴ δ
         h (inl ⋆) = δ₀-below-δ
@@ -155,20 +222,26 @@ module Enderton
      ⊴-trans α₁ α₂ δ k m
    P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β)
    P-bounded = δ , (λ α p → pr₂ p)
-   open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
-module Enderton'
+\end{code}
+
+We also provide the following more convenient interface in case we have an
+endofunction t that simply preserves suprema.
+
+\begin{code}
+
+module Enderton-like'
         (t : Ordinal 𝓤 → Ordinal 𝓤)
         (δ : Ordinal 𝓤)
-        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+        (t-preserves-suprema : (I : 𝓤 ̇ ) (F : I → Ordinal 𝓤)
                              → t (sup F) ＝ sup (t ∘ F))
        where
 
- t-preserves-suprema-up-to-join
-  : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
+ preservation-of-suprema-up-to-join
+  : (I : 𝓤 ̇) (F : I → Ordinal 𝓤)
   → t (sup F) ＝ sup (cases (λ _  → 𝟘ₒ) (t ∘ F))
- t-preserves-suprema-up-to-join {I} F =
-  t-preserves-suprema F
+ preservation-of-suprema-up-to-join I F =
+  t-preserves-suprema I F
   ∙ (⊴-antisym (sup (t ∘ F)) (sup G) u v)
   where
    G : 𝟙{𝓤} + I → Ordinal 𝓤
@@ -184,256 +257,227 @@ module Enderton'
      w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (t ∘ F))
      w (inr i) = sup-is-upper-bound (t ∘ F) i
 
- open Enderton t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) t-preserves-suprema-up-to-join public
+ open Enderton-like
+       t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) preservation-of-suprema-up-to-join
+      public
 
-module Enderton-classical-variation
+\end{code}
+
+If we additionally assume that t is inflationary, then can construct the
+greatest γ such that t γ ⊴ δ (and the separate property γ ⊴ δ follows).
+
+\begin{code}
+
+module Enderton-like-inflationary
         (t : Ordinal 𝓤 → Ordinal 𝓤)
         (δ₀ δ : Ordinal 𝓤)
         (δ₀-below-δ : δ₀ ⊴ δ)
-        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤) -- TODO: rename
-                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
-        (t-increasing : (α : Ordinal 𝓤) → α ⊴ t α)
+        (t-preserves-suprema-up-to-join
+          : (I : 𝓤 ̇ ) (F : I → Ordinal 𝓤)
+          → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
+        (t-inflationary : (α : Ordinal 𝓤) → α ⊴ t α)
        where
 
- enderton-classical : Σ γ ꞉ Ordinal 𝓤 , γ ⊴ δ × γ greatest-satisfying (λ - → (t - ⊴ δ))
- enderton-classical = γ , γ-fact₂ , γ-fact₁ , γ-fact₄
+ enderton-like-inflationary
+  : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ δ) × (γ greatest-satisfying (λ - → t - ⊴ δ))
+ enderton-like-inflationary = γ , IV , III , VI
   where
-   open Enderton t δ₀ δ δ₀-below-δ t-preserves-suprema
-   I : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → t - ⊴ δ × - ⊴ δ)
-   I = enderton
+   open Enderton-like t δ₀ δ δ₀-below-δ t-preserves-suprema-up-to-join
+   I : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (t - ⊴ δ) × (- ⊴ δ))
+   I = enderton-like
    γ : Ordinal 𝓤
    γ = pr₁ I
-   γ-fact₁ : t γ ⊴ δ
-   γ-fact₁ = pr₁ (pr₁ (pr₂ I))
-   γ-fact₂ : γ ⊴ δ
-   γ-fact₂ = pr₂ (pr₁ (pr₂ I))
-   γ-fact₃ : (α : Ordinal 𝓤) → (t α ⊴ δ) × (α ⊴ δ) → α ⊴ γ
-   γ-fact₃ = pr₂ (pr₂ I)
-   γ-fact₄ : (α : Ordinal 𝓤) → t α ⊴ δ → α ⊴ γ
-   γ-fact₄ α l = γ-fact₃ α (l , (⊴-trans α (t α) δ (t-increasing α) l))
+   II : γ greatest-satisfying (λ - → (t - ⊴ δ) × (- ⊴ δ))
+   II = pr₂ I
+   III : t γ ⊴ δ
+   III = pr₁ (greatest-satisfies γ II)
+   IV : γ ⊴ δ
+   IV = pr₂ (greatest-satisfies γ II)
+   V : γ is-upper-bound-for (λ - → (t - ⊴ δ) × (- ⊴ δ))
+   V = pr₂ II
+   VI : γ is-upper-bound-for (λ - → t - ⊴ δ)
+   VI α l = V α (l , (⊴-trans α (t α) δ (t-inflationary α) l))
 
-module Enderton-classical-variation'
+\end{code}
+
+The following provides a convenient interface for inflationary endofunctions
+that simply preserve suprema.
+
+\begin{code}
+
+module Enderton-like-inflationary'
         (t : Ordinal 𝓤 → Ordinal 𝓤)
         (δ : Ordinal 𝓤)
-        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → t (sup F) ＝ sup (t ∘ F))
-        (t-increasing : (α : Ordinal 𝓤) → α ⊴ t α)
+        (t-preserves-suprema : (I : 𝓤 ̇ ) (F : I → Ordinal 𝓤)
+                             → t (sup F) ＝ sup (t ∘ F))
+        (t-inflationary : (α : Ordinal 𝓤) → α ⊴ t α)
        where
 
- open Enderton-classical-variation t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) (Enderton'.t-preserves-suprema-up-to-join t δ t-preserves-suprema) t-increasing public
+ open Enderton-like-inflationary
+       t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ)
+       (Enderton-like'.preservation-of-suprema-up-to-join
+         t δ t-preserves-suprema)
+       t-inflationary
+      public
+
+\end{code}
+
+We now consider some examples and applications.
+
+While the existence of a subtraction function on ordinals implies excluded
+middle (see Ordinals.AdditionProperties), we can construct an approximate of what
+would be the ordinal β - α (for α ⊴ β) in the following sense.
+
+\begin{code}
 
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))
-approximate-subtraction {𝓤} α β β-above-α = enderton
+approximate-subtraction {𝓤} α β l = enderton-like
  where
-  open Enderton (α +ₒ_) α β β-above-α (+ₒ-preserves-suprema pt sr α)
-
-approximate-division
- : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α -- In our weakening this assumption becomes redundant
- → Σ γ ꞉ Ordinal 𝓤 ,
-    γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β) × (- ⊴ β))
-approximate-division {𝓤} α β α-pos = enderton
- where
-  open Enderton' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α)
-
-open import Ordinals.Exponentiation.Supremum ua pt sr
-aproximate-logarithm
- : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β -- 𝟙ₒ ⊲ α should be included too, even if it's not technically necessary
- → Σ γ ꞉ Ordinal 𝓤 ,
-    γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
-aproximate-logarithm {𝓤} α β β-pos = enderton
- where
- open Enderton (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α _)
+  open Enderton-like (α +ₒ_) α β l (+ₒ-preserves-suprema-up-to-join pt sr α)
 
 \end{code}
 
-TODO. The seemingly mild variation
-
-approximate-subtraction'
- : (α β : Ordinal 𝓤) → α ⊴ β
- → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β)))
-
-yields LEM, and similarly for division and logarithm.
+In a similar sense, we can approximate division of ordinals.
 
 \begin{code}
 
-open import MLTT.Plus-Properties
-open import UF.ClassicalLogic
-open import Ordinals.Exponentiation.Taboos ua pt sr
-
--- TODO: Upstream
-+ₒ-as-large-as-right-summand-implies-EM : ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
-                                     → EM 𝓤
-+ₒ-as-large-as-right-summand-implies-EM hyp P P-is-prop = IV
+approximate-division
+ : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
+ → Σ γ ꞉ Ordinal 𝓤 ,
+    γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β) × (- ⊴ β))
+approximate-division {𝓤} α β _ = enderton-like
  where
-  α = prop-ordinal P P-is-prop
-  β = 𝟙ₒ
-  𝕗 : β ⊴ α +ₒ β
-  𝕗 = hyp α β
-  f = [ β , α +ₒ β ]⟨ 𝕗 ⟩
-  I : (p : P) → f ⋆ ＝ inl p → P
-  I p _ = p
-  II : (p : P) → f ⋆ ＝ inl p
-  II p = simulations-preserve-least β (α +ₒ β) ⋆ (inl p) f [ β , α +ₒ β ]⟨ 𝕗 ⟩-is-simulation 𝟙ₒ-least l
-   where
-    l : is-least (α +ₒ β) (inl p)
-    l = minimal-is-least (α +ₒ β) (inl p) m
-     where
-      m : is-minimal (α +ₒ β) (inl p)
-      m (inl p') = 𝟘-elim
-      m (inr ⋆ ) = 𝟘-elim
-  III : f ⋆ ＝ inr ⋆ → ¬ P
-  III e p = +disjoint ((II p) ⁻¹ ∙ e)
-  IV : P + ¬ P
-  IV = equality-cases (f ⋆) (λ p → inl ∘ I p) (λ _ → inr ∘ III)
+  open Enderton-like' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α)
 
-EM-implies-+ₒ-as-large-as-right-summand : EM 𝓤
-                                        → ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
-EM-implies-+ₒ-as-large-as-right-summand em α β =
- ≼-gives-⊴ β (α +ₒ β)
-           (EM-implies-order-preserving-gives-≼ em β (α +ₒ β) (f , I))
-  where
-   f : ⟨ β ⟩ → ⟨ α +ₒ β ⟩
-   f = inr
-   I : is-order-preserving β (α +ₒ β) f
-   I y y' l = l
----
+\end{code}
+
+Note that the assumption 𝟘ₒ ⊲ α isn't actually used (for α ＝ 𝟘ₒ, we simply get
+γ ＝ β due to the - ⊴ β requirement).
+
+Again, in a similar sense, we can approximate logarithms of
+ordinals. And similarly, the assumption 𝟙ₒ ⊲ α isn't used.
+
+\begin{code}
+
+aproximate-logarithm
+ : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
+ → Σ γ ꞉ Ordinal 𝓤 ,
+    γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
+aproximate-logarithm {𝓤} α β β-pos _ = enderton-like
+ where
+ open Enderton-like (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α)
+
+\end{code}
+
+Now, as alluded to above, the seemingly mild variation
+
+approximate-subtraction-variation
+ : (α β : Ordinal 𝓤) → α ⊴ β
+ → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β)))
+
+is equivalent to excluded middle, and similarly for division and logarithm.
+
+\begin{code}
 
 approximate-subtraction-variation-implies-EM
  : ((α β : Ordinal 𝓤) → α ⊴ β
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β))))
  → EM 𝓤
-approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-as-right-summand-implies-EM I
- where
-  I : (α β : Ordinal 𝓤) → β ⊴ α +ₒ β
-  I α β = IV
-   where
-    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α +ₒ β) × (γ greatest-satisfying (λ - → α +ₒ - ⊴ α +ₒ β))
-    II = hyp α (α +ₒ β) (+ₒ-left-⊴ α β)
-    γ = pr₁ II
-    III : β ⊴ γ
-    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α +ₒ β))
-    IV : β ⊴ α +ₒ β
-    IV = ⊴-trans β γ (α +ₒ β) III (pr₁ (pr₂ II))
+approximate-subtraction-variation-implies-EM {𝓤} hyp =
+ +ₒ-as-large-as-right-summand-implies-EM I
+  where
+   I : (α β : Ordinal 𝓤) → β ⊴ α +ₒ β
+   I α β = IV
+    where
+     II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α +ₒ β)
+                          × (γ greatest-satisfying (λ - → α +ₒ - ⊴ α +ₒ β))
+     II = hyp α (α +ₒ β) (+ₒ-left-⊴ α β)
+     γ = pr₁ II
+     III : β ⊴ γ
+     III = greatest-is-upper-bound γ (pr₂ (pr₂ II)) β (⊴-refl (α +ₒ β))
+     IV : β ⊴ α +ₒ β
+     IV = ⊴-trans β γ (α +ₒ β) III (pr₁ (pr₂ II))
 
 EM-implies-approximate-subtraction-variation
  : EM 𝓤
  → (α β : Ordinal 𝓤) → α ⊴ β
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β)))
-EM-implies-approximate-subtraction-variation {𝓤} em α β l = enderton-classical
- where
-  open Enderton-classical-variation (α +ₒ_) α β l (+ₒ-preserves-suprema pt sr α) (EM-implies-+ₒ-as-large-as-right-summand em α)
-
--- TODO: Upstream
-+ₒ-minimal : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
-           → is-minimal α a₀ → is-minimal (α +ₒ β) (inl a₀)
-+ₒ-minimal α β a₀ a₀-minimal (inl a) = a₀-minimal a
-+ₒ-minimal α β a₀ a₀-minimal (inr b) = 𝟘-elim
-
-+ₒ-least : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
-         → is-least α a₀ → is-least (α +ₒ β) (inl a₀)
-+ₒ-least α β  a₀ a₀-least =
- minimal-is-least (α +ₒ β) (inl a₀) (+ₒ-minimal α β a₀ (least-is-minimal α a₀ a₀-least))
-
--- TODO: Upstream
-×ₒ-as-large-as-right-factor-implies-EM : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β)
-                                     → EM 𝓤
-×ₒ-as-large-as-right-factor-implies-EM  hyp P P-is-prop = IV (f (inr ⋆)) refl
- where
-  Pₒ = prop-ordinal P P-is-prop
-  α = 𝟙ₒ +ₒ Pₒ
-  β = 𝟚ₒ
-  𝕗 : β ⊴ α ×ₒ β
-  𝕗 = hyp α β (inl ⋆ , (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆))
-  f = [ β , α ×ₒ β ]⟨ 𝕗 ⟩
-  I : (p : P) → f (inr ⋆) ＝ (inr p , inl ⋆)
-  I p = ↓-lc (α ×ₒ β) (f (inr ⋆)) (inr p , inl ⋆) e
-   where
-    e = (α ×ₒ β) ↓ f (inr ⋆) ＝⟨ (simulations-preserve-↓ β (α ×ₒ β) 𝕗 (inr ⋆)) ⁻¹ ⟩
-        β ↓ inr ⋆ ＝⟨ +ₒ-↓-right ⋆ ⁻¹ ∙ ap (𝟙ₒ +ₒ_) 𝟙ₒ-↓ ∙ 𝟘ₒ-right-neutral 𝟙ₒ ⟩
-        𝟙ₒ ＝⟨ (𝟘ₒ-right-neutral 𝟙ₒ) ⁻¹ ∙ ap (𝟙ₒ +ₒ_) ((prop-ordinal-↓ P-is-prop p) ⁻¹) ∙ +ₒ-↓-right p ⟩
-        α ↓ inr p ＝⟨ (ap (_+ₒ (α ↓ inr p)) (×ₒ-𝟘ₒ-right α) ∙ 𝟘ₒ-left-neutral (α ↓ inr p)) ⁻¹ ⟩
-        α ×ₒ 𝟘ₒ +ₒ (α ↓ inr p) ＝⟨ ap (λ - → α ×ₒ - +ₒ (α ↓ inr p)) (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆) ⟩
-        α ×ₒ (β ↓ inl ⋆) +ₒ (α ↓ inr p) ＝⟨ ×ₒ-↓ α β ⁻¹ ⟩
-        (α ×ₒ β) ↓ (inr p , inl ⋆)      ∎
-  II : (x : ⟨ α ⟩) → f (inr ⋆) ＝ (x , inr ⋆) → ¬ P
-  II x e p = +disjoint (ap pr₂ ((I p) ⁻¹ ∙ e))
-  III : f (inr ⋆) ≠ (inl ⋆ , inl ⋆)
-  III h = +disjoint (simulations-are-lc β (α ×ₒ β) f [ β , α ×ₒ β ]⟨ 𝕗 ⟩-is-simulation (e ∙ h ⁻¹))
-   where
-    e : f (inl ⋆) ＝ (inl ⋆ , inl ⋆)
-    e = simulations-preserve-least β (α ×ₒ β) (inl ⋆) (inl ⋆ , inl ⋆) f [ β , α ×ₒ β ]⟨ 𝕗 ⟩-is-simulation β-least (×ₒ-least α β (inl ⋆) (inl ⋆) (+ₒ-least 𝟙ₒ Pₒ ⋆ 𝟙ₒ-least) β-least)
-     where
-      β-least : is-least β (inl ⋆)
-      β-least = +ₒ-least 𝟙ₒ 𝟙ₒ ⋆ 𝟙ₒ-least
-  IV : (x : ⟨ α ×ₒ β ⟩) → f (inr ⋆) ＝ x → P + ¬ P
-  IV (inl ⋆ , inl ⋆) e = 𝟘-elim (III e)
-  IV (inr p , inl ⋆) e = inl p
-  IV (inl ⋆ , inr ⋆) e = inr (II (inl ⋆) e)
-  IV (inr p , inr ⋆) e = inl p
-
-EM-implies-×ₒ-as-large-as-right-factor
- : EM 𝓤
- → (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
-EM-implies-×ₒ-as-large-as-right-factor em α β (a₀ , _) =
- ≼-gives-⊴ β (α ×ₒ β)
-           (EM-implies-order-preserving-gives-≼ em β (α ×ₒ β) (f , I))
+EM-implies-approximate-subtraction-variation {𝓤} em α β l =
+ enderton-like-inflationary
   where
-   f : ⟨ β ⟩ → ⟨ α ×ₒ β ⟩
-   f b = (a₀ , b)
-   I : is-order-preserving β (α ×ₒ β) f
-   I b b' l = inl l
----
+   open Enderton-like-inflationary
+         (α +ₒ_) α β l
+         (+ₒ-preserves-suprema-up-to-join pt sr α)
+         (EM-implies-+ₒ-as-large-as-right-summand em α)
+
+\end{code}
+
+Indeed, analogous results hold for approximate division and logarithm.
+
+\begin{code}
 
 approximate-division-variation-implies-EM
  : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β))))
  → EM 𝓤
-approximate-division-variation-implies-EM {𝓤} hyp = ×ₒ-as-large-as-right-factor-implies-EM I
- where
-  I : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
-  I α β α-pos = IV
-   where
-    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ×ₒ β) × (γ greatest-satisfying (λ - → α ×ₒ - ⊴ α ×ₒ β))
-    II = hyp α (α ×ₒ β) α-pos
-    γ = pr₁ II
-    III : β ⊴ γ
-    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ×ₒ β))
-    IV : β ⊴ α ×ₒ β
-    IV = ⊴-trans β γ (α ×ₒ β) III (pr₁ (pr₂ II))
+approximate-division-variation-implies-EM {𝓤} hyp =
+ ×ₒ-as-large-as-right-factor-implies-EM I
+  where
+   I : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
+   I α β α-pos = IV
+    where
+     II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ×ₒ β)
+                          × (γ greatest-satisfying (λ - → α ×ₒ - ⊴ α ×ₒ β))
+     II = hyp α (α ×ₒ β) α-pos
+     γ = pr₁ II
+     III : β ⊴ γ
+     III = greatest-is-upper-bound γ (pr₂ (pr₂ II)) β (⊴-refl (α ×ₒ β))
+     IV : β ⊴ α ×ₒ β
+     IV = ⊴-trans β γ (α ×ₒ β) III (pr₁ (pr₂ II))
 
 EM-implies-approximate-division-variation
  : EM 𝓤
  → (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β)))
-EM-implies-approximate-division-variation em α β α-pos = enderton-classical
- where
-  open Enderton-classical-variation' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α) (λ δ → EM-implies-×ₒ-as-large-as-right-factor em α δ α-pos)
+EM-implies-approximate-division-variation em α β α-pos =
+ enderton-like-inflationary
+  where
+   open Enderton-like-inflationary'
+         (α ×ₒ_) β
+         (×ₒ-preserves-suprema pt sr α)
+         (λ δ → EM-implies-×ₒ-as-large-as-right-factor em α δ α-pos)
 
 approximate-logarithm-variation-implies-EM
  : ((α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β))))
  → EM 𝓤
-approximate-logarithm-variation-implies-EM {𝓤} hyp = ^ₒ-as-large-as-exponent-implies-EM I
- where
-  I : (α β : Ordinal 𝓤) → 𝟙ₒ ⊲ α → β ⊴ α ^ₒ β
-  I α β α-strictly-pos = IV
-   where
-    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ^ₒ β) × (γ greatest-satisfying (λ - → α ^ₒ - ⊴ α ^ₒ β))
-    II = hyp α (α ^ₒ β) (^ₒ-has-least-element α β) α-strictly-pos
-    γ = pr₁ II
-    III : β ⊴ γ
-    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ^ₒ β))
-    IV : β ⊴ α ^ₒ β
-    IV = ⊴-trans β γ (α ^ₒ β) III (pr₁ (pr₂ II))
+approximate-logarithm-variation-implies-EM {𝓤} hyp =
+ ^ₒ-as-large-as-exponent-implies-EM I
+  where
+   I : (α β : Ordinal 𝓤) → 𝟙ₒ ⊲ α → β ⊴ α ^ₒ β
+   I α β α-strictly-pos = IV
+    where
+     II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ^ₒ β)
+                          × (γ greatest-satisfying (λ - → α ^ₒ - ⊴ α ^ₒ β))
+     II = hyp α (α ^ₒ β) (^ₒ-has-least-element α β) α-strictly-pos
+     γ = pr₁ II
+     III : β ⊴ γ
+     III = greatest-is-upper-bound γ (pr₂ (pr₂ II)) β (⊴-refl (α ^ₒ β))
+     IV : β ⊴ α ^ₒ β
+     IV = ⊴-trans β γ (α ^ₒ β) III (pr₁ (pr₂ II))
 
 EM-implies-approximate-logarithm-variation
  : EM 𝓤
  → (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β)))
-EM-implies-approximate-logarithm-variation em α β β-pos α-strictly-pos = enderton-classical
+EM-implies-approximate-logarithm-variation em α β β-pos α-strictly-pos =
+ enderton-like-inflationary
   where
-   open Enderton-classical-variation (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α _) (λ δ → EM-implies-^ₒ-as-large-as-exponent em α δ α-strictly-pos)
+   open Enderton-like-inflationary
+         (α ^ₒ_) 𝟙ₒ β β-pos
+         (^ₒ-satisfies-strong-sup-specification α)
+         (λ δ → EM-implies-^ₒ-as-large-as-exponent em α δ α-strictly-pos)
 
 \end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -1,0 +1,121 @@
+Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, Chuangjie Xu.
+14 July 2025.
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K --exact-split #-}
+
+open import UF.Univalence
+open import UF.PropTrunc
+open import UF.Size
+
+module Ordinals.BoundedOperations
+       (ua : Univalence)
+       (pt : propositional-truncations-exist)
+       (sr : Set-Replacement pt)
+       where
+
+open import UF.FunExt
+open import UF.UA-FunExt
+
+private
+ fe : FunExt
+ fe = Univalence-gives-FunExt ua
+
+ fe' : Fun-Ext
+ fe' {𝓤} {𝓥} = fe 𝓤 𝓥
+
+open import MLTT.Spartan
+
+open import UF.Base
+-- open import UF.ImageAndSurjection pt
+open import UF.Subsingletons
+-- open import UF.UniverseEmbedding
+
+open import Ordinals.AdditionProperties ua
+open import Ordinals.Arithmetic fe
+open import Ordinals.Exponentiation.Specification ua pt sr
+open import Ordinals.Maps
+open import Ordinals.MultiplicationProperties ua
+open import Ordinals.OrdinalOfOrdinals ua
+open import Ordinals.OrdinalOfOrdinalsSuprema ua
+open import Ordinals.Propositions ua
+open import Ordinals.Type
+open import Ordinals.Underlying
+
+open PropositionalTruncation pt
+open suprema pt sr
+
+_greatest-satisfying_ : Ordinal 𝓤 → (Ordinal 𝓤 → 𝓥 ̇ ) → 𝓤 ⁺ ⊔ 𝓥 ̇
+_greatest-satisfying_ {𝓤} γ P = (α : Ordinal 𝓤) → P α → α ⊴ γ
+
+module greatest-element-satisfying-predicate
+        (P : Ordinal 𝓤 → 𝓤 ̇ )
+        (P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                                → ((i : I) → P (F i))
+                                → P (sup F))
+        (P-antitone : (α β : Ordinal 𝓤) → α ⊴ β → P β → P α)
+        (P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β))
+       where
+
+ private
+  β : Ordinal 𝓤
+  β = pr₁ P-bounded
+  β-is-bound : (α : Ordinal 𝓤) → P α → α ⊴ β
+  β-is-bound = pr₂ P-bounded
+
+  S : (α : Ordinal 𝓤) → ⟨ α ⟩ → Ordinal 𝓤
+  S α a = (α ↓ a) +ₒ 𝟙ₒ
+
+ γ : Ordinal 𝓤
+ γ = sup {𝓤} {Σ b ꞉ ⟨ β ⟩ , P (S β b)} (λ (b , _) → S β b)
+
+ γ-satisfies-P : P γ
+ γ-satisfies-P = P-closed-under-suprema (λ (b , _) → S β b) (λ (b , p) → p)
+
+ γ-greatest-satisfying-P : γ greatest-satisfying P
+ γ-greatest-satisfying-P α p = to-⊴ α γ I
+  where
+   II : (a : ⟨ α ⟩) → Σ bₐ ꞉ ⟨ β ⟩ , α ↓ a ＝ β ↓ bₐ
+   II = from-≼ (⊴-gives-≼ α β (β-is-bound α p))
+   I : (a : ⟨ α ⟩) → α ↓ a ⊲ γ
+   I a = c , (α ↓ a ＝⟨ eq ⟩
+              β ↓ bₐ ＝⟨ (successor-lemma-right (β ↓ bₐ)) ⁻¹ ⟩
+              S β bₐ ↓ inr ⋆ ＝⟨ (initial-segment-of-sup-at-component _ (bₐ , p') (inr ⋆)) ⁻¹ ⟩
+              γ ↓ c ∎)
+    where
+     bₐ = pr₁ (II a)
+     eq = pr₂ (II a)
+     p' : P (S β bₐ)
+     p' = transport P (ap (_+ₒ 𝟙ₒ) eq) p''
+      where
+       p'' : P (S α a)
+       p'' = P-antitone _ _ (upper-bound-of-successors-of-initial-segments α a) p
+     c : ⟨ γ ⟩
+     c = [ S β bₐ , γ ]⟨ sup-is-upper-bound _ (bₐ , p') ⟩ (inr ⋆)
+
+approximate-subtraction
+ : (α β : Ordinal 𝓤) → α ⊴ β
+ → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))
+approximate-subtraction {𝓤} α β β-above-α = γ , γ-greatest-satisfying-P
+ where
+  P : Ordinal 𝓤 → 𝓤 ̇
+  P δ = (α +ₒ δ ⊴ β) × (δ ⊴ β)
+  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → ((i : I) → P (F i))
+                         → P (sup F)
+  P-closed-under-suprema {I} F ρ =
+      {!!} -- Should formalize [α +ₒ (sup F) ＝ α ∨ sup (λ i → α +ₒ F i)]
+    , (sup-is-lower-bound-of-upper-bounds F β (λ i → pr₂ (ρ i)))
+  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
+  P-antitone α₁ α₂ k (l , m) =
+     ⊴-trans (α +ₒ α₁) (α +ₒ α₂) β (≼-gives-⊴ _ _ (+ₒ-right-monotone α α₁ α₂ (⊴-gives-≼ α₁ α₂ k))) l
+     -- Should record monotonicity for ⊴
+   , ⊴-trans α₁ α₂ β k m
+  P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β)
+  P-bounded = β , (λ α p → pr₂ p)
+  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+
+
+
+\end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -122,6 +122,44 @@ approximate-subtraction {𝓤} α β β-above-α = γ , γ-greatest-satisfying-P
   P-bounded = β , (λ α p → pr₂ p)
   open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
+approximate-division
+ : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β
+ → Σ γ ꞉ Ordinal 𝓤 ,
+    γ greatest-satisfying (λ - → Σ b ꞉ ⟨ β ⟩ , (β ×ₒ - +ₒ (β ↓ b) ⊴ α) × (- ⊴ α))
+approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
+ where
+  b₀ : ⟨ β ⟩
+  b₀ = pr₁ β-pos
+  b₀-eq : β ↓ b₀ ＝ 𝟘ₒ
+  b₀-eq = (pr₂ β-pos) ⁻¹
+  fact : (δ : Ordinal 𝓤) → β ×ₒ δ +ₒ (β ↓ b₀) ＝ β ×ₒ δ
+  fact δ = ap (β ×ₒ δ +ₒ_) b₀-eq ∙ 𝟘ₒ-right-neutral (β ×ₒ δ)
 
+  P : Ordinal 𝓤 → 𝓤 ̇
+  P δ = Σ b ꞉ ⟨ β ⟩ , (β ×ₒ δ +ₒ (β ↓ b) ⊴ α) × (δ ⊴ α)
+  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → ((i : I) → P (F i))
+                         → P (sup F)
+  P-closed-under-suprema {I} F ρ =
+   b₀ ,
+   transport⁻¹ (_⊴ α) (fact (sup F) ∙ ×ₒ-preserves-suprema pt sr β F) t ,
+   sup-is-lower-bound-of-upper-bounds F α (λ i → pr₂ (pr₂ (ρ i)))
+    where
+     t : sup (λ i → β ×ₒ F i) ⊴ α
+     t = sup-is-lower-bound-of-upper-bounds _ α s
+      where
+       s : (i : I) → β ×ₒ F i ⊴ α
+       s i = ⊴-trans (β ×ₒ F i) (β ×ₒ F i +ₒ (β ↓ bᵢ)) α (+ₒ-left-⊴ (β ×ₒ F i) (β ↓ bᵢ)) (pr₁ (pr₂ (ρ i)))
+        where
+         bᵢ : ⟨ β ⟩
+         bᵢ = pr₁ (ρ i)
+  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
+  P-antitone α₁ α₂ k (b , l , m) = b₀ , transport⁻¹ (_⊴ α) (fact α₁) t , ⊴-trans α₁ α₂ α k m
+   where
+    t : β ×ₒ α₁ ⊴ α
+    t = ⊴-trans (β ×ₒ α₁) (β ×ₒ α₂) α (×ₒ-right-monotone-⊴ β α₁ α₂ k) (⊴-trans (β ×ₒ α₂) (β ×ₒ α₂ +ₒ (β ↓ b)) α (+ₒ-left-⊴ (β ×ₒ α₂) (β ↓ b)) l)
+  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
+  P-bounded = α , (λ δ p → pr₂ (pr₂ p))
+  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
 \end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -164,28 +164,63 @@ module Enderton'
                              → t (sup F) ＝ sup (t ∘ F))
        where
 
- private
-  t-preserve-suprema-up-to-join
-   : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
-   → t (sup F) ＝ sup (cases (λ _  → 𝟘ₒ) (t ∘ F))
-  t-preserve-suprema-up-to-join {I} F =
-   t-preserves-suprema F
-   ∙ (⊴-antisym (sup (t ∘ F)) (sup G) u v)
-   where
-    G : 𝟙{𝓤} + I → Ordinal 𝓤
-    G = cases (λ _ → 𝟘ₒ) (t ∘ F)
-    u : sup (t ∘ F) ⊴ sup G
-    u = sup-is-lower-bound-of-upper-bounds (t ∘ F) (sup G)
-         (λ i → sup-is-upper-bound G (inr i))
-    v : sup G ⊴ sup (t ∘ F)
-    v = sup-is-lower-bound-of-upper-bounds G (sup (t ∘ F)) w
-     where
-      w : (x : 𝟙 + I)
-        → cases (λ _ → 𝟘ₒ) (t ∘ F) x ⊴ sup (t ∘ F)
-      w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (t ∘ F))
-      w (inr i) = sup-is-upper-bound (t ∘ F) i
+ t-preserves-suprema-up-to-join
+  : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
+  → t (sup F) ＝ sup (cases (λ _  → 𝟘ₒ) (t ∘ F))
+ t-preserves-suprema-up-to-join {I} F =
+  t-preserves-suprema F
+  ∙ (⊴-antisym (sup (t ∘ F)) (sup G) u v)
+  where
+   G : 𝟙{𝓤} + I → Ordinal 𝓤
+   G = cases (λ _ → 𝟘ₒ) (t ∘ F)
+   u : sup (t ∘ F) ⊴ sup G
+   u = sup-is-lower-bound-of-upper-bounds (t ∘ F) (sup G)
+        (λ i → sup-is-upper-bound G (inr i))
+   v : sup G ⊴ sup (t ∘ F)
+   v = sup-is-lower-bound-of-upper-bounds G (sup (t ∘ F)) w
+    where
+     w : (x : 𝟙 + I)
+       → cases (λ _ → 𝟘ₒ) (t ∘ F) x ⊴ sup (t ∘ F)
+     w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (t ∘ F))
+     w (inr i) = sup-is-upper-bound (t ∘ F) i
 
- open Enderton t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) t-preserve-suprema-up-to-join public
+ open Enderton t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) t-preserves-suprema-up-to-join public
+
+module Enderton-classical-variation
+        (t : Ordinal 𝓤 → Ordinal 𝓤)
+        (δ₀ δ : Ordinal 𝓤)
+        (δ₀-below-δ : δ₀ ⊴ δ)
+        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤) -- TODO: rename
+                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
+        (t-increasing : (α : Ordinal 𝓤) → α ⊴ t α)
+       where
+
+ enderton-classical : Σ γ ꞉ Ordinal 𝓤 , γ ⊴ δ × γ greatest-satisfying (λ - → (t - ⊴ δ))
+ enderton-classical = γ , γ-fact₂ , γ-fact₁ , γ-fact₄
+  where
+   open Enderton t δ₀ δ δ₀-below-δ t-preserves-suprema
+   I : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → t - ⊴ δ × - ⊴ δ)
+   I = enderton
+   γ : Ordinal 𝓤
+   γ = pr₁ I
+   γ-fact₁ : t γ ⊴ δ
+   γ-fact₁ = pr₁ (pr₁ (pr₂ I))
+   γ-fact₂ : γ ⊴ δ
+   γ-fact₂ = pr₂ (pr₁ (pr₂ I))
+   γ-fact₃ : (α : Ordinal 𝓤) → (t α ⊴ δ) × (α ⊴ δ) → α ⊴ γ
+   γ-fact₃ = pr₂ (pr₂ I)
+   γ-fact₄ : (α : Ordinal 𝓤) → t α ⊴ δ → α ⊴ γ
+   γ-fact₄ α l = γ-fact₃ α (l , (⊴-trans α (t α) δ (t-increasing α) l))
+
+module Enderton-classical-variation'
+        (t : Ordinal 𝓤 → Ordinal 𝓤)
+        (δ : Ordinal 𝓤)
+        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → t (sup F) ＝ sup (t ∘ F))
+        (t-increasing : (α : Ordinal 𝓤) → α ⊴ t α)
+       where
+
+ open Enderton-classical-variation t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) (Enderton'.t-preserves-suprema-up-to-join t δ t-preserves-suprema) t-increasing public
 
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
@@ -227,10 +262,10 @@ open import MLTT.Plus-Properties
 open import UF.ClassicalLogic
 open import Ordinals.Exponentiation.Taboos ua pt sr
 
--- TODO: Upstream and include converse
-+ₒ-as-large-right-summand-implies-EM : ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
+-- TODO: Upstream
++ₒ-as-large-as-right-summand-implies-EM : ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
                                      → EM 𝓤
-+ₒ-as-large-right-summand-implies-EM hyp P P-is-prop = IV
++ₒ-as-large-as-right-summand-implies-EM hyp P P-is-prop = IV
  where
   α = prop-ordinal P P-is-prop
   β = 𝟙ₒ
@@ -253,12 +288,23 @@ open import Ordinals.Exponentiation.Taboos ua pt sr
   IV : P + ¬ P
   IV = equality-cases (f ⋆) (λ p → inl ∘ I p) (λ _ → inr ∘ III)
 
--- TODO: Add converse
+EM-implies-+ₒ-as-large-as-right-summand : EM 𝓤
+                                        → ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
+EM-implies-+ₒ-as-large-as-right-summand em α β =
+ ≼-gives-⊴ β (α +ₒ β)
+           (EM-implies-order-preserving-gives-≼ em β (α +ₒ β) (f , I))
+  where
+   f : ⟨ β ⟩ → ⟨ α +ₒ β ⟩
+   f = inr
+   I : is-order-preserving β (α +ₒ β) f
+   I y y' l = l
+---
+
 approximate-subtraction-variation-implies-EM
  : ((α β : Ordinal 𝓤) → α ⊴ β
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β))))
  → EM 𝓤
-approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-right-summand-implies-EM I
+approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-as-right-summand-implies-EM I
  where
   I : (α β : Ordinal 𝓤) → β ⊴ α +ₒ β
   I α β = IV
@@ -271,6 +317,14 @@ approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-right-su
     IV : β ⊴ α +ₒ β
     IV = ⊴-trans β γ (α +ₒ β) III (pr₁ (pr₂ II))
 
+EM-implies-approximate-subtraction-variation
+ : EM 𝓤
+ → (α β : Ordinal 𝓤) → α ⊴ β
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β)))
+EM-implies-approximate-subtraction-variation {𝓤} em α β l = enderton-classical
+ where
+  open Enderton-classical-variation (α +ₒ_) α β l (+ₒ-preserves-suprema pt sr α) (EM-implies-+ₒ-as-large-as-right-summand em α)
+
 -- TODO: Upstream
 +ₒ-minimal : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
            → is-minimal α a₀ → is-minimal (α +ₒ β) (inl a₀)
@@ -282,10 +336,10 @@ approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-right-su
 +ₒ-least α β  a₀ a₀-least =
  minimal-is-least (α +ₒ β) (inl a₀) (+ₒ-minimal α β a₀ (least-is-minimal α a₀ a₀-least))
 
--- TODO: Upstream and include converse
-×ₒ-as-large-right-summand-implies-EM : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β)
+-- TODO: Upstream
+×ₒ-as-large-as-right-factor-implies-EM : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β)
                                      → EM 𝓤
-×ₒ-as-large-right-summand-implies-EM  hyp P P-is-prop = IV (f (inr ⋆)) refl
+×ₒ-as-large-as-right-factor-implies-EM  hyp P P-is-prop = IV (f (inr ⋆)) refl
  where
   Pₒ = prop-ordinal P P-is-prop
   α = 𝟙ₒ +ₒ Pₒ
@@ -319,12 +373,24 @@ approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-right-su
   IV (inl ⋆ , inr ⋆) e = inr (II (inl ⋆) e)
   IV (inr p , inr ⋆) e = inl p
 
--- TODO: Add converses
+EM-implies-×ₒ-as-large-as-right-factor
+ : EM 𝓤
+ → (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
+EM-implies-×ₒ-as-large-as-right-factor em α β (a₀ , _) =
+ ≼-gives-⊴ β (α ×ₒ β)
+           (EM-implies-order-preserving-gives-≼ em β (α ×ₒ β) (f , I))
+  where
+   f : ⟨ β ⟩ → ⟨ α ×ₒ β ⟩
+   f b = (a₀ , b)
+   I : is-order-preserving β (α ×ₒ β) f
+   I b b' l = inl l
+---
+
 approximate-division-variation-implies-EM
  : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
    → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β))))
  → EM 𝓤
-approximate-division-variation-implies-EM {𝓤} hyp = ×ₒ-as-large-right-summand-implies-EM I
+approximate-division-variation-implies-EM {𝓤} hyp = ×ₒ-as-large-as-right-factor-implies-EM I
  where
   I : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
   I α β α-pos = IV
@@ -336,6 +402,14 @@ approximate-division-variation-implies-EM {𝓤} hyp = ×ₒ-as-large-right-summ
     III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ×ₒ β))
     IV : β ⊴ α ×ₒ β
     IV = ⊴-trans β γ (α ×ₒ β) III (pr₁ (pr₂ II))
+
+EM-implies-approximate-division-variation
+ : EM 𝓤
+ → (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β)))
+EM-implies-approximate-division-variation em α β α-pos = enderton-classical
+ where
+  open Enderton-classical-variation' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α) (λ δ → EM-implies-×ₒ-as-large-as-right-factor em α δ α-pos)
 
 approximate-logarithm-variation-implies-EM
  : ((α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
@@ -353,5 +427,13 @@ approximate-logarithm-variation-implies-EM {𝓤} hyp = ^ₒ-as-large-as-exponen
     III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ^ₒ β))
     IV : β ⊴ α ^ₒ β
     IV = ⊴-trans β γ (α ^ₒ β) III (pr₁ (pr₂ II))
+
+EM-implies-approximate-logarithm-variation
+ : EM 𝓤
+ → (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β)))
+EM-implies-approximate-logarithm-variation em α β β-pos α-strictly-pos = enderton-classical
+  where
+   open Enderton-classical-variation (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α _) (λ δ → EM-implies-^ₒ-as-large-as-exponent em α δ α-strictly-pos)
 
 \end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -97,6 +97,10 @@ module greatest-element-satisfying-predicate
  γ-greatest-satisfying-P : γ greatest-satisfying P
  γ-greatest-satisfying-P = γ-satisfies-P , γ-greatest
 
+-- TODO: Capture the common core à la Enderton
+-- Note that we can't quite assume continuity, but we can assume something like
+-- t (sup F) ＝ c ∨ sup (t ∘ F) for some suitable c
+
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))
@@ -150,6 +154,31 @@ approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
   P-antitone α₁ α₂ k (l , m) = ⊴-trans (β ×ₒ α₁) (β ×ₒ α₂) α (×ₒ-right-monotone-⊴ β α₁ α₂ k) l , ⊴-trans α₁ α₂ α k m
   P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
   P-bounded = α , (λ δ p → pr₂ p)
+  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+
+open import Ordinals.Exponentiation.Supremum ua pt sr
+aproximate-logarithm
+ : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β
+ → Σ γ ꞉ Ordinal 𝓤 ,
+    γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
+aproximate-logarithm {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
+ where
+  P : Ordinal 𝓤 → 𝓤 ̇
+  P δ = (α ^ₒ δ ⊴ β) × (δ ⊴ β)
+  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                         → ((i : I) → P (F i))
+                         → P (sup F)
+  P-closed-under-suprema {I} F ρ =
+   transport⁻¹ (_⊴ β) (^ₒ-satisfies-strong-sup-specification α I F) (sup-is-lower-bound-of-upper-bounds _ β h) ,
+   sup-is-lower-bound-of-upper-bounds F β (λ i → pr₂ (ρ i))
+    where
+     h : (x : 𝟙 + I) → cases (λ _ → 𝟙ₒ) (λ i → α ^ₒ F i) x ⊴ β
+     h (inl ⋆) = β-pos
+     h (inr i) = pr₁ (ρ i)
+  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
+  P-antitone α₁ α₂ k (l , m) = ⊴-trans (α ^ₒ α₁) (α ^ₒ α₂) β (^ₒ-monotone-in-exponent α α₁ α₂ k) l , ⊴-trans α₁ α₂ β k m
+  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
+  P-bounded = β , (λ δ p → pr₂ p)
   open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
 {-

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -415,7 +415,8 @@ EM-implies-approximate-subtraction-variation {𝓤} em α β l =
 
 \end{code}
 
-Indeed, analogous results hold for approximate division and logarithm.
+Indeed, analogous results hold for approximate division (with the assumption
+𝟘₀ ⊲ α this time) and logarithm (with the assumption 𝟙₀ ⊲ α this time).
 
 \begin{code}
 

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -1,9 +1,9 @@
 Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, Chuangjie Xu.
-14 July 2025.
+14-15 July 2025.
 
 \begin{code}
 
-{-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
+{-# OPTIONS --safe --without-K --exact-split #-}
 
 open import UF.Univalence
 open import UF.PropTrunc
@@ -157,6 +157,35 @@ module Enderton
    P-bounded = δ , (λ α p → pr₂ p)
    open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
+module Enderton'
+        (t : Ordinal 𝓤 → Ordinal 𝓤)
+        (δ : Ordinal 𝓤)
+        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                             → t (sup F) ＝ sup (t ∘ F))
+       where
+
+ private
+  t-preserve-suprema-up-to-join
+   : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
+   → t (sup F) ＝ sup (cases (λ _  → 𝟘ₒ) (t ∘ F))
+  t-preserve-suprema-up-to-join {I} F =
+   t-preserves-suprema F
+   ∙ (⊴-antisym (sup (t ∘ F)) (sup G) u v)
+   where
+    G : 𝟙{𝓤} + I → Ordinal 𝓤
+    G = cases (λ _ → 𝟘ₒ) (t ∘ F)
+    u : sup (t ∘ F) ⊴ sup G
+    u = sup-is-lower-bound-of-upper-bounds (t ∘ F) (sup G) (λ i → sup-is-upper-bound G (inr i))
+    v : sup G ⊴ sup (t ∘ F)
+    v = sup-is-lower-bound-of-upper-bounds G (sup (t ∘ F)) w
+     where
+      w : (x : 𝟙 + I)
+        → cases (λ _ → 𝟘ₒ) (t ∘ F) x ⊴ sup (t ∘ F)
+      w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (t ∘ F))
+      w (inr i) = sup-is-upper-bound (t ∘ F) i
+
+ open Enderton t 𝟘ₒ δ (𝟘ₒ-least-⊴ δ) t-preserve-suprema-up-to-join public
+
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))
@@ -169,26 +198,8 @@ approximate-division
  → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → (β ×ₒ - ⊴ α) × (- ⊴ α))
 approximate-division {𝓤} α β β-pos = enderton
- where -- TODO: Upstream this part into the Enderton module
-  σ : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
-    → β ×ₒ sup F ＝ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
-  σ {I} F = e₁ ∙ e₂
-   where
-    e₁ : β ×ₒ sup F ＝ sup (λ i → β ×ₒ F i)
-    e₁ = ×ₒ-preserves-suprema pt sr β F
-    e₂ : sup (λ i → β ×ₒ F i) ＝ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
-    e₂ = ⊴-antisym _ _ u v
-     where
-      u : sup (λ i → β ×ₒ F i) ⊴ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
-      u = sup-is-lower-bound-of-upper-bounds _ _ (λ i → sup-is-upper-bound _ (inr i))
-      v : sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i)) ⊴ sup (λ i → β ×ₒ F i)
-      v = sup-is-lower-bound-of-upper-bounds _ _ w
-       where
-        w : (x : 𝟙 + I)
-          → cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i) x ⊴ sup (λ i → β ×ₒ F i)
-        w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (λ i → β ×ₒ F i))
-        w (inr i) = sup-is-upper-bound (λ j → β ×ₒ F j) i
-  open Enderton (β ×ₒ_) 𝟘ₒ α (𝟘ₒ-least-⊴ α) σ
+ where
+  open Enderton' (β ×ₒ_) α (×ₒ-preserves-suprema pt sr β)
 
 open import Ordinals.Exponentiation.Supremum ua pt sr
 aproximate-logarithm

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -3,7 +3,7 @@ Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, Chuangjie Xu.
 
 \begin{code}
 
-{-# OPTIONS --safe --without-K --exact-split #-}
+{-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
 
 open import UF.Univalence
 open import UF.PropTrunc
@@ -204,7 +204,7 @@ approximate-division {𝓤} α β α-pos = enderton
 
 open import Ordinals.Exponentiation.Supremum ua pt sr
 aproximate-logarithm
- : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β
+ : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β -- 𝟙ₒ ⊲ α should be included too, even if it's not technically necessary
  → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
 aproximate-logarithm {𝓤} α β β-pos = enderton
@@ -217,6 +217,141 @@ TODO. The seemingly mild variation
 
 approximate-subtraction'
  : (α β : Ordinal 𝓤) → α ⊴ β
- → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β))
+ → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β)))
 
 yields LEM, and similarly for division and logarithm.
+
+\begin{code}
+
+open import MLTT.Plus-Properties
+open import UF.ClassicalLogic
+open import Ordinals.Exponentiation.Taboos ua pt sr
+
+-- TODO: Upstream and include converse
++ₒ-as-large-right-summand-implies-EM : ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)
+                                     → EM 𝓤
++ₒ-as-large-right-summand-implies-EM hyp P P-is-prop = IV
+ where
+  α = prop-ordinal P P-is-prop
+  β = 𝟙ₒ
+  𝕗 : β ⊴ α +ₒ β
+  𝕗 = hyp α β
+  f = [ β , α +ₒ β ]⟨ 𝕗 ⟩
+  I : (p : P) → f ⋆ ＝ inl p → P
+  I p _ = p
+  II : (p : P) → f ⋆ ＝ inl p
+  II p = simulations-preserve-least β (α +ₒ β) ⋆ (inl p) f [ β , α +ₒ β ]⟨ 𝕗 ⟩-is-simulation 𝟙ₒ-least l
+   where
+    l : is-least (α +ₒ β) (inl p)
+    l = minimal-is-least (α +ₒ β) (inl p) m
+     where
+      m : is-minimal (α +ₒ β) (inl p)
+      m (inl p') = 𝟘-elim
+      m (inr ⋆ ) = 𝟘-elim
+  III : f ⋆ ＝ inr ⋆ → ¬ P
+  III e p = +disjoint ((II p) ⁻¹ ∙ e)
+  IV : P + ¬ P
+  IV = equality-cases (f ⋆) (λ p → inl ∘ I p) (λ _ → inr ∘ III)
+
+-- TODO: Add converse
+approximate-subtraction-variation-implies-EM
+ : ((α β : Ordinal 𝓤) → α ⊴ β
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β))))
+ → EM 𝓤
+approximate-subtraction-variation-implies-EM {𝓤} hyp = +ₒ-as-large-right-summand-implies-EM I
+ where
+  I : (α β : Ordinal 𝓤) → β ⊴ α +ₒ β
+  I α β = IV
+   where
+    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α +ₒ β) × (γ greatest-satisfying (λ - → α +ₒ - ⊴ α +ₒ β))
+    II = hyp α (α +ₒ β) (+ₒ-left-⊴ α β)
+    γ = pr₁ II
+    III : β ⊴ γ
+    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α +ₒ β))
+    IV : β ⊴ α +ₒ β
+    IV = ⊴-trans β γ (α +ₒ β) III (pr₁ (pr₂ II))
+
+-- TODO: Upstream
++ₒ-minimal : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
+           → is-minimal α a₀ → is-minimal (α +ₒ β) (inl a₀)
++ₒ-minimal α β a₀ a₀-minimal (inl a) = a₀-minimal a
++ₒ-minimal α β a₀ a₀-minimal (inr b) = 𝟘-elim
+
++ₒ-least : (α β : Ordinal 𝓤) (a₀ : ⟨ α ⟩)
+         → is-least α a₀ → is-least (α +ₒ β) (inl a₀)
++ₒ-least α β  a₀ a₀-least =
+ minimal-is-least (α +ₒ β) (inl a₀) (+ₒ-minimal α β a₀ (least-is-minimal α a₀ a₀-least))
+
+-- TODO: Upstream and include converse
+×ₒ-as-large-right-summand-implies-EM : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β)
+                                     → EM 𝓤
+×ₒ-as-large-right-summand-implies-EM  hyp P P-is-prop = IV (f (inr ⋆)) refl
+ where
+  Pₒ = prop-ordinal P P-is-prop
+  α = 𝟙ₒ +ₒ Pₒ
+  β = 𝟚ₒ
+  𝕗 : β ⊴ α ×ₒ β
+  𝕗 = hyp α β (inl ⋆ , (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆))
+  f = [ β , α ×ₒ β ]⟨ 𝕗 ⟩
+  I : (p : P) → f (inr ⋆) ＝ (inr p , inl ⋆)
+  I p = ↓-lc (α ×ₒ β) (f (inr ⋆)) (inr p , inl ⋆) e
+   where
+    e = (α ×ₒ β) ↓ f (inr ⋆) ＝⟨ (simulations-preserve-↓ β (α ×ₒ β) 𝕗 (inr ⋆)) ⁻¹ ⟩
+        β ↓ inr ⋆ ＝⟨ +ₒ-↓-right ⋆ ⁻¹ ∙ ap (𝟙ₒ +ₒ_) 𝟙ₒ-↓ ∙ 𝟘ₒ-right-neutral 𝟙ₒ ⟩
+        𝟙ₒ ＝⟨ (𝟘ₒ-right-neutral 𝟙ₒ) ⁻¹ ∙ ap (𝟙ₒ +ₒ_) ((prop-ordinal-↓ P-is-prop p) ⁻¹) ∙ +ₒ-↓-right p ⟩
+        α ↓ inr p ＝⟨ (ap (_+ₒ (α ↓ inr p)) (×ₒ-𝟘ₒ-right α) ∙ 𝟘ₒ-left-neutral (α ↓ inr p)) ⁻¹ ⟩
+        α ×ₒ 𝟘ₒ +ₒ (α ↓ inr p) ＝⟨ ap (λ - → α ×ₒ - +ₒ (α ↓ inr p)) (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆) ⟩
+        α ×ₒ (β ↓ inl ⋆) +ₒ (α ↓ inr p) ＝⟨ ×ₒ-↓ α β ⁻¹ ⟩
+        (α ×ₒ β) ↓ (inr p , inl ⋆)      ∎
+  II : (x : ⟨ α ⟩) → f (inr ⋆) ＝ (x , inr ⋆) → ¬ P
+  II x e p = +disjoint (ap pr₂ ((I p) ⁻¹ ∙ e))
+  III : f (inr ⋆) ≠ (inl ⋆ , inl ⋆)
+  III h = +disjoint (simulations-are-lc β (α ×ₒ β) f [ β , α ×ₒ β ]⟨ 𝕗 ⟩-is-simulation (e ∙ h ⁻¹))
+   where
+    e : f (inl ⋆) ＝ (inl ⋆ , inl ⋆)
+    e = simulations-preserve-least β (α ×ₒ β) (inl ⋆) (inl ⋆ , inl ⋆) f [ β , α ×ₒ β ]⟨ 𝕗 ⟩-is-simulation β-least (×ₒ-least α β (inl ⋆) (inl ⋆) (+ₒ-least 𝟙ₒ Pₒ ⋆ 𝟙ₒ-least) β-least)
+     where
+      β-least : is-least β (inl ⋆)
+      β-least = +ₒ-least 𝟙ₒ 𝟙ₒ ⋆ 𝟙ₒ-least
+  IV : (x : ⟨ α ×ₒ β ⟩) → f (inr ⋆) ＝ x → P + ¬ P
+  IV (inl ⋆ , inl ⋆) e = 𝟘-elim (III e)
+  IV (inr p , inl ⋆) e = inl p
+  IV (inl ⋆ , inr ⋆) e = inr (II (inl ⋆) e)
+  IV (inr p , inr ⋆) e = inl p
+
+-- TODO: Add converses
+approximate-division-variation-implies-EM
+ : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β))))
+ → EM 𝓤
+approximate-division-variation-implies-EM {𝓤} hyp = ×ₒ-as-large-right-summand-implies-EM I
+ where
+  I : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
+  I α β α-pos = IV
+   where
+    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ×ₒ β) × (γ greatest-satisfying (λ - → α ×ₒ - ⊴ α ×ₒ β))
+    II = hyp α (α ×ₒ β) α-pos
+    γ = pr₁ II
+    III : β ⊴ γ
+    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ×ₒ β))
+    IV : β ⊴ α ×ₒ β
+    IV = ⊴-trans β γ (α ×ₒ β) III (pr₁ (pr₂ II))
+
+approximate-logarithm-variation-implies-EM
+ : ((α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
+   → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β))))
+ → EM 𝓤
+approximate-logarithm-variation-implies-EM {𝓤} hyp = ^ₒ-as-large-as-exponent-implies-EM I
+ where
+  I : (α β : Ordinal 𝓤) → 𝟙ₒ ⊲ α → β ⊴ α ^ₒ β
+  I α β α-strictly-pos = IV
+   where
+    II : Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ α ^ₒ β) × (γ greatest-satisfying (λ - → α ^ₒ - ⊴ α ^ₒ β))
+    II = hyp α (α ^ₒ β) (^ₒ-has-least-element α β) α-strictly-pos
+    γ = pr₁ II
+    III : β ⊴ γ
+    III = pr₂ (pr₂ (pr₂ II)) β (⊴-refl (α ^ₒ β))
+    IV : β ⊴ α ^ₒ β
+    IV = ⊴-trans β γ (α ^ₒ β) III (pr₁ (pr₂ II))
+
+\end{code}

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -344,28 +344,28 @@ In a similar sense, we can approximate division of ordinals.
 \begin{code}
 
 approximate-division
- : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α
- → Σ γ ꞉ Ordinal 𝓤 ,
-    γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β) × (- ⊴ β))
-approximate-division {𝓤} α β _ = enderton-like
+ : (α β : Ordinal 𝓤)
+ → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β) × (- ⊴ β))
+approximate-division {𝓤} α β = enderton-like
  where
   open Enderton-like' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α)
 
 \end{code}
 
-Note that the assumption 𝟘ₒ ⊲ α isn't actually used (for α ＝ 𝟘ₒ, we simply get
-γ ＝ β due to the - ⊴ β requirement).
+Note that it is not technically necessary to assume 𝟘ₒ ⊲ α in the above, even
+though division by 𝟘ₒ is not well defined. In fact, the - ⊴ β requirement forces
+γ ＝ β in case α ＝ 𝟘₀.
 
 Again, in a similar sense, we can approximate logarithms of
-ordinals. And similarly, the assumption 𝟙ₒ ⊲ α isn't used.
+ordinals. And similarly, assuming 𝟙ₒ ⊲ α isn't needed.
 
 \begin{code}
 
 aproximate-logarithm
- : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β → 𝟙ₒ ⊲ α
+ : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
-aproximate-logarithm {𝓤} α β β-pos _ = enderton-like
+aproximate-logarithm {𝓤} α β β-pos = enderton-like
  where
  open Enderton-like (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α)
 

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -105,12 +105,18 @@ approximate-subtraction {𝓤} α β β-above-α = γ , γ-greatest-satisfying-P
                          → ((i : I) → P (F i))
                          → P (sup F)
   P-closed-under-suprema {I} F ρ =
-      {!!} -- Should formalize [α +ₒ (sup F) ＝ α ∨ sup (λ i → α +ₒ F i)]
+      transport⁻¹ (_⊴ β) (+ₒ-preserves-suprema pt sr α F) σ
     , (sup-is-lower-bound-of-upper-bounds F β (λ i → pr₂ (ρ i)))
+   where
+    σ : sup (cases (λ ⋆ → α) (λ i → α +ₒ F i)) ⊴ β
+    σ = sup-is-lower-bound-of-upper-bounds _ β h
+     where
+      h : (x : 𝟙 + I) → cases (λ _ → α) (λ i → α +ₒ F i) x ⊴ β
+      h (inl ⋆) = β-above-α
+      h (inr i) = pr₁ (ρ i)
   P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
   P-antitone α₁ α₂ k (l , m) =
-     ⊴-trans (α +ₒ α₁) (α +ₒ α₂) β (≼-gives-⊴ _ _ (+ₒ-right-monotone α α₁ α₂ (⊴-gives-≼ α₁ α₂ k))) l
-     -- Should record monotonicity for ⊴
+     ⊴-trans (α +ₒ α₁) (α +ₒ α₂) β (+ₒ-right-monotone-⊴ α α₁ α₂ k) l
    , ⊴-trans α₁ α₂ β k m
   P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β)
   P-bounded = β , (λ α p → pr₂ p)

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -105,7 +105,7 @@ module Enderton
         (δ₀ δ : Ordinal 𝓤)
         (δ₀-below-δ : δ₀ ⊴ δ)
         (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤) -- TODO: rename
-                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (λ i → t (F i))))
+                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (t ∘ F)))
        where
 
  private
@@ -123,7 +123,7 @@ module Enderton
       ub : (i : 𝟙 + 𝟙) → F i ⊴ β
       ub (inl ⋆) = l
       ub (inr ⋆) = ⊴-refl β
-    II : t (sup F) ＝ sup (cases (λ _ → δ₀) (λ i → t (F i)))
+    II : t (sup F) ＝ sup (cases (λ _ → δ₀) (t ∘ F))
     II = t-preserves-suprema F
     III : t α ⊴ t β
     III = transport⁻¹
@@ -175,7 +175,8 @@ module Enderton'
     G : 𝟙{𝓤} + I → Ordinal 𝓤
     G = cases (λ _ → 𝟘ₒ) (t ∘ F)
     u : sup (t ∘ F) ⊴ sup G
-    u = sup-is-lower-bound-of-upper-bounds (t ∘ F) (sup G) (λ i → sup-is-upper-bound G (inr i))
+    u = sup-is-lower-bound-of-upper-bounds (t ∘ F) (sup G)
+         (λ i → sup-is-upper-bound G (inr i))
     v : sup G ⊴ sup (t ∘ F)
     v = sup-is-lower-bound-of-upper-bounds G (sup (t ∘ F)) w
      where
@@ -194,12 +195,12 @@ approximate-subtraction {𝓤} α β β-above-α = enderton
   open Enderton (α +ₒ_) α β β-above-α (+ₒ-preserves-suprema pt sr α)
 
 approximate-division
- : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β -- In our weakening this assumption becomes redundant
+ : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α -- In our weakening this assumption becomes redundant
  → Σ γ ꞉ Ordinal 𝓤 ,
-    γ greatest-satisfying (λ - → (β ×ₒ - ⊴ α) × (- ⊴ α))
-approximate-division {𝓤} α β β-pos = enderton
+    γ greatest-satisfying (λ - → (α ×ₒ - ⊴ β) × (- ⊴ β))
+approximate-division {𝓤} α β α-pos = enderton
  where
-  open Enderton' (β ×ₒ_) α (×ₒ-preserves-suprema pt sr β)
+  open Enderton' (α ×ₒ_) β (×ₒ-preserves-suprema pt sr α)
 
 open import Ordinals.Exponentiation.Supremum ua pt sr
 aproximate-logarithm
@@ -211,3 +212,11 @@ aproximate-logarithm {𝓤} α β β-pos = enderton
  open Enderton (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α _)
 
 \end{code}
+
+TODO. The seemingly mild variation
+
+approximate-subtraction'
+ : (α β : Ordinal 𝓤) → α ⊴ β
+ → Σ γ ꞉ Ordinal 𝓤 , (γ ⊴ β) × (γ greatest-satisfying (λ - → (α +ₒ - ⊴ β))
+
+yields LEM, and similarly for division and logarithm.

--- a/source/Ordinals/BoundedOperations.lagda
+++ b/source/Ordinals/BoundedOperations.lagda
@@ -3,7 +3,7 @@ Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, Chuangjie Xu.
 
 \begin{code}
 
-{-# OPTIONS --safe --without-K --exact-split #-}
+{-# OPTIONS --safe --without-K --exact-split --lossy-unification #-}
 
 open import UF.Univalence
 open import UF.PropTrunc
@@ -97,184 +97,106 @@ module greatest-element-satisfying-predicate
  γ-greatest-satisfying-P : γ greatest-satisfying P
  γ-greatest-satisfying-P = γ-satisfies-P , γ-greatest
 
--- TODO: Capture the common core à la Enderton
 -- Note that we can't quite assume continuity, but we can assume something like
 -- t (sup F) ＝ c ∨ sup (t ∘ F) for some suitable c
 
 module Enderton
         (t : Ordinal 𝓤 → Ordinal 𝓤)
-        (γ : Ordinal 𝓤)
-        (t-is-continuous : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → γ) (λ i → t (F i))))
+        (δ₀ δ : Ordinal 𝓤)
+        (δ₀-below-δ : δ₀ ⊴ δ)
+        (t-preserves-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤) -- TODO: rename
+                         → t (sup F) ＝ sup (cases (λ (_ : 𝟙{𝓤}) → δ₀) (λ i → t (F i))))
        where
 
  private
   t-is-monotone : (α β : Ordinal 𝓤) → α ⊴ β → t α ⊴ t β
-  t-is-monotone α β l = {!!}
+  t-is-monotone α β l = III
    where
     F : 𝟙{𝓤} + 𝟙{𝓤} → Ordinal 𝓤
     F (inl ⋆) = α
     F (inr ⋆) = β
     I : sup F ＝ β
-    I = {!!}
-    II : t (sup F) ＝ sup (cases (λ _ → γ) (λ i → t (F i)))
-    II = t-is-continuous F
+    I = ⊴-antisym (sup F) β
+         (sup-is-lower-bound-of-upper-bounds F β ub)
+         (sup-is-upper-bound F (inr ⋆))
+     where
+      ub : (i : 𝟙 + 𝟙) → F i ⊴ β
+      ub (inl ⋆) = l
+      ub (inr ⋆) = ⊴-refl β
+    II : t (sup F) ＝ sup (cases (λ _ → δ₀) (λ i → t (F i)))
+    II = t-preserves-suprema F
     III : t α ⊴ t β
-    III = {!!} -- t α ⊴ sup (cases (λ _ → γ) (λ i → t (F i))) ⊴ t (sup F) ＝ t (sup β)
+    III = transport⁻¹
+           (t α ⊴_)
+           (ap t I ⁻¹ ∙ II)
+           (sup-is-upper-bound (cases (λ _ → δ₀) (t ∘ F)) (inr (inl ⋆)))
+
+ enderton : Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (t - ⊴ δ) × (- ⊴ δ))
+ enderton = γ , γ-greatest-satisfying-P
+  where
+   P : Ordinal 𝓤 → 𝓤 ̇
+   P α = (t α ⊴ δ) × (α ⊴ δ)
+   P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
+                          → ((i : I) → P (F i))
+                          → P (sup F)
+   P-closed-under-suprema {I} F ρ =
+    transport⁻¹ (_⊴ δ) (t-preserves-suprema F) σ ,
+    sup-is-lower-bound-of-upper-bounds F δ (λ i → pr₂ (ρ i))
+     where
+      σ : sup (cases (λ ⋆ → δ₀) (λ i → t (F i))) ⊴ δ
+      σ = sup-is-lower-bound-of-upper-bounds _ δ h
+       where
+        h : (x : 𝟙 + I) → cases (λ ⋆ → δ₀) (λ i → t (F i)) x ⊴ δ
+        h (inl ⋆) = δ₀-below-δ
+        h (inr i) = pr₁ (ρ i)
+   P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
+   P-antitone α₁ α₂ k (l , m) =
+     ⊴-trans (t α₁) (t α₂) δ (t-is-monotone α₁ α₂ k) l ,
+     ⊴-trans α₁ α₂ δ k m
+   P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β)
+   P-bounded = δ , (λ α p → pr₂ p)
+   open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
 
 approximate-subtraction
  : (α β : Ordinal 𝓤) → α ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 , γ greatest-satisfying (λ - → (α +ₒ - ⊴ β) × (- ⊴ β))
-approximate-subtraction {𝓤} α β β-above-α = γ , γ-greatest-satisfying-P
+approximate-subtraction {𝓤} α β β-above-α = enderton
  where
-  P : Ordinal 𝓤 → 𝓤 ̇
-  P δ = (α +ₒ δ ⊴ β) × (δ ⊴ β)
-  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → ((i : I) → P (F i))
-                         → P (sup F)
-  P-closed-under-suprema {I} F ρ =
-      transport⁻¹ (_⊴ β) (+ₒ-preserves-suprema pt sr α F) σ
-    , (sup-is-lower-bound-of-upper-bounds F β (λ i → pr₂ (ρ i)))
-   where
-    σ : sup (cases (λ ⋆ → α) (λ i → α +ₒ F i)) ⊴ β
-    σ = sup-is-lower-bound-of-upper-bounds _ β h
-     where
-      h : (x : 𝟙 + I) → cases (λ _ → α) (λ i → α +ₒ F i) x ⊴ β
-      h (inl ⋆) = β-above-α
-      h (inr i) = pr₁ (ρ i)
-  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
-  P-antitone α₁ α₂ k (l , m) =
-     ⊴-trans (α +ₒ α₁) (α +ₒ α₂) β (+ₒ-right-monotone-⊴ α α₁ α₂ k) l
-   , ⊴-trans α₁ α₂ β k m
-  P-bounded : Σ β ꞉ Ordinal 𝓤 , ((α : Ordinal 𝓤) → P α → α ⊴ β)
-  P-bounded = β , (λ α p → pr₂ p)
-  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+  open Enderton (α +ₒ_) α β β-above-α (+ₒ-preserves-suprema pt sr α)
 
 approximate-division
- : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β
+ : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β -- In our weakening this assumption becomes redundant
  → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → (β ×ₒ - ⊴ α) × (- ⊴ α))
-approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
- where
-  b₀ : ⟨ β ⟩
-  b₀ = pr₁ β-pos
-  b₀-eq : β ↓ b₀ ＝ 𝟘ₒ
-  b₀-eq = (pr₂ β-pos) ⁻¹
-  fact : (δ : Ordinal 𝓤) → β ×ₒ δ +ₒ (β ↓ b₀) ＝ β ×ₒ δ
-  fact δ = ap (β ×ₒ δ +ₒ_) b₀-eq ∙ 𝟘ₒ-right-neutral (β ×ₒ δ)
-
-  P : Ordinal 𝓤 → 𝓤 ̇
-  P δ = (β ×ₒ δ ⊴ α) × (δ ⊴ α)
-  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → ((i : I) → P (F i))
-                         → P (sup F)
-  P-closed-under-suprema {I} F ρ =
-     transport⁻¹ (_⊴ α) (×ₒ-preserves-suprema pt sr β F) (sup-is-lower-bound-of-upper-bounds (λ i → β ×ₒ F i) α (λ i → pr₁ (ρ i)))
-   , sup-is-lower-bound-of-upper-bounds F α (λ i → pr₂ (ρ i))
-  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
-  P-antitone α₁ α₂ k (l , m) = ⊴-trans (β ×ₒ α₁) (β ×ₒ α₂) α (×ₒ-right-monotone-⊴ β α₁ α₂ k) l , ⊴-trans α₁ α₂ α k m
-  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
-  P-bounded = α , (λ δ p → pr₂ p)
-  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
+approximate-division {𝓤} α β β-pos = enderton
+ where -- TODO: Upstream this part into the Enderton module
+  σ : {I : 𝓤 ̇} (F : I → Ordinal 𝓤)
+    → β ×ₒ sup F ＝ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
+  σ {I} F = e₁ ∙ e₂
+   where
+    e₁ : β ×ₒ sup F ＝ sup (λ i → β ×ₒ F i)
+    e₁ = ×ₒ-preserves-suprema pt sr β F
+    e₂ : sup (λ i → β ×ₒ F i) ＝ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
+    e₂ = ⊴-antisym _ _ u v
+     where
+      u : sup (λ i → β ×ₒ F i) ⊴ sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i))
+      u = sup-is-lower-bound-of-upper-bounds _ _ (λ i → sup-is-upper-bound _ (inr i))
+      v : sup (cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i)) ⊴ sup (λ i → β ×ₒ F i)
+      v = sup-is-lower-bound-of-upper-bounds _ _ w
+       where
+        w : (x : 𝟙 + I)
+          → cases (λ _ → 𝟘ₒ) (λ i → β ×ₒ F i) x ⊴ sup (λ i → β ×ₒ F i)
+        w (inl ⋆) = 𝟘ₒ-least-⊴ (sup (λ i → β ×ₒ F i))
+        w (inr i) = sup-is-upper-bound (λ j → β ×ₒ F j) i
+  open Enderton (β ×ₒ_) 𝟘ₒ α (𝟘ₒ-least-⊴ α) σ
 
 open import Ordinals.Exponentiation.Supremum ua pt sr
 aproximate-logarithm
  : (α β : Ordinal 𝓤) → 𝟙ₒ ⊴ β
  → Σ γ ꞉ Ordinal 𝓤 ,
     γ greatest-satisfying (λ - → (α ^ₒ - ⊴ β) × (- ⊴ β))
-aproximate-logarithm {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
+aproximate-logarithm {𝓤} α β β-pos = enderton
  where
-  P : Ordinal 𝓤 → 𝓤 ̇
-  P δ = (α ^ₒ δ ⊴ β) × (δ ⊴ β)
-  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → ((i : I) → P (F i))
-                         → P (sup F)
-  P-closed-under-suprema {I} F ρ =
-   transport⁻¹ (_⊴ β) (^ₒ-satisfies-strong-sup-specification α I F) (sup-is-lower-bound-of-upper-bounds _ β h) ,
-   sup-is-lower-bound-of-upper-bounds F β (λ i → pr₂ (ρ i))
-    where
-     h : (x : 𝟙 + I) → cases (λ _ → 𝟙ₒ) (λ i → α ^ₒ F i) x ⊴ β
-     h (inl ⋆) = β-pos
-     h (inr i) = pr₁ (ρ i)
-  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
-  P-antitone α₁ α₂ k (l , m) = ⊴-trans (α ^ₒ α₁) (α ^ₒ α₂) β (^ₒ-monotone-in-exponent α α₁ α₂ k) l , ⊴-trans α₁ α₂ β k m
-  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
-  P-bounded = β , (λ δ p → pr₂ p)
-  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
-
-{-
-Original silly version
-approximate-division
- : (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ β
- → Σ γ ꞉ Ordinal 𝓤 ,
-    γ greatest-satisfying (λ - → Σ b ꞉ ⟨ β ⟩ , (β ×ₒ - +ₒ (β ↓ b) ⊴ α) × (- ⊴ α))
-approximate-division {𝓤} α β β-pos = γ , γ-greatest-satisfying-P
- where
-  b₀ : ⟨ β ⟩
-  b₀ = pr₁ β-pos
-  b₀-eq : β ↓ b₀ ＝ 𝟘ₒ
-  b₀-eq = (pr₂ β-pos) ⁻¹
-  fact : (δ : Ordinal 𝓤) → β ×ₒ δ +ₒ (β ↓ b₀) ＝ β ×ₒ δ
-  fact δ = ap (β ×ₒ δ +ₒ_) b₀-eq ∙ 𝟘ₒ-right-neutral (β ×ₒ δ)
-
-  P : Ordinal 𝓤 → 𝓤 ̇
-  P δ = Σ b ꞉ ⟨ β ⟩ , (β ×ₒ δ +ₒ (β ↓ b) ⊴ α) × (δ ⊴ α)
-  P-closed-under-suprema : {I : 𝓤 ̇ } (F : I → Ordinal 𝓤)
-                         → ((i : I) → P (F i))
-                         → P (sup F)
-  P-closed-under-suprema {I} F ρ =
-   b₀ ,
-   transport⁻¹ (_⊴ α) (fact (sup F) ∙ ×ₒ-preserves-suprema pt sr β F) t ,
-   sup-is-lower-bound-of-upper-bounds F α (λ i → pr₂ (pr₂ (ρ i)))
-    where
-     t : sup (λ i → β ×ₒ F i) ⊴ α
-     t = sup-is-lower-bound-of-upper-bounds _ α s
-      where
-       s : (i : I) → β ×ₒ F i ⊴ α
-       s i = ⊴-trans (β ×ₒ F i) (β ×ₒ F i +ₒ (β ↓ bᵢ)) α (+ₒ-left-⊴ (β ×ₒ F i) (β ↓ bᵢ)) (pr₁ (pr₂ (ρ i)))
-        where
-         bᵢ : ⟨ β ⟩
-         bᵢ = pr₁ (ρ i)
-  P-antitone : (α₁ α₂ : Ordinal 𝓤) → α₁ ⊴ α₂ → P α₂ → P α₁
-  P-antitone α₁ α₂ k (b , l , m) = b₀ , transport⁻¹ (_⊴ α) (fact α₁) t , ⊴-trans α₁ α₂ α k m
-   where
-    t : β ×ₒ α₁ ⊴ α
-    t = ⊴-trans (β ×ₒ α₁) (β ×ₒ α₂) α (×ₒ-right-monotone-⊴ β α₁ α₂ k) (⊴-trans (β ×ₒ α₂) (β ×ₒ α₂ +ₒ (β ↓ b)) α (+ₒ-left-⊴ (β ×ₒ α₂) (β ↓ b)) l)
-  P-bounded : Σ ε ꞉ Ordinal 𝓤 , ((δ : Ordinal 𝓤) → P δ → δ ⊴ ε)
-  P-bounded = α , (λ δ p → pr₂ (pr₂ p))
-  open greatest-element-satisfying-predicate P P-closed-under-suprema P-antitone P-bounded
--}
-
-{-
-open import UF.Subsingletons-FunExt
-experiment : (P : 𝓤 ̇ ) → is-prop P → Ordinal 𝓤
-experiment {𝓤} P P-is-prop = γ
- where
-  Pₒ ¬Pₒ α β : Ordinal 𝓤
-  Pₒ = prop-ordinal P P-is-prop
-  ¬Pₒ = prop-ordinal (¬ P) (negations-are-props fe')
-  α = 𝟚ₒ{𝓤} ×ₒ Pₒ +ₒ ¬Pₒ
-  β = 𝟚ₒ{𝓤}
-  β-pos : 𝟘ₒ ⊲ β
-  β-pos = inl ⋆ , (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆)
-  γ =  pr₁ (approximate-division α β β-pos)
-  bit : 𝟙 + 𝟙
-  bit = pr₁ (pr₁ (pr₂ (approximate-division α β β-pos)))
-  I : ¬ P → bit ＝ inr ⋆
-  I ν = {!!}
-   where
-    e : α ＝ 𝟙ₒ
-    e = {!!}
-    fact : 𝟘ₒ greatest-satisfying (λ - → Σ b ꞉ ⟨ β ⟩ , (β ×ₒ - +ₒ (β ↓ b) ⊴ α) × (- ⊴ α))
-    fact = ((inr ⋆) , ({!-- OK using e!} , {!-- OK using e!})) , fact'
-     where
-      fact' : (α₁ : Ordinal 𝓤) →
-                Sigma (Underlying.⟨ underlying-type-of-ordinal ⟩ β)
-                (λ b → β ×ₒ α₁ +ₒ (β ↓ b) ⊴ α × α₁ ⊴ α) →
-                α₁ ⊴ 𝟘ₒ
-      fact' δ (b , k , l) = {!-- OK as δ must be empty by k and e!}
-    foo : γ ⊴ 𝟘ₒ
-    foo = pr₂ fact γ (pr₁ ((pr₂ (approximate-division α β β-pos))))
--}
+ open Enderton (α ^ₒ_) 𝟙ₒ β β-pos (^ₒ-satisfies-strong-sup-specification α _)
 
 \end{code}

--- a/source/Ordinals/Exponentiation/Paper.lagda
+++ b/source/Ordinals/Exponentiation/Paper.lagda
@@ -140,7 +140,7 @@ Eq-3 I F y = ∥∥-functor h
 
 Lemma-2 : (α : Ordinal 𝓤)
         → ((β γ : Ordinal 𝓥) → β ⊴ γ → α ×ₒ β ⊴ α ×ₒ γ)
-        × ({I : 𝓤 ̇  } (F : I → Ordinal 𝓤) → α ×ₒ sup F ＝ sup (λ i → α ×ₒ F i))
+        × ((I : 𝓤 ̇ ) (F : I → Ordinal 𝓤) → α ×ₒ sup F ＝ sup (λ i → α ×ₒ F i))
 Lemma-2 α = ×ₒ-right-monotone-⊴ α , ×ₒ-preserves-suprema pt sr α
 
 Eq-double-dagger : (Ordinal 𝓤 → Ordinal 𝓤 → Ordinal 𝓤) → 𝓤 ⁺ ̇

--- a/source/Ordinals/Exponentiation/Supremum.lagda
+++ b/source/Ordinals/Exponentiation/Supremum.lagda
@@ -451,7 +451,7 @@ product into the supremum.
    F = cases (λ _ → γ) (λ b → γ ×ₒ α ^ₒ (β ↓ b) ×ₒ α)
 
    I   = ap (γ ×ₒ_) (^ₒ-behaviour α β)
-   II  = ×ₒ-preserves-suprema pt sr γ (^ₒ-family α β)
+   II  = ×ₒ-preserves-suprema pt sr γ _ (^ₒ-family α β)
    III = ap sup (dfunext fe' h)
     where
      h : (λ - → γ ×ₒ ^ₒ-family α β -) ∼ F

--- a/source/Ordinals/MultiplicationProperties.lagda
+++ b/source/Ordinals/MultiplicationProperties.lagda
@@ -1,7 +1,7 @@
 Fredrik Nordvall Forsberg, 13 November 2023.
 In collaboration with Tom de Jong, Nicolai Kraus and Chuangjie Xu.
 
-Minor updates 9 and 11 September, and 1 November 2024.
+Minor updates 9 and 11 September, 1 November 2024 and 15 July 2025.
 
 We prove several properties of ordinal multiplication, including that it
 preserves suprema of ordinals and that it enjoys a left-cancellation property.
@@ -34,13 +34,14 @@ private
 open import MLTT.Spartan
 open import MLTT.Plus-Properties
 
+open import Ordinals.AdditionProperties ua
 open import Ordinals.Arithmetic fe
 open import Ordinals.Equivalence
 open import Ordinals.Maps
 open import Ordinals.OrdinalOfOrdinals ua
+open import Ordinals.Propositions ua
 open import Ordinals.Type
 open import Ordinals.Underlying
-open import Ordinals.AdditionProperties ua
 
 ×ₒ-𝟘ₒ-right : (α : Ordinal 𝓤) → α ×ₒ 𝟘ₒ {𝓥} ＝ 𝟘ₒ
 ×ₒ-𝟘ₒ-right α = ⊴-antisym _ _
@@ -307,9 +308,9 @@ module _ (pt : propositional-truncations-exist)
  open suprema pt sr
  open PropositionalTruncation pt
 
- ×ₒ-preserves-suprema : (α : Ordinal 𝓤) {I : 𝓤 ̇ } (β : I → Ordinal 𝓤)
+ ×ₒ-preserves-suprema : (α : Ordinal 𝓤) (I : 𝓤 ̇ ) (β : I → Ordinal 𝓤)
                       → α ×ₒ sup β ＝ sup (λ i → α ×ₒ β i)
- ×ₒ-preserves-suprema {𝓤} α {I} β = ⊴-antisym (α ×ₒ sup β) (sup (λ i → α ×ₒ β i)) ⦅1⦆ ⦅2⦆
+ ×ₒ-preserves-suprema {𝓤} α I β = ⊴-antisym (α ×ₒ sup β) (sup (λ i → α ×ₒ β i)) ⦅1⦆ ⦅2⦆
   where
    ⦅2⦆ : sup (λ i → α ×ₒ β i) ⊴ (α ×ₒ sup β)
    ⦅2⦆ = sup-is-lower-bound-of-upper-bounds (λ i → α ×ₒ β i) (α ×ₒ sup β)
@@ -384,7 +385,7 @@ operation even though they are not constructively sufficient to define it.
  ×ₒ-recursive-equation : recursive-equation {𝓤} _×ₒ_
  ×ₒ-recursive-equation =
   successor-and-suprema-equations-give-recursive-equation
-    _×ₒ_ ×ₒ-successor (λ α _ β → ×ₒ-preserves-suprema α β)
+    _×ₒ_ ×ₒ-successor ×ₒ-preserves-suprema
 
  ×ₒ-is-uniquely-specified'
   : (_⊗_ : Ordinal 𝓤 → Ordinal 𝓤 → Ordinal 𝓤)
@@ -409,7 +410,7 @@ operation even though they are not constructively sufficient to define it.
   : ∃! _⊗_ ꞉ (Ordinal 𝓤 → Ordinal 𝓤 → Ordinal 𝓤) ,
      (successor-equation _⊗_) × (suprema-equation _⊗_)
  ×ₒ-is-uniquely-specified {𝓤} =
-  (_×ₒ_ , (×ₒ-successor , (λ α _ β → ×ₒ-preserves-suprema α β))) ,
+  (_×ₒ_ , (×ₒ-successor , ×ₒ-preserves-suprema)) ,
   (λ (_⊗_ , ⊗-succ , ⊗-sup) →
    to-subtype-＝
     (λ F → ×-is-prop (Π₂-is-prop fe'
@@ -1007,5 +1008,73 @@ simulation-product-decomposition-leftover-empty α β γ (a₀ , p) a e = II
 
   III : β ＝ γ ↓ c
   III = ×ₒ-left-cancellable α β (γ ↓ c) α-positive II
+
+\end{code}
+
+Added 15 July 2025 by Tom de Jong.
+
+\begin{code}
+
+×ₒ-as-large-as-right-factor-implies-EM
+ : ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β) → EM 𝓤
+×ₒ-as-large-as-right-factor-implies-EM  hyp P P-is-prop = IV (f (inr ⋆)) refl
+ where
+  Pₒ = prop-ordinal P P-is-prop
+  α = 𝟙ₒ +ₒ Pₒ
+  β = 𝟚ₒ
+  𝕗 : β ⊴ α ×ₒ β
+  𝕗 = hyp α β (inl ⋆ , (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆))
+  f = [ β , α ×ₒ β ]⟨ 𝕗 ⟩
+  f-is-sim : is-simulation β (α ×ₒ β) f
+  f-is-sim = [ β , α ×ₒ β ]⟨ 𝕗 ⟩-is-simulation
+
+  I : (p : P) → f (inr ⋆) ＝ (inr p , inl ⋆)
+  I p = ↓-lc (α ×ₒ β) (f (inr ⋆)) (inr p , inl ⋆) e
+   where
+    e = (α ×ₒ β) ↓ f (inr ⋆)            ＝⟨ e₁ ⟩
+        β ↓ inr ⋆                       ＝⟨ e₂ ⟩
+        𝟙ₒ                              ＝⟨ e₃ ⟩
+        α ↓ inr p                       ＝⟨ e₄ ⟩
+        α ×ₒ 𝟘ₒ +ₒ (α ↓ inr p)          ＝⟨ e₅ ⟩
+        α ×ₒ (β ↓ inl ⋆) +ₒ (α ↓ inr p) ＝⟨ ×ₒ-↓ α β ⁻¹ ⟩
+        (α ×ₒ β) ↓ (inr p , inl ⋆)      ∎
+     where
+      e₁ = (simulations-preserve-↓ β (α ×ₒ β) 𝕗 (inr ⋆)) ⁻¹
+      e₂ = +ₒ-↓-right ⋆ ⁻¹ ∙ ap (𝟙ₒ +ₒ_) 𝟙ₒ-↓ ∙ 𝟘ₒ-right-neutral 𝟙ₒ
+      e₃ = (𝟘ₒ-right-neutral 𝟙ₒ) ⁻¹
+           ∙ ap (𝟙ₒ +ₒ_) ((prop-ordinal-↓ P-is-prop p) ⁻¹) ∙ +ₒ-↓-right p
+      e₄ = (ap (_+ₒ (α ↓ inr p)) (×ₒ-𝟘ₒ-right α)
+           ∙ 𝟘ₒ-left-neutral (α ↓ inr p)) ⁻¹
+      e₅ = ap (λ - → α ×ₒ - +ₒ (α ↓ inr p)) (𝟙ₒ-↓ ⁻¹ ∙ +ₒ-↓-left ⋆)
+  II : (x : ⟨ α ⟩) → f (inr ⋆) ＝ (x , inr ⋆) → ¬ P
+  II x e p = +disjoint (ap pr₂ ((I p) ⁻¹ ∙ e))
+  III : f (inr ⋆) ≠ (inl ⋆ , inl ⋆)
+  III h = +disjoint (simulations-are-lc β (α ×ₒ β) f f-is-sim (e ∙ h ⁻¹))
+   where
+    e : f (inl ⋆) ＝ (inl ⋆ , inl ⋆)
+    e = simulations-preserve-least
+         β (α ×ₒ β) (inl ⋆) (inl ⋆ , inl ⋆) f f-is-sim
+         β-least
+         (×ₒ-least α β (inl ⋆) (inl ⋆) (+ₒ-least 𝟙ₒ Pₒ ⋆ 𝟙ₒ-least) β-least)
+     where
+      β-least : is-least β (inl ⋆)
+      β-least = +ₒ-least 𝟙ₒ 𝟙ₒ ⋆ 𝟙ₒ-least
+  IV : (x : ⟨ α ×ₒ β ⟩) → f (inr ⋆) ＝ x → P + ¬ P
+  IV (inl ⋆ , inl ⋆) e = 𝟘-elim (III e)
+  IV (inr p , inl ⋆) e = inl p
+  IV (inl ⋆ , inr ⋆) e = inr (II (inl ⋆) e)
+  IV (inr p , inr ⋆) e = inl p
+
+EM-implies-×ₒ-as-large-as-right-factor
+ : EM 𝓤
+ → (α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β
+EM-implies-×ₒ-as-large-as-right-factor em α β (a₀ , _) =
+ ≼-gives-⊴ β (α ×ₒ β)
+             (EM-implies-order-preserving-gives-≼ em β (α ×ₒ β) (f , I))
+  where
+   f : ⟨ β ⟩ → ⟨ α ×ₒ β ⟩
+   f b = (a₀ , b)
+   I : is-order-preserving β (α ×ₒ β) f
+   I b b' l = inl l
 
 \end{code}

--- a/source/Ordinals/Propositions.lagda
+++ b/source/Ordinals/Propositions.lagda
@@ -65,6 +65,9 @@ prop-ordinal-least : {P : 𝓤 ̇  } (i : is-prop P) (p : P)
                    → is-least (prop-ordinal P i) p
 prop-ordinal-least i p p' p'' l = 𝟘-elim l
 
+𝟙ₒ-least : {x : 𝟙 {𝓤}} → is-least 𝟙ₒ x
+𝟙ₒ-least = prop-ordinal-least 𝟙-is-prop _
+
 𝟙ₒ-↓ : {x : 𝟙 {𝓤}} → 𝟙ₒ ↓ x ＝ 𝟘ₒ
 𝟙ₒ-↓ {𝓤} {x} = prop-ordinal-↓ 𝟙-is-prop x
 

--- a/source/Ordinals/index.lagda
+++ b/source/Ordinals/index.lagda
@@ -8,6 +8,7 @@ module Ordinals.index where
 
 import Ordinals.Arithmetic
 import Ordinals.AdditionProperties
+import Ordinals.BoundedOperations             -- by [2]
 import Ordinals.Brouwer
 import Ordinals.BuraliForti                   -- by [1]
 import Ordinals.Closure


### PR DESCRIPTION
The main addition is the file `Ordinals/BoundedOperations.lagda`. See the comments throughout that file for a description.

En passant, I also show that both
* ((α β : Ordinal 𝓤) → 𝟘ₒ ⊲ α → β ⊴ α ×ₒ β) and
* ((α β : Ordinal 𝓤) → β ⊴ α +ₒ β)

are equivalent to EM 𝓤.

NB. We already had that EM 𝓤 is equivalent to ((α β : Ordinal 𝓤) → 𝟙ₒ ⊲ α → β ⊴ α ^ₒ β).