### PR TITLE
Add syntax for definitional equational/equivalence reasoning steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Please add yourself the first time you contribute.
 * Ayberk Tosun
 * Brendan Hart
 * Bruno Paiva
+* Carlo Angiuli
 * Chuangjie Xu
 * Cory Knapp
 * Ettore Aldrovandi

--- a/source/MLTT/Id.lagda
+++ b/source/MLTT/Id.lagda
@@ -140,6 +140,22 @@ module _ {X : 𝓤 ̇ } {A : X → 𝓥 ̇ } where
 
 \end{code}
 
+Added by Carlo Angiuli on November 20, 2025.
+
+Special syntax for definitional steps in equality chain reasoning:
+
+\begin{code}
+
+_＝⟨refl⟩_ : {X : 𝓤 ̇ } (x : X) {y : X} → x ＝ y → x ＝ y
+_ ＝⟨refl⟩ p = p
+
+_＝⟨by-definition⟩_ : {X : 𝓤 ̇ } (x : X) {y : X} → x ＝ y → x ＝ y
+_＝⟨by-definition⟩_ = _＝⟨refl⟩_
+
+\end{code}
+
+End of addition.
+
 Fixities:
 
 \begin{code}
@@ -147,6 +163,8 @@ Fixities:
 infix  3  _⁻¹
 infix  1 _∎
 infixr 0 _＝⟨_⟩_
+infixr 0 _＝⟨refl⟩_
+infixr 0 _＝⟨by-definition⟩_
 infixl 2 _∙_
 
 \end{code}

--- a/source/UF/Equiv.lagda
+++ b/source/UF/Equiv.lagda
@@ -113,6 +113,26 @@ _ ≃⟨ d ⟩ e = d ● e
 _■ : (X : 𝓤 ̇ ) → X ≃ X
 _■ = ≃-refl
 
+\end{code}
+
+Added by Carlo Angiuli on November 20, 2025.
+
+Special syntax for definitional steps in equivalence chain reasoning:
+
+\begin{code}
+
+_≃⟨refl⟩_ : (X : 𝓤 ̇ ) {Y : 𝓥 ̇ } → X ≃ Y → X ≃ Y
+_ ≃⟨refl⟩ e = e
+
+_≃⟨by-definition⟩_ : (X : 𝓤 ̇ ) {Y : 𝓥 ̇ } → X ≃ Y → X ≃ Y
+_≃⟨by-definition⟩_ = _≃⟨refl⟩_
+
+\end{code}
+
+End of addition.
+
+\begin{code}
+
 Eqtofun : (X : 𝓤 ̇ ) (Y : 𝓥 ̇ ) → X ≃ Y → X → Y
 Eqtofun X Y (f , _) = f
 
@@ -908,6 +928,8 @@ infix  0 _≃_
 infix  0 _≅_
 infix  1 _■
 infixr 0 _≃⟨_⟩_
+infixr 0 _≃⟨refl⟩_
+infixr 0 _≃⟨by-definition⟩_
 infixl 2 _●_
 infix  1 ⌜_⌝
 


### PR DESCRIPTION
Following some discussion with @martinescardo both privately and on [this gist](https://gist.github.com/cangiuli/f6aa6fcc6d67a727c8a01ac0b06b997c), I have added special syntax for reflexive steps in equational (and equivalence) reasoning chains that are made explicit for reasons of readability. As described in the above gist, these new combinators do not insert any unnecessary reflexive paths/equivalences into the chain, in contrast to the standard equational/equivalence combinator (in many but not all cases).

As this is my first time contributing to TypeTopology, please let me know if I am not following any of your conventions correctly.

I also want to note that there are a few things that one might want that are not (yet?) included in this PR, notably (1) explicitly including the rationale for these combinators in the library (e.g., by committing a version of the above gist), or (2) changing any of the current code to actually use these combinators. As discussed in the comments of the above gist, a simple `grep` reveals at least 991 occurrences of reflexive equational steps in TypeTopology, and at least 34 occurrences of reflexive equivalence steps.