### PR TITLE
Adding a file which states type replacement 

### DIFF
--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -1,7 +1,8 @@
 Ian Ray, 17th August 2025.
 
 The type theoretic axiom of replacement (see section 2.19 of Symmetry:
-chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://unimath.github.io/SymmetryBook/book.pdf) is a statement about the size of the image of a function when certain
+chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://unimath.github.io/SymmetryBook/book.pdf)
+is a statement about the size of the image of a function when certain
 smallness assumptions are made about the domain and codomain. The nomenclature
 is derived from the axiom of replacement from axiomatic set theory. In type
 theory, this statement may be assumed or proven depending on the context. Thus,

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -23,9 +23,8 @@ in other TypeTopology files.
 
 It is worth noting that the status of type replacement in the hierarchy of HIT
 strength is not completely understood (afaik), but it appears to be weaker than
-the assumption that pushouts exist. For this reason, we feel it is reasonable to
-explore type replacement as an explicit assumption and derive variations for
-future use.
+the assumption that pushouts exist. For this reason, it is reasonable to explore
+type replacement as an explicit assumption and derive variations for future use.
 
 \begin{code}
 

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -31,7 +31,7 @@ It is worth noting that the status of type replacement in the hierarchy of HIT
 strength is not completely understood, but it appears to be weaker than the
 assumption that pushouts exist (this observation will follow from a forthcoming
 write up by Reid Barton). In light of this, it is reasonable to explore type
-replacement and use it as an indepent assumption when neccesary.
+replacement and use it as an independent assumption when neccesary.
 
 \begin{code}
 

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -1,0 +1,79 @@
+Ian Ray, 17th August 2025.
+
+The type theoretic axiom of replacement (reference) is a statement about the
+size of the image of a function with certain smallness assumptions made about
+the domain and codomain. The nomenclature is derived from the axiom of
+replacement from (ZFC) set theory. We will simply call this statement
+'type replacement' because it may be assumed or it may be proven depending on
+the context.
+
+The statement of type replacement follows:
+The image of a map f : A → X, from a small type A to a locally smally type X,
+is itself small.
+
+Type replacement is provable in the presence of a certain class of higher
+inductive types (HITs). In particular, "The Join Construction" by Egbert Rijke
+(https://arxiv.org/abs/1701.07538.) provides a construction that permits a proof
+of type replacement in the presence of 'graph quotients'. More conservativly one
+can carry out the construction merely with pushouts (in fact one only requires
+the join of maps and sequential colimits). This route is activly being explored
+in other TypeTopology files.
+
+It is worth noting that the status of type replacement in the hierarchy of HIT
+strength is not completely understood (afaik) but it appears to be weaker than
+the assumption that pushouts exist. For this reason we feel it is reasonable to
+explore type replacement as an explicit assumption and derive variations for
+future use.
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K #-}
+
+open import UF.FunExt
+open import UF.PropTrunc
+
+module UF.Replacement (fe : Fun-Ext)
+                      (pt : propositional-truncations-exist)
+                       where
+
+open import MLTT.Spartan
+open import UF.ImageAndSurjection pt
+open import UF.Size
+
+\end{code}
+
+We begin by giving a precise statement of type replacement.
+
+\begin{code}
+
+module _ {𝓤 𝓥  𝓦 : Universe} where
+
+ Replacement : (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
+ Replacement = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
+             → A is 𝓥 small
+             → X is-locally 𝓥 small
+             → image f is 𝓥 small
+
+\end{code}
+
+We can also give a variation of this statement when f is surjective.
+
+\begin{code}
+
+ Replacement' : (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
+ Replacement' = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
+              → A is 𝓥 small
+              → X is-locally 𝓥 small
+              → is-surjection f
+              → X is 𝓥 small
+
+\end{code}
+
+Of course the two statements are inter-derivable.
+
+\begin{code}
+
+ Replacement-to-Replacement' : Replacement → Replacement' 
+ Replacement-to-Replacement' = {!!}
+
+\end{code}

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -1,30 +1,37 @@
 Ian Ray, 17th August 2025.
 
-The type theoretic axiom of replacement (see section 2.19 of Symmetry:
-chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://unimath.github.io/SymmetryBook/book.pdf)
+The type theoretic axiom of replacement (see section 24.5 of Introduction to
+Homotopy Type Theory by Egbert Rijke:
+chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://ulrikbuchholtz.dk/hott1920/hott-intro.pdf)
 is a statement about the size of the image of a function when certain smallness
-assumptions are made about the domain and codomain. The nomenclature is derived
-from the axiom of replacement from axiomatic set theory. In type theory, this
-statement may be assumed or proven depending on the context. Thus, we will call
-it 'type replacement' or simply 'replacement' (when there is no risk of
-confusion with set replacement).
+assumptions are imposed on the domain and codomain. The nomenclature is derived
+from the set theoretic axiom of replacement, where 'sethood' provides a notion
+of size. In type theory, this statement may be assumed or proven depending on
+the context. Thus, we will call it 'type replacement' or simply 'replacement'
+(when there is no risk of confusion with set replacement).
 
 The statement of type replacement is as follows:
 The image of a map f : A → X, from a small type A to a locally small type X, is
 itself small.
+
+Note: some authors use the term 'essentially small' for what the TypeTopology
+refers to as simply 'small'. Although, often times it is desirable to explicitly
+state the universe with which a type is small relative to, as you will see in
+the code below.
 
 Type replacement is provable in the presence of a certain class of higher
 inductive types (HITs). In particular, "The Join Construction" by Egbert Rijke
 (https://arxiv.org/abs/1701.07538.) provides a construction that allows a proof
 of type replacement in the presence of 'graph quotients'. More conservativly one
 may carry out this construction merely with pushouts (in fact, one only requires
-the join of maps and sequential colimits). This route is actively being explored
-in other TypeTopology files.
+the join of maps and sequential colimits, which are instances of pushouts).
+This route is actively being explored in other TypeTopology files.
 
 It is worth noting that the status of type replacement in the hierarchy of HIT
-strength is not completely understood (afaik), but it appears to be weaker than
-the assumption that pushouts exist. For this reason, it is reasonable to explore
-type replacement as an explicit assumption and derive variations for future use.
+strength is not completely understood, but it appears to be weaker than the
+assumption that pushouts exist (this observation will follow from a forthcoming
+write up by Reid Barton). In light of this, it is reasonable to explore type
+replacement and use it as an indepent assumption when neccesary.
 
 \begin{code}
 
@@ -52,9 +59,9 @@ module _ {𝓥 : Universe} where
 
  Replacement : {𝓤 𝓦 : Universe} → (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
  Replacement {𝓤} {𝓦} = {A : 𝓤 ̇ } {X : 𝓦 ̇ } (f : A → X)
-             → A is 𝓥 small
-             → X is-locally 𝓥 small
-             → image f is 𝓥 small
+                     → A is 𝓥 small
+                     → X is-locally 𝓥 small
+                     → image f is 𝓥 small
 
 \end{code}
 

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -2,12 +2,12 @@ Ian Ray, 17th August 2025.
 
 The type theoretic axiom of replacement (see section 2.19 of Symmetry:
 chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://unimath.github.io/SymmetryBook/book.pdf)
-is a statement about the size of the image of a function when certain
-smallness assumptions are made about the domain and codomain. The nomenclature
-is derived from the axiom of replacement from axiomatic set theory. In type
-theory, this statement may be assumed or proven depending on the context. Thus,
-we will call it 'type replacement' or simply 'replacement' (when there is no
-risk of confusion with set replacement).
+is a statement about the size of the image of a function when certain smallness
+assumptions are made about the domain and codomain. The nomenclature is derived
+from the axiom of replacement from axiomatic set theory. In type theory, this
+statement may be assumed or proven depending on the context. Thus, we will call
+it 'type replacement' or simply 'replacement' (when there is no risk of
+confusion with set replacement).
 
 The statement of type replacement is as follows:
 The image of a map f : A → X, from a small type A to a locally small type X, is

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -30,13 +30,9 @@ future use.
 
 {-# OPTIONS --safe --without-K #-}
 
-open import UF.FunExt
 open import UF.PropTrunc
-open import UF.Univalence
 
-module UF.Replacement (fe : Fun-Ext)
-                      (pt : propositional-truncations-exist)
-                      (ua : Univalence)
+module UF.Replacement (pt : propositional-truncations-exist)
                        where
 
 open import MLTT.Spartan
@@ -45,7 +41,6 @@ open import UF.EquivalenceExamples
 open import UF.ImageAndSurjection pt
 open import UF.Size
 open import UF.SmallnessProperties
-open import UF.UniverseEmbedding
 
 \end{code}
 
@@ -81,7 +76,7 @@ Of course the two statements are inter-derivable.
 \begin{code}
 
  Replacement-to-Replacement' : {𝓤 𝓦 : Universe}
-                             → Replacement → Replacement' {𝓤} {𝓦}
+                             → Replacement {𝓤} {𝓦} → Replacement' {𝓤} {𝓦}
  Replacement-to-Replacement' 𝓡 {_} {X} f A-small X-loc-small f-surj
   = smallness-closed-under-≃ I II
   where
@@ -92,24 +87,13 @@ Of course the two statements are inter-derivable.
 
  open propositional-truncations-exist pt
 
- Replacement'-to-Replacement : Replacement' → Replacement {𝓤} {𝓦}
+ Replacement'-to-Replacement : {𝓤 𝓦 : Universe}
+                             → Replacement' {𝓤} {𝓤 ⊔ 𝓦} → Replacement {𝓤} {𝓦}
  Replacement'-to-Replacement 𝓡' {A} {X} f A-small X-loc-small
   = 𝓡' (corestriction f) A-small I II
   where
    I : image f is-locally 𝓥 small
-   I x y = smallness-closed-under-≃'
-            (Σ-is-small (X-loc-small (restriction f x) (restriction f y))
-             {!!}) Σ-＝-≃
-    where
-     III : (p : restriction f x ＝ restriction f y)
-         → (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y) is 𝓥 small
-     III p = ∥∥-rec
-      (being-small-is-prop ua (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y)
-       𝓥) {!!} (pr₂ y)
-      where
-       IV : Σ (λ x₁ → f x₁ ＝ pr₁ y)
-          → (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y) is 𝓥 small
-       IV (a , q) = {!!}
+   I = subtype-is-locally-small' X-loc-small (λ - → ∥∥-is-prop)
    II : is-surjection (corestriction f)
    II = corestrictions-are-surjections f
 

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -1,27 +1,28 @@
 Ian Ray, 17th August 2025.
 
-The type theoretic axiom of replacement (reference) is a statement about the
-size of the image of a function with certain smallness assumptions made about
-the domain and codomain. The nomenclature is derived from the axiom of
-replacement from (ZFC) set theory. We will simply call this statement
-'type replacement' because it may be assumed or it may be proven depending on
-the context.
+The type theoretic axiom of replacement (see section 2.19 of Symmetry:
+chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://unimath.github.io/SymmetryBook/book.pdf) is a statement about the size of the image of a function when certain
+smallness assumptions are made about the domain and codomain. The nomenclature
+is derived from the axiom of replacement from axiomatic set theory. In type
+theory, this statement may be assumed or proven depending on the context. Thus,
+we will call it 'type replacement' or simply 'replacement' (when there is no
+risk of confusion with set replacement).
 
-The statement of type replacement follows:
-The image of a map f : A → X, from a small type A to a locally smally type X,
-is itself small.
+The statement of type replacement is as follows:
+The image of a map f : A → X, from a small type A to a locally small type X, is
+itself small.
 
 Type replacement is provable in the presence of a certain class of higher
 inductive types (HITs). In particular, "The Join Construction" by Egbert Rijke
-(https://arxiv.org/abs/1701.07538.) provides a construction that permits a proof
+(https://arxiv.org/abs/1701.07538.) provides a construction that allows a proof
 of type replacement in the presence of 'graph quotients'. More conservativly one
-can carry out the construction merely with pushouts (in fact one only requires
-the join of maps and sequential colimits). This route is activly being explored
+may carry out this construction merely with pushouts (in fact, one only requires
+the join of maps and sequential colimits). This route is actively being explored
 in other TypeTopology files.
 
 It is worth noting that the status of type replacement in the hierarchy of HIT
-strength is not completely understood (afaik) but it appears to be weaker than
-the assumption that pushouts exist. For this reason we feel it is reasonable to
+strength is not completely understood (afaik), but it appears to be weaker than
+the assumption that pushouts exist. For this reason, we feel it is reasonable to
 explore type replacement as an explicit assumption and derive variations for
 future use.
 
@@ -31,14 +32,20 @@ future use.
 
 open import UF.FunExt
 open import UF.PropTrunc
+open import UF.Univalence
 
 module UF.Replacement (fe : Fun-Ext)
                       (pt : propositional-truncations-exist)
+                      (ua : Univalence)
                        where
 
 open import MLTT.Spartan
+open import UF.Equiv
+open import UF.EquivalenceExamples
 open import UF.ImageAndSurjection pt
 open import UF.Size
+open import UF.SmallnessProperties
+open import UF.UniverseEmbedding
 
 \end{code}
 
@@ -46,10 +53,10 @@ We begin by giving a precise statement of type replacement.
 
 \begin{code}
 
-module _ {𝓤 𝓥  𝓦 : Universe} where
+module _ {𝓥 : Universe} where
 
- Replacement : (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
- Replacement = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
+ Replacement : {𝓤 𝓦 : Universe} → (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
+ Replacement {𝓤} {𝓦} = {A : 𝓤 ̇ } {X : 𝓦 ̇ } (f : A → X)
              → A is 𝓥 small
              → X is-locally 𝓥 small
              → image f is 𝓥 small
@@ -60,12 +67,12 @@ We can also give a variation of this statement when f is surjective.
 
 \begin{code}
 
- Replacement' : (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
- Replacement' = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
-              → A is 𝓥 small
-              → X is-locally 𝓥 small
-              → is-surjection f
-              → X is 𝓥 small
+ Replacement' : {𝓤 𝓦 : Universe} → (𝓤 ⁺) ⊔ (𝓥 ⁺) ⊔ (𝓦 ⁺) ̇
+ Replacement' {𝓤} {𝓦} = {A : 𝓤 ̇ } {X : 𝓦 ̇ } (f : A → X)
+                      → A is 𝓥 small
+                      → X is-locally 𝓥 small
+                      → is-surjection f
+                      → X is 𝓥 small
 
 \end{code}
 
@@ -73,7 +80,37 @@ Of course the two statements are inter-derivable.
 
 \begin{code}
 
- Replacement-to-Replacement' : Replacement → Replacement' 
- Replacement-to-Replacement' = {!!}
+ Replacement-to-Replacement' : {𝓤 𝓦 : Universe}
+                             → Replacement → Replacement' {𝓤} {𝓦}
+ Replacement-to-Replacement' 𝓡 {_} {X} f A-small X-loc-small f-surj
+  = smallness-closed-under-≃ I II
+  where
+   I : image f is 𝓥 small
+   I = 𝓡 f A-small X-loc-small
+   II : image f ≃ X
+   II = surjection-≃-image f f-surj
+
+ open propositional-truncations-exist pt
+
+ Replacement'-to-Replacement : Replacement' → Replacement {𝓤} {𝓦}
+ Replacement'-to-Replacement 𝓡' {A} {X} f A-small X-loc-small
+  = 𝓡' (corestriction f) A-small I II
+  where
+   I : image f is-locally 𝓥 small
+   I x y = smallness-closed-under-≃'
+            (Σ-is-small (X-loc-small (restriction f x) (restriction f y))
+             {!!}) Σ-＝-≃
+    where
+     III : (p : restriction f x ＝ restriction f y)
+         → (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y) is 𝓥 small
+     III p = ∥∥-rec
+      (being-small-is-prop ua (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y)
+       𝓥) {!!} (pr₂ y)
+      where
+       IV : Σ (λ x₁ → f x₁ ＝ pr₁ y)
+          → (transport (λ - → - ∈image f) p (pr₂ x) ＝ pr₂ y) is 𝓥 small
+       IV (a , q) = {!!}
+   II : is-surjection (corestriction f)
+   II = corestrictions-are-surjections f
 
 \end{code}

--- a/source/UF/Replacement.lagda
+++ b/source/UF/Replacement.lagda
@@ -1,8 +1,8 @@
 Ian Ray, 17th August 2025.
 
-The type theoretic axiom of replacement (see section 24.5 of Introduction to
+The type theoretic axiom of replacement (section 24.5 of Introduction to
 Homotopy Type Theory by Egbert Rijke:
-chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://ulrikbuchholtz.dk/hott1920/hott-intro.pdf)
+https://ulrikbuchholtz.dk/hott1920/hott-intro.pdf)
 is a statement about the size of the image of a function when certain smallness
 assumptions are imposed on the domain and codomain. The nomenclature is derived
 from the set theoretic axiom of replacement, where 'sethood' provides a notion

--- a/source/UF/Size-TruncatedConnected.lagda
+++ b/source/UF/Size-TruncatedConnected.lagda
@@ -63,22 +63,22 @@ being-locally-small-is-prop : {X : 𝓤 ̇ } {n : ℕ}
                             → Univalence
                             → is-prop (X is n locally-small)
 being-locally-small-is-prop {_} {X} {zero} ua = being-small-is-prop ua X 𝓥
-being-locally-small-is-prop {_} {X} {succ n} ua =
- Π₂-is-prop fe (λ x y → being-locally-small-is-prop ua)
+being-locally-small-is-prop {_} {X} {succ n} ua
+ = Π₂-is-prop fe (λ x y → being-locally-small-is-prop ua)
 
 being-locally-small-is-upper-closed : {X : 𝓤 ̇ } {n : ℕ}
                                     → X is n locally-small
                                     → X is (succ n) locally-small
 being-locally-small-is-upper-closed {_} {X} {zero} = small-implies-locally-small X 𝓥
-being-locally-small-is-upper-closed {_} {X} {succ n} X-loc-small x x' =
- being-locally-small-is-upper-closed (X-loc-small x x')
+being-locally-small-is-upper-closed {_} {X} {succ n} X-loc-small x x'
+ = being-locally-small-is-upper-closed (X-loc-small x x')
 
 locally-small-types-are-small : {X : 𝓤 ̇ } {n : ℕ}
                               → X is 𝓥 small
                               → X is n locally-small
 locally-small-types-are-small {_} {_} {zero} X-small = X-small
-locally-small-types-are-small {_} {X} {succ n} X-small x x' =
- locally-small-types-are-small (small-implies-locally-small X 𝓥 X-small x x')
+locally-small-types-are-small {_} {X} {succ n} X-small x x'
+ = locally-small-types-are-small (small-implies-locally-small X 𝓥 X-small x x')
 
 \end{code}
 
@@ -91,8 +91,8 @@ local-smallness-is-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {n : ℕ}
                                   → X ≃ Y
                                   → X is n locally-small
                                   → Y is n locally-small
-local-smallness-is-closed-under-≃ {_} {_} {_} {_} {zero} e X-small =
- smallness-closed-under-≃ X-small e
+local-smallness-is-closed-under-≃ {_} {_} {_} {_} {zero} e X-small
+ = smallness-closed-under-≃ X-small e
 local-smallness-is-closed-under-≃ {_} {_} {_} {_} {succ n} e X-loc-small y y' =
  local-smallness-is-closed-under-≃ path-equiv (X-loc-small (⌜ e ⌝⁻¹ y) (⌜ e ⌝⁻¹ y'))
  where
@@ -103,13 +103,13 @@ local-smallness-is-closed-under-Σ : {X : 𝓤 ̇ } {Y : X → 𝓦 ̇ } {n : �
                                   → X is n locally-small
                                   → ((x : X) → (Y x) is n locally-small)
                                   → (Σ x ꞉ X , Y x) is n locally-small
-local-smallness-is-closed-under-Σ {_} {_} {_} {_} {zero} X-small Y-small =
- Σ-is-small X-small Y-small
+local-smallness-is-closed-under-Σ {_} {_} {_} {_} {zero} X-small Y-small
+ = Σ-is-small X-small Y-small
 local-smallness-is-closed-under-Σ {_} {_} {_} {Y} {succ n}
- X-loc-small Y-loc-small (x , y) (x' , y') =
- local-smallness-is-closed-under-≃ (≃-sym Σ-＝-≃)
-  (local-smallness-is-closed-under-Σ (X-loc-small x x')
-   (λ - → Y-loc-small x' (transport Y - y) y'))
+ X-loc-small Y-loc-small (x , y) (x' , y')
+ = local-smallness-is-closed-under-≃ (≃-sym Σ-＝-≃)
+    (local-smallness-is-closed-under-Σ (X-loc-small x x')
+     (λ - → Y-loc-small x' (transport Y - y) y'))
 
 open general-truncations-exist te
 
@@ -117,15 +117,15 @@ local-smallness-is-closed-under-truncation : {X : 𝓤 ̇ } {n : ℕ₋₂}
                                            → Univalence
                                            → X is ι (n + 2) locally-small
                                            → ∥ X ∥[ n ] is ι (n + 2) locally-small
-local-smallness-is-closed-under-truncation {_} {X} {−2} ua =
- truncations-of-small-types-are-small
-local-smallness-is-closed-under-truncation {_} {X} {succ n} ua X-loc-small =
- ∥∥ₙ-ind₂ (λ u v → (u ＝ v) is ι (n + 2) locally-small)
-          (λ u v → truncation-levels-are-upper-closed' ⋆
-                    (is-prop-implies-is-prop' (being-locally-small-is-prop ua)))
-          (λ x y → local-smallness-is-closed-under-≃
-                    (eliminated-trunc-identity-char (ua _))
-                   (local-smallness-is-closed-under-truncation ua (X-loc-small x y)))
+local-smallness-is-closed-under-truncation {_} {X} {−2} ua
+ = truncations-of-small-types-are-small
+local-smallness-is-closed-under-truncation {_} {X} {succ n} ua X-loc-small
+ = ∥∥ₙ-ind₂ (λ u v → (u ＝ v) is ι (n + 2) locally-small)
+            (λ u v → truncation-levels-are-upper-closed' ⋆
+                      (is-prop-implies-is-prop' (being-locally-small-is-prop ua)))
+            (λ x y → local-smallness-is-closed-under-≃
+                      (eliminated-trunc-identity-char (ua _))
+                      (local-smallness-is-closed-under-truncation ua (X-loc-small x y)))
 
 \end{code}
 
@@ -172,20 +172,19 @@ Prop 2.2 of [1]
 
 open PropositionalTruncation pt
 
-module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
+module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
 
  Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
   : {𝓤 𝓦 : Universe} {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X} {n : ℕ₋₂}
-  → Univalence
   → f is n connected-map
   → A is 𝓥 small
   → X is ι (n + 2) locally-small
   → X is 𝓥 small
  Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-  {_} {_} {_} {_} {_} {−2} ua f-con A-small X-small = X-small
+  {_} {_} {_} {_} {_} {−2} f-con A-small X-small = X-small
  Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-  {𝓤} {𝓦} {A} {X} {f} {succ n} ua f-con A-small X-is-loc-small =
-  rep A-small (III (−1-connected-maps-are-surjections I)) I
+  {𝓤} {𝓦} {A} {X} {f} {succ n} f-con A-small X-is-loc-small
+  = rep A-small (III (−1-connected-maps-are-surjections I)) I
   where
    I : f is −1 connected-map
    I = map-connectedness-is-lower-closed ⋆ f-con
@@ -193,11 +192,11 @@ module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
       → Σ a ꞉ A , f a ＝ x
       → Σ a ꞉ A , f a ＝ x'
       → (x ＝ x') is 𝓥 small
-   II .(f a) .(f a') (a , refl) (a' , refl) =
-    Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-     ua (ap-is-less-connected (ua (𝓤 ⊔ 𝓦)) f f-con)
-      (small-implies-locally-small A 𝓥 A-small a a')
-       (X-is-loc-small (f a) (f a'))
+   II .(f a) .(f a') (a , refl) (a' , refl)
+    = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+       (ap-is-less-connected (ua (𝓤 ⊔ 𝓦)) f f-con)
+        (small-implies-locally-small A 𝓥 A-small a a')
+         (X-is-loc-small (f a) (f a'))
    III : is-surjection f
        → (x x' : X)
        → (x ＝ x') is 𝓥 small
@@ -217,10 +216,10 @@ Lemma-2-3[truncated-types-are-locally-small] : {X : 𝓤 ̇ } {n : ℕ₋₂}
                                              → Propositional-Resizing
                                              → X is (n + 1) truncated
                                              → X is ι (n + 2) locally-small
-Lemma-2-3[truncated-types-are-locally-small] {_} {X} {−2} pr X-prop =
- pr X (is-prop'-implies-is-prop X-prop)
-Lemma-2-3[truncated-types-are-locally-small] {_} {_} {succ n} pr X-trunc x x' =
- Lemma-2-3[truncated-types-are-locally-small] pr (X-trunc x x')
+Lemma-2-3[truncated-types-are-locally-small] {_} {X} {−2} pr X-prop
+ = pr X (is-prop'-implies-is-prop X-prop)
+Lemma-2-3[truncated-types-are-locally-small] {_} {_} {succ n} pr X-trunc x x'
+ = Lemma-2-3[truncated-types-are-locally-small] pr (X-trunc x x')
 
 truncated-types-are-locally-small = Lemma-2-3[truncated-types-are-locally-small]
 
@@ -235,8 +234,8 @@ truncated-types-are-locally-small-gives-propositional-resizing
  : ({X : 𝓤 ̇ } {n : ℕ₋₂} → X is (n + 1) truncated → X is ι (n + 2) locally-small)
  → propositional-resizing 𝓤 𝓥
 truncated-types-are-locally-small-gives-propositional-resizing
- trunc-gives-loc-small P P-prop =
-  trunc-gives-loc-small {P} {−2} (is-prop-implies-is-prop' P-prop)
+ trunc-gives-loc-small P P-prop
+ = trunc-gives-loc-small {P} {−2} (is-prop-implies-is-prop' P-prop)
 
 \end{code}
 
@@ -251,13 +250,13 @@ Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
  → Y is ι (n + 2) locally-small
  → X is ι (n + 2) locally-small
 Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
- {_} {_} {_} {_} {f} {_} pr f-trunc Y-loc-small =
- local-smallness-is-closed-under-≃ (total-fiber-is-domain f)
-  (local-smallness-is-closed-under-Σ Y-loc-small
-   (λ y → Lemma-2-3[truncated-types-are-locally-small] pr (f-trunc y)))
+ {_} {_} {_} {_} {f} {_} pr f-trunc Y-loc-small
+ = local-smallness-is-closed-under-≃ (total-fiber-is-domain f)
+    (local-smallness-is-closed-under-Σ Y-loc-small
+     (λ y → Lemma-2-3[truncated-types-are-locally-small] pr (f-trunc y)))
 
-type-with-truncated-map-to-locally-small-type-is-locally-small =
- Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
+type-with-truncated-map-to-locally-small-type-is-locally-small
+ = Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
 
 \end{code}
 
@@ -265,19 +264,18 @@ Lemma 2.5 of [1]
 
 \begin{code}
 
-module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
+module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
 
  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
   : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
-  → Univalence
   → Propositional-Resizing
   → f is (n + 1) truncated-map
   → Y is ι (n + 2) locally-small
   → X is (n + 1) connected
   → X is 𝓥 small
  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
-  {𝓤} {_} {X} {_} {_} {n} ua pr f-trunc Y-loc-small X-conn =
-  ∥∥-rec (being-small-is-prop ua X 𝓥) VI (center II)
+  {𝓤} {_} {X} {_} {_} {n} pr f-trunc Y-loc-small X-conn
+  = ∥∥-rec (being-small-is-prop ua X 𝓥) VI (center II)
   where
    I : X is ι (n + 2) locally-small
    I = Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
@@ -292,10 +290,10 @@ module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
    V = pr 𝟙 𝟙-is-prop
    VI : X → X is 𝓥 small
    VI x = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-           rep ua (IV x) V I
+           ua rep (IV x) V I
 
- connected-type-with-truncated-map-to-locally-small-type-is-small =
-  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
+ connected-type-with-truncated-map-to-locally-small-type-is-small
+  = Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
 
 \end{code}
 
@@ -309,16 +307,15 @@ prove a few lemmas.
 
  small-path-space-from-locally-small-type-and-small-truncation
   : {X : 𝓤 ̇ } {n : ℕ₋₂}
-  → Univalence
   → X is ι (n + 2) locally-small
    × ∥ X ∥[ n + 1 ] is 𝓥 small
   → (Σ y ꞉ ∥ X ∥[ n + 1 ] , Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ y) is 𝓥 small
  small-path-space-from-locally-small-type-and-small-truncation
-  {𝓤} {X} {n} ua (X-loc-small , trunc-X-small) = Σ-is-small trunc-X-small IX
+  {𝓤} {X} {n} (X-loc-small , trunc-X-small) = Σ-is-small trunc-X-small IX
   where
    I : (x' : X) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is 𝓥 small
    I x' = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-           rep ua IV V VI
+           ua rep IV V VI
     where
      II : 𝟙 {𝓤} → Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]
      II ⋆ = (x' , refl)
@@ -345,14 +342,13 @@ prove a few lemmas.
 
  locally-small-type-with-small-truncation-is-small
   : {X : 𝓤 ̇ } {n : ℕ₋₂}
-  → Univalence
   → X is ι (n + 2) locally-small
     × ∥ X ∥[ n + 1 ] is 𝓥 small
   → X is 𝓥 small
- locally-small-type-with-small-truncation-is-small {_} {X} {n} ua small-hyp =
-  smallness-closed-under-≃'
-   (small-path-space-from-locally-small-type-and-small-truncation ua small-hyp)
-    (domain-is-total-fiber ∣_∣[ succ n ])
+ locally-small-type-with-small-truncation-is-small {_} {X} {n} small-hyp
+  = smallness-closed-under-≃'
+     (small-path-space-from-locally-small-type-and-small-truncation small-hyp)
+      (domain-is-total-fiber ∣_∣[ succ n ])
 
 \end{code}
 
@@ -362,12 +358,11 @@ Theorem 2.6 of [1]
 
  Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
   : {X : 𝓤 ̇ } {n : ℕ₋₂}
-  → Univalence
   → X is 𝓥 small
   ↔ X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
  Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
-  {_} {X} {n} ua =
-  (I , locally-small-type-with-small-truncation-is-small ua)
+  {_} {X} {n}
+  = (I , locally-small-type-with-small-truncation-is-small)
   where
    I : X is 𝓥 small
      → X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
@@ -384,13 +379,12 @@ We will record the following corollary of Theorem 2.6 from [1]:
 
 \begin{code}
 
- set-truncation-of-universe-is-large : Univalence
-                                     → is-large ∥ 𝓥 ̇ ∥[ 0 ]
- set-truncation-of-universe-is-large ua =
-  contrapositive I universes-are-large
+ set-truncation-of-universe-is-large : is-large ∥ 𝓥 ̇ ∥[ 0 ]
+ set-truncation-of-universe-is-large
+  = contrapositive I universes-are-large
   where
    I : is-small ∥ 𝓥 ̇ ∥[ 0 ] → is-small (𝓥 ̇ )
-   I small-trunc = locally-small-type-with-small-truncation-is-small ua
+   I small-trunc = locally-small-type-with-small-truncation-is-small
                     (universes-are-locally-small (ua 𝓥) , small-trunc)
 
 \end{code}
@@ -401,20 +395,19 @@ Corollary 2.7 of [1]
 
  Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
   : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
-  → Univalence
   → Propositional-Resizing
   → f is (n + 1) truncated-map
   → Y is ι (n + 2) locally-small
   → ∥ X ∥[ n + 1 ] is 𝓥 small
   → X is 𝓥 small
  Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
-  ua pr f-trunc Y-loc-small trunc-X-small =
-  locally-small-type-with-small-truncation-is-small ua
-   (Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
-    pr f-trunc Y-loc-small , trunc-X-small)
+  pr f-trunc Y-loc-small trunc-X-small
+  = locally-small-type-with-small-truncation-is-small
+     (Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
+      pr f-trunc Y-loc-small , trunc-X-small)
 
- type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small =
-  Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+ type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small
+  = Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
 
 \end{code}
 

--- a/source/UF/Size-TruncatedConnected.lagda
+++ b/source/UF/Size-TruncatedConnected.lagda
@@ -48,10 +48,10 @@ open import UF.Replacement pt
 
 \end{code}
 
-We begin by giving some definitions from [1] and proving important properties about
-them. We have fixed the universe parameter 𝓥 and use it as our point of reference
-for 'smallness'. Also, note that in what follows we only use univalence locally
-as some critical results hold in its absence.
+We begin by giving some definitions from [1] and proving important properties
+about them. We have fixed the universe parameter 𝓥 and use it as our point of
+reference for 'smallness'. Also, note that in what follows we will explicilty
+assume univalence as some critical results hold in its absence.
 
 \begin{code}
 
@@ -69,7 +69,8 @@ being-locally-small-is-prop {_} {X} {succ n} ua
 being-locally-small-is-upper-closed : {X : 𝓤 ̇ } {n : ℕ}
                                     → X is n locally-small
                                     → X is (succ n) locally-small
-being-locally-small-is-upper-closed {_} {X} {zero} = small-implies-locally-small X 𝓥
+being-locally-small-is-upper-closed {_} {X} {zero}
+ = small-implies-locally-small X 𝓥
 being-locally-small-is-upper-closed {_} {X} {succ n} X-loc-small x x'
  = being-locally-small-is-upper-closed (X-loc-small x x')
 
@@ -94,7 +95,8 @@ local-smallness-is-closed-under-≃ : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {n : ℕ}
 local-smallness-is-closed-under-≃ {_} {_} {_} {_} {zero} e X-small
  = smallness-closed-under-≃ X-small e
 local-smallness-is-closed-under-≃ {_} {_} {_} {_} {succ n} e X-loc-small y y' =
- local-smallness-is-closed-under-≃ path-equiv (X-loc-small (⌜ e ⌝⁻¹ y) (⌜ e ⌝⁻¹ y'))
+ local-smallness-is-closed-under-≃ path-equiv
+  (X-loc-small (⌜ e ⌝⁻¹ y) (⌜ e ⌝⁻¹ y'))
  where
   path-equiv : (⌜ e ⌝⁻¹ y ＝ ⌜ e ⌝⁻¹ y') ≃ (y ＝ y')
   path-equiv = ≃-sym (ap ⌜ e ⌝⁻¹ , ap-is-equiv ⌜ e ⌝⁻¹ (⌜⌝⁻¹-is-equiv e))
@@ -113,19 +115,20 @@ local-smallness-is-closed-under-Σ {_} {_} {_} {Y} {succ n}
 
 open general-truncations-exist te
 
-local-smallness-is-closed-under-truncation : {X : 𝓤 ̇ } {n : ℕ₋₂}
-                                           → Univalence
-                                           → X is ι (n + 2) locally-small
-                                           → ∥ X ∥[ n ] is ι (n + 2) locally-small
+local-smallness-is-closed-under-truncation
+ : {X : 𝓤 ̇ } {n : ℕ₋₂}
+ → Univalence
+ → X is ι (n + 2) locally-small
+ → ∥ X ∥[ n ] is ι (n + 2) locally-small
 local-smallness-is-closed-under-truncation {_} {X} {−2} ua
  = truncations-of-small-types-are-small
 local-smallness-is-closed-under-truncation {_} {X} {succ n} ua X-loc-small
  = ∥∥ₙ-ind₂ (λ u v → (u ＝ v) is ι (n + 2) locally-small)
             (λ u v → truncation-levels-are-upper-closed' ⋆
-                      (is-prop-implies-is-prop' (being-locally-small-is-prop ua)))
+             (is-prop-implies-is-prop' (being-locally-small-is-prop ua)))
             (λ x y → local-smallness-is-closed-under-≃
-                      (eliminated-trunc-identity-char (ua _))
-                      (local-smallness-is-closed-under-truncation ua (X-loc-small x y)))
+             (eliminated-trunc-identity-char (ua _))
+             (local-smallness-is-closed-under-truncation ua (X-loc-small x y)))
 
 \end{code}
 
@@ -135,9 +138,10 @@ X and a function f : A → X the image of f is small. In the paper 'the join
 construction' by Egbert Rijke, the axiom of replacement is shown to follow from
 the join construction. Interestingly, it seems that the assumptions neccesary to
 carry out the join construction are stronger than simply assuming replacement.
-In the interest of keeping the present work self contained and requiring only the
-weakest assumptions possible we simply assume the relevant form of replacement
-(globally) and show it is equivalent to the other phrasings of replacement.
+In the interest of keeping the present work self contained and requiring only
+the weakest assumptions possible we simply assume the relevant form of
+replacement (globally) and show it is equivalent to the other phrasings of
+replacement.
 
 \begin{code}
 
@@ -172,7 +176,9 @@ Prop 2.2 of [1]
 
 open PropositionalTruncation pt
 
-module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
+module _ (ua : Univalence)
+         (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦})
+       where
 
  Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
   : {𝓤 𝓦 : Universe} {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X} {n : ℕ₋₂}
@@ -264,7 +270,9 @@ Lemma 2.5 of [1]
 
 \begin{code}
 
-module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
+module _ (ua : Univalence)
+         (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦})
+       where
 
  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
   : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
@@ -289,8 +297,9 @@ module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤
    V : 𝟙 {𝓤} is 𝓥 small
    V = pr 𝟙 𝟙-is-prop
    VI : X → X is 𝓥 small
-   VI x = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-           ua rep (IV x) V I
+   VI x
+    = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+       ua rep (IV x) V I
 
  connected-type-with-truncated-map-to-locally-small-type-is-small
   = Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
@@ -299,9 +308,9 @@ module _ (ua : Univalence) (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤
 
 In [1] Christensen proves Theorem 2.6 with propositional resizing and without.
 In the presence of resizing Theorem 2.6 follows from previous results, but as
-we are interested in avoiding unnecessary use of propositional resizing, we choose
-to record the latter proof. It is a bit more involved, so we will first need to
-prove a few lemmas.
+we are interested in avoiding unnecessary use of propositional resizing, we
+choose to record the latter proof. It is a bit more involved, so we will first
+need to prove a few lemmas.
 
 \begin{code}
 
@@ -314,8 +323,9 @@ prove a few lemmas.
   {𝓤} {X} {n} (X-loc-small , trunc-X-small) = Σ-is-small trunc-X-small IX
   where
    I : (x' : X) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is 𝓥 small
-   I x' = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-           ua rep IV V VI
+   I x'
+    = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+       ua rep IV V VI
     where
      II : 𝟙 {𝓤} → Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]
      II ⋆ = (x' , refl)
@@ -325,7 +335,8 @@ prove a few lemmas.
      IV = basepoint-map-is-less-connected (ua _) II III
      V : 𝟙 {𝓤} is 𝓥 small
      V = (𝟙 {𝓥} , one-𝟙-only)
-     VI : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is ι (n + 2) locally-small
+     VI : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ])
+           is ι (n + 2) locally-small
      VI = local-smallness-is-closed-under-Σ X-loc-small VII
       where
        VII : (x : X)
@@ -380,8 +391,7 @@ We will record the following corollary of Theorem 2.6 from [1]:
 \begin{code}
 
  set-truncation-of-universe-is-large : is-large ∥ 𝓥 ̇ ∥[ 0 ]
- set-truncation-of-universe-is-large
-  = contrapositive I universes-are-large
+ set-truncation-of-universe-is-large = contrapositive I universes-are-large
   where
    I : is-small ∥ 𝓥 ̇ ∥[ 0 ] → is-small (𝓥 ̇ )
    I small-trunc = locally-small-type-with-small-truncation-is-small
@@ -393,21 +403,21 @@ Corollary 2.7 of [1]
 
 \begin{code}
 
- Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+ Corollary-2-7[type-with-small-truncation-truncated-map-to-locally-small-is-small]
   : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
   → Propositional-Resizing
   → f is (n + 1) truncated-map
   → Y is ι (n + 2) locally-small
   → ∥ X ∥[ n + 1 ] is 𝓥 small
   → X is 𝓥 small
- Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+ Corollary-2-7[type-with-small-truncation-truncated-map-to-locally-small-is-small]
   pr f-trunc Y-loc-small trunc-X-small
   = locally-small-type-with-small-truncation-is-small
      (Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
       pr f-trunc Y-loc-small , trunc-X-small)
 
  type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small
-  = Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+  = Corollary-2-7[type-with-small-truncation-truncated-map-to-locally-small-is-small]
 
 \end{code}
 

--- a/source/UF/Size-TruncatedConnected.lagda
+++ b/source/UF/Size-TruncatedConnected.lagda
@@ -4,6 +4,8 @@ Modifications made by Ian Ray on 14 October 2024.
 
 Modifications made by Ian Ray on 7 January 2025.
 
+Modification made by Ian Ray on 17 August 2025.
+
 We develop some results that relate size, truncation and connectedness from
 the following paper:
 [1] Christensen, J.D. (2024), Non-accessible localizations.

--- a/source/UF/Size-TruncatedConnected.lagda
+++ b/source/UF/Size-TruncatedConnected.lagda
@@ -140,8 +140,7 @@ the join construction. Interestingly, it seems that the assumptions neccesary to
 carry out the join construction are stronger than simply assuming replacement.
 In the interest of keeping the present work self contained and requiring only
 the weakest assumptions possible we simply assume the relevant form of
-replacement (globally) and show it is equivalent to the other phrasings of
-replacement.
+replacement as it is needed.
 
 \begin{code}
 

--- a/source/UF/Size-TruncatedConnected.lagda
+++ b/source/UF/Size-TruncatedConnected.lagda
@@ -44,6 +44,7 @@ private
  pt = general-truncations-give-propositional-truncations fe te
 
 open import UF.ImageAndSurjection pt
+open import UF.Replacement pt
 
 \end{code}
 
@@ -132,31 +133,34 @@ Many of the results in [1] follow from a fact that some call the type theoretic
 axiom of replacement. It states that given a small type A, a locally small type
 X and a function f : A → X the image of f is small. In the paper 'the join
 construction' by Egbert Rijke, the axiom of replacement is shown to follow from
-the join construction. Currently, the join construction and the derivation of the
-axiom of replacement are not implemented in the TypeTopology library. We will
-state a more convenient but equivalent form of replacement.
+the join construction. Interestingly, it seems that the assumptions neccesary to
+carry out the join construction are stronger than simply assuming replacement.
+In the interest of keeping the present work self contained and requiring only the
+weakest assumptions possible we simply assume the relevant form of replacement
+(globally) and show it is equivalent to the other phrasings of replacement.
 
 \begin{code}
 
 open connectedness-results te
-open PropositionalTruncation pt
 
-Replacement' : {𝓤 𝓦 : Universe} → (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
-Replacement' {𝓤} {𝓦} = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
-                     → A is 𝓥 small
-                     → X is 1 locally-small
-                     → f is −1 connected-map
-                     → X is 𝓥 small
+Replacement'' : {𝓤 𝓦 : Universe} → (𝓥 ⁺) ⊔ (𝓤 ⁺) ⊔ (𝓦 ⁺) ̇
+Replacement'' {𝓤} {𝓦} = {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X}
+                      → A is 𝓥 small
+                      → X is 1 locally-small
+                      → f is −1 connected-map
+                      → X is 𝓥 small
+
+Replacement'-to-Replacement'' : {𝓤 𝓦 : Universe}
+                              → Replacement' {𝓥} {𝓤} {𝓦} → Replacement'' {𝓤} {𝓦}
+Replacement'-to-Replacement'' rep' {_} {_} {f} A-sm X-ls f-con
+ = rep' f A-sm X-ls (−1-connected-maps-are-surjections f-con)
+
+Replacement''-to-Replacement' : {𝓤 𝓦 : Universe}
+                              → Replacement'' {𝓤} {𝓦} → Replacement' {𝓥} {𝓤} {𝓦}
+Replacement''-to-Replacement' rep'' {_} {_} f A-sm X-ls f-surj
+ = rep'' A-sm X-ls (surjections-are-−1-connected f-surj)
 
 \end{code}
-
-Notice that under the assumption that f : A → X is −1 connected (i.e. surjective)
-the image of f is equivalent to X. We will explicitly assume Replacement' when
-necessary.
-
-TODO. Implement the join construction and derive Replacement (with small image as
-its conclusion) and Replacement' (with -1 connected assumption and small codomain
-as its conclusion). Then remove Replacement' as an explicit assumption below.
 
 We will now begin proving some of the results from [1]. We will attempt to
 avoid any unnecessary use of propositional resizing. Theorem numbers will be
@@ -166,39 +170,42 @@ Prop 2.2 of [1]
 
 \begin{code}
 
-Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
- : {𝓤 𝓦 : Universe} {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X} {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓦}
- → f is n connected-map
- → A is 𝓥 small
- → X is ι (n + 2) locally-small
- → X is 𝓥 small
-Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
- {_} {_} {_} {_} {_} {−2} ua j f-con A-small X-small = X-small
-Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
- {𝓤} {𝓦} {A} {X} {f} {succ n} ua j f-con A-small X-is-loc-small =
- j A-small (III (−1-connected-maps-are-surjections I)) I
- where
-  I : f is −1 connected-map
-  I = map-connectedness-is-lower-closed ⋆ f-con
-  II : (x x' : X)
-     → Σ a ꞉ A , f a ＝ x
-     → Σ a ꞉ A , f a ＝ x'
-     → (x ＝ x') is 𝓥 small
-  II .(f a) .(f a') (a , refl) (a' , refl) =
-   Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-    ua j (ap-is-less-connected (ua (𝓤 ⊔ 𝓦)) f f-con)
+open PropositionalTruncation pt
+
+module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
+
+ Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+  : {𝓤 𝓦 : Universe} {A : 𝓤 ̇ } {X : 𝓦 ̇ } {f : A → X} {n : ℕ₋₂}
+  → Univalence
+  → f is n connected-map
+  → A is 𝓥 small
+  → X is ι (n + 2) locally-small
+  → X is 𝓥 small
+ Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+  {_} {_} {_} {_} {_} {−2} ua f-con A-small X-small = X-small
+ Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+  {𝓤} {𝓦} {A} {X} {f} {succ n} ua f-con A-small X-is-loc-small =
+  rep A-small (III (−1-connected-maps-are-surjections I)) I
+  where
+   I : f is −1 connected-map
+   I = map-connectedness-is-lower-closed ⋆ f-con
+   II : (x x' : X)
+      → Σ a ꞉ A , f a ＝ x
+      → Σ a ꞉ A , f a ＝ x'
+      → (x ＝ x') is 𝓥 small
+   II .(f a) .(f a') (a , refl) (a' , refl) =
+    Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+     ua (ap-is-less-connected (ua (𝓤 ⊔ 𝓦)) f f-con)
       (small-implies-locally-small A 𝓥 A-small a a')
        (X-is-loc-small (f a) (f a'))
-  III : is-surjection f
-      → (x x' : X)
-      → (x ＝ x') is 𝓥 small
-  III f-is-surj x x' = ∥∥-rec₂ (being-small-is-prop ua (x ＝ x') 𝓥)
-                        (II x x') (f-is-surj x) (f-is-surj x')
+   III : is-surjection f
+       → (x x' : X)
+       → (x ＝ x') is 𝓥 small
+   III f-is-surj x x' = ∥∥-rec₂ (being-small-is-prop ua (x ＝ x') 𝓥)
+                         (II x x') (f-is-surj x) (f-is-surj x')
 
-locally-small-type-with-connected-map-from-small-type-is-small =
- Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+ locally-small-type-with-connected-map-from-small-type-is-small =
+  Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
 
 \end{code}
 
@@ -258,36 +265,37 @@ Lemma 2.5 of [1]
 
 \begin{code}
 
-Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
- : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓤}
- → Propositional-Resizing
- → f is (n + 1) truncated-map
- → Y is ι (n + 2) locally-small
- → X is (n + 1) connected
- → X is 𝓥 small
-Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
- {𝓤} {_} {X} {_} {_} {n} ua j pr f-trunc Y-loc-small X-conn =
- ∥∥-rec (being-small-is-prop ua X 𝓥) VI (center II)
- where
-  I : X is ι (n + 2) locally-small
-  I = Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
-       pr f-trunc Y-loc-small
-  II : X is −1 connected
-  II = connectedness-is-lower-closed' ⋆ X-conn
-  III : X → 𝟙 {𝓤} → X
-  III x ⋆ = x
-  IV : (x : X) → (III x) is n connected-map
-  IV x = basepoint-map-is-less-connected (ua _) (III x) X-conn
-  V : 𝟙 {𝓤} is 𝓥 small
-  V = pr 𝟙 𝟙-is-prop
-  VI : X → X is 𝓥 small
-  VI x = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-          ua j (IV x) V I
+module _ (rep : {𝓤 𝓦 : Universe} → Replacement'' {𝓤} {𝓦}) where
 
-connected-type-with-truncated-map-to-locally-small-type-is-small =
  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
+  : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
+  → Univalence
+  → Propositional-Resizing
+  → f is (n + 1) truncated-map
+  → Y is ι (n + 2) locally-small
+  → X is (n + 1) connected
+  → X is 𝓥 small
+ Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
+  {𝓤} {_} {X} {_} {_} {n} ua pr f-trunc Y-loc-small X-conn =
+  ∥∥-rec (being-small-is-prop ua X 𝓥) VI (center II)
+  where
+   I : X is ι (n + 2) locally-small
+   I = Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
+        pr f-trunc Y-loc-small
+   II : X is −1 connected
+   II = connectedness-is-lower-closed' ⋆ X-conn
+   III : X → 𝟙 {𝓤} → X
+   III x ⋆ = x
+   IV : (x : X) → (III x) is n connected-map
+   IV x = basepoint-map-is-less-connected (ua _) (III x) X-conn
+   V : 𝟙 {𝓤} is 𝓥 small
+   V = pr 𝟙 𝟙-is-prop
+   VI : X → X is 𝓥 small
+   VI x = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+           rep ua (IV x) V I
+
+ connected-type-with-truncated-map-to-locally-small-type-is-small =
+  Lemma-2-5[connected-type-with-truncated-map-to-locally-small-type-is-small]
 
 \end{code}
 
@@ -299,54 +307,52 @@ prove a few lemmas.
 
 \begin{code}
 
-small-path-space-from-locally-small-type-and-small-truncation
- : {X : 𝓤 ̇ } {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓤}
- → X is ι (n + 2) locally-small
-  × ∥ X ∥[ n + 1 ] is 𝓥 small
- → (Σ y ꞉ ∥ X ∥[ n + 1 ] , Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ y) is 𝓥 small
-small-path-space-from-locally-small-type-and-small-truncation
- {_} {X} {n} ua j (X-loc-small , trunc-X-small) = Σ-is-small trunc-X-small IX
- where
-  I : (x' : X) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is 𝓥 small
-  I x' = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
-          ua j IV V VI
-   where
-    II : 𝟙 {𝓤} → Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]
-    II ⋆ = (x' , refl)
-    III : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is (n + 1) connected
-    III = trunc-map-is-connected ∣ x' ∣[ n + 1 ]
-    IV : II is n connected-map
-    IV = basepoint-map-is-less-connected (ua _) II III
-    V : 𝟙 {𝓤} is 𝓥 small
-    V = (𝟙 {𝓥} , one-𝟙-only)
-    VI : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is ι (n + 2) locally-small
-    VI = local-smallness-is-closed-under-Σ X-loc-small VII
-     where
-      VII : (x : X)
-          → (∣ x ∣[ succ n ] ＝ ∣ x' ∣[ succ n ]) is ι (n + 2) locally-small
-      VII x = local-smallness-is-closed-under-≃
-               (eliminated-trunc-identity-char (ua _)) VIII
+ small-path-space-from-locally-small-type-and-small-truncation
+  : {X : 𝓤 ̇ } {n : ℕ₋₂}
+  → Univalence
+  → X is ι (n + 2) locally-small
+   × ∥ X ∥[ n + 1 ] is 𝓥 small
+  → (Σ y ꞉ ∥ X ∥[ n + 1 ] , Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ y) is 𝓥 small
+ small-path-space-from-locally-small-type-and-small-truncation
+  {𝓤} {X} {n} ua (X-loc-small , trunc-X-small) = Σ-is-small trunc-X-small IX
+  where
+   I : (x' : X) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is 𝓥 small
+   I x' = Prop-2-2[locally-small-type-with-connected-map-from-small-type-is-small]
+           rep ua IV V VI
+    where
+     II : 𝟙 {𝓤} → Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]
+     II ⋆ = (x' , refl)
+     III : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is (n + 1) connected
+     III = trunc-map-is-connected ∣ x' ∣[ n + 1 ]
+     IV : II is n connected-map
+     IV = basepoint-map-is-less-connected (ua _) II III
+     V : 𝟙 {𝓤} is 𝓥 small
+     V = (𝟙 {𝓥} , one-𝟙-only)
+     VI : (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ ∣ x' ∣[ n + 1 ]) is ι (n + 2) locally-small
+     VI = local-smallness-is-closed-under-Σ X-loc-small VII
+      where
+       VII : (x : X)
+           → (∣ x ∣[ succ n ] ＝ ∣ x' ∣[ succ n ]) is ι (n + 2) locally-small
+       VII x = local-smallness-is-closed-under-≃
+                (eliminated-trunc-identity-char (ua _)) VIII
         where
          VIII : ∥ x ＝ x' ∥[ n ] is ι (n + 2) locally-small
          VIII = local-smallness-is-closed-under-truncation
                  ua (being-locally-small-is-upper-closed X-loc-small x x')
-  IX : (y : ∥ X ∥[ n + 1 ]) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ y) is 𝓥 small
-  IX = ∥∥ₙ-ind (λ - → props-are-truncated pt
-        (being-small-is-prop ua (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ -) 𝓥)) I
+   IX : (y : ∥ X ∥[ n + 1 ]) → (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ y) is 𝓥 small
+   IX = ∥∥ₙ-ind (λ - → props-are-truncated pt
+         (being-small-is-prop ua (Σ x ꞉ X , ∣ x ∣[ n + 1 ] ＝ -) 𝓥)) I
 
-locally-small-type-with-small-truncation-is-small
- : {X : 𝓤 ̇ } {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓤}
- → X is ι (n + 2) locally-small
-  × ∥ X ∥[ n + 1 ] is 𝓥 small
- → X is 𝓥 small
-locally-small-type-with-small-truncation-is-small {_} {X} {n} ua j small-hyp =
- smallness-closed-under-≃'
-  (small-path-space-from-locally-small-type-and-small-truncation ua j small-hyp)
-   (domain-is-total-fiber ∣_∣[ succ n ])
+ locally-small-type-with-small-truncation-is-small
+  : {X : 𝓤 ̇ } {n : ℕ₋₂}
+  → Univalence
+  → X is ι (n + 2) locally-small
+    × ∥ X ∥[ n + 1 ] is 𝓥 small
+  → X is 𝓥 small
+ locally-small-type-with-small-truncation-is-small {_} {X} {n} ua small-hyp =
+  smallness-closed-under-≃'
+   (small-path-space-from-locally-small-type-and-small-truncation ua small-hyp)
+    (domain-is-total-fiber ∣_∣[ succ n ])
 
 \end{code}
 
@@ -354,23 +360,22 @@ Theorem 2.6 of [1]
 
 \begin{code}
 
-Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
- : {X : 𝓤 ̇ } {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓤}
- → X is 𝓥 small
- ↔ X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
-Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
- {_} {X} {n} ua j =
- (I , locally-small-type-with-small-truncation-is-small ua j)
- where
-  I : X is 𝓥 small
-    → X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
-  I X-small = (locally-small-types-are-small X-small ,
-               truncations-of-small-types-are-small X-small)
-
-type-is-small-iff-type-is-locally-small-and-has-small-truncation =
  Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
+  : {X : 𝓤 ̇ } {n : ℕ₋₂}
+  → Univalence
+  → X is 𝓥 small
+  ↔ X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
+ Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
+  {_} {X} {n} ua =
+  (I , locally-small-type-with-small-truncation-is-small ua)
+  where
+   I : X is 𝓥 small
+     → X is ι (n + 2) locally-small × ∥ X ∥[ n + 1 ] is 𝓥 small
+   I X-small = (locally-small-types-are-small X-small ,
+                truncations-of-small-types-are-small X-small)
+
+ type-is-small-iff-type-is-locally-small-and-has-small-truncation =
+  Theorem-2-6[type-is-small-iff-type-is-locally-small-and-has-small-truncation]
 
 \end{code}
 
@@ -379,15 +384,14 @@ We will record the following corollary of Theorem 2.6 from [1]:
 
 \begin{code}
 
-set-truncation-of-universe-is-large : Univalence
-                                    → Replacement'
-                                    → is-large ∥ 𝓥 ̇ ∥[ 0 ]
-set-truncation-of-universe-is-large ua j =
- contrapositive I universes-are-large
- where
-  I : is-small ∥ 𝓥 ̇ ∥[ 0 ] → is-small (𝓥 ̇ )
-  I small-trunc = locally-small-type-with-small-truncation-is-small ua j
-                   (universes-are-locally-small (ua 𝓥) , small-trunc)
+ set-truncation-of-universe-is-large : Univalence
+                                     → is-large ∥ 𝓥 ̇ ∥[ 0 ]
+ set-truncation-of-universe-is-large ua =
+  contrapositive I universes-are-large
+  where
+   I : is-small ∥ 𝓥 ̇ ∥[ 0 ] → is-small (𝓥 ̇ )
+   I small-trunc = locally-small-type-with-small-truncation-is-small ua
+                    (universes-are-locally-small (ua 𝓥) , small-trunc)
 
 \end{code}
 
@@ -395,23 +399,22 @@ Corollary 2.7 of [1]
 
 \begin{code}
 
-Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
- : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
- → Univalence
- → Replacement' {𝓤} {𝓤}
- → Propositional-Resizing
- → f is (n + 1) truncated-map
- → Y is ι (n + 2) locally-small
- → ∥ X ∥[ n + 1 ] is 𝓥 small
- → X is 𝓥 small
-Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
- ua j pr f-trunc Y-loc-small trunc-X-small =
- locally-small-type-with-small-truncation-is-small ua j
-  (Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
-   pr f-trunc Y-loc-small , trunc-X-small)
-
-type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small =
  Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+  : {X : 𝓤 ̇ } {Y : 𝓦 ̇ } {f : X → Y} {n : ℕ₋₂}
+  → Univalence
+  → Propositional-Resizing
+  → f is (n + 1) truncated-map
+  → Y is ι (n + 2) locally-small
+  → ∥ X ∥[ n + 1 ] is 𝓥 small
+  → X is 𝓥 small
+ Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
+  ua pr f-trunc Y-loc-small trunc-X-small =
+  locally-small-type-with-small-truncation-is-small ua
+   (Lemma-2-4[type-with-truncated-map-to-locally-small-type-is-locally-small]
+    pr f-trunc Y-loc-small , trunc-X-small)
+
+ type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small =
+  Corollary-2-7[type-with-small-truncation-and-truncated-map-to-locally-small-type-is-small]
 
 \end{code}
 

--- a/source/UF/Size.lagda
+++ b/source/UF/Size.lagda
@@ -1084,6 +1084,31 @@ module _ (pt : propositional-truncations-exist) where
                  → image f is (𝓤 ⊔ 𝓥) small
 \end{code}
 
+Added by Ian Ray 18th August 2025.
+
+\begin{code}
+
+subtype-is-locally-small' : {𝓤' : Universe} {X : 𝓤 ̇ } {A : X → 𝓥 ̇ }
+                          → X is-locally 𝓤' small
+                          → ((x : X) → is-prop (A x))
+                          → Σ A is-locally 𝓤' small
+subtype-is-locally-small' {_} {_} {𝓤'} {X} {A} X-ls A-is-prop-valued (x , a) (y , b) = γ
+ where
+  γ : ((x , a) ＝ (y , b)) is 𝓤' small
+  γ = resized (x ＝ y) (X-ls x y) ,
+      (resized (x ＝ y) (X-ls x y) ≃⟨ resizing-condition (X-ls x y) ⟩
+      (x ＝ y)                     ≃⟨ I ⟩
+      ((x , a) ＝ (y , b))         ■)
+    where
+     I = ≃-sym (ap pr₁ ,
+                embedding-gives-embedding'
+                 pr₁
+                 (pr₁-is-embedding A-is-prop-valued)
+                 (x , a)
+                 (y , b))
+
+\end{code}
+
 Added by Ian Ray 11th September 2024.
 
 If X is 𝓥-small then it is locally 𝓥-small.

--- a/source/UF/SmallnessProperties.lagda
+++ b/source/UF/SmallnessProperties.lagda
@@ -225,3 +225,21 @@ Id-is-small {𝓤} ua fe⁺ X A =
     II = Σ-cong (λ x → ≃-sym (≃-funext fe⁺ _ _))
 
 \end{code}
+
+Added by Ian Ray 18th August 2025.
+
+We show locally smallness (wrt arbitray universe level) is closed under sigma.
+
+\begin{code}
+
+Σ-is-locally-small : {𝓤' 𝓥' : Universe} {X : 𝓤 ̇ } {A : X → 𝓥 ̇ }
+                   → X is-locally 𝓤' small
+                   → ((x : X) → A x is-locally 𝓥' small)
+                   → Σ A is-locally 𝓤' ⊔ 𝓥' small
+Σ-is-locally-small {_} {_} {𝓤'} {𝓥'} {X} {A} X-ls A-ls (x , α) (y , β)
+ = smallness-closed-under-≃' I Σ-＝-≃
+ where
+  I : (Σ p ꞉ (x ＝ y) , transport A p α ＝ β) is 𝓤' ⊔ 𝓥' small
+  I = Σ-is-small (X-ls x y) (λ - → A-ls y (transport A - α) β)
+
+\end{code}

--- a/source/UF/index.lagda
+++ b/source/UF/index.lagda
@@ -52,6 +52,7 @@ import UF.PropTrunc
 import UF.PropTrunc-Variation
 import UF.Pullback
 import UF.Pushouts                   -- by [2]
+import UF.Replacement                -- by [2]
 import UF.Retracts
 import UF.Retracts-FunExt
 import UF.SIP


### PR DESCRIPTION
Type replacement and variations are investigated. Along the way some size related lemmas where considered although not all of them ended up being required. 

We use the newly added replacement file to give another equivalent statement of type replacement (where we use language of connectedness) in the formalization of Dan Christensen's results on size, truncation and connectedness. 