### PR TITLE
Ported initial implementation of CwF of C-spaces

### DIFF
--- a/source/C-Spaces/CwFs/Base.lagda
+++ b/source/C-Spaces/CwFs/Base.lagda
@@ -1,0 +1,74 @@
+Chuangjie Xu 2026
+
+This module defines the basic structure of a Category with Family (CwF).
+Additional structure such as Pi types, Sigma types, and other type 
+constructors are developed in separate, specialized modules to maintain 
+modularity and clarity of the core definitions.
+
+\begin{code}
+
+module C-Spaces.CwFs.Base where
+
+open import MLTT.Spartan
+
+record CwF : (𝓤 ⊔ 𝓥)⁺ ̇ where
+  field
+    -- Category of contexts
+    Con : 𝓤 ̇
+    Sub : Con → Con → 𝓥 ̇
+    idSub : {Γ : Con} → Sub Γ Γ
+    _○_ : {Γ Δ Θ : Con} → Sub Δ Θ → Sub Γ Δ → Sub Γ Θ
+    -- Terminal object, i.e., empty context
+    ε : Con
+    εSub : {Γ : Con} → Sub Γ ε
+    -- Rules for substitution
+    idl : {Γ Δ : Con} {σ : Sub Γ Δ}
+        → idSub ○ σ ＝ σ
+    idr : {Γ Δ : Con} {σ : Sub Γ Δ}
+        → σ ○ idSub ＝ σ
+    ○-assoc : {Γ Δ Θ Ξ : Con} {σ : Sub Θ Ξ} {τ : Sub Δ Θ} {ρ : Sub Γ Δ}
+            → (σ ○ τ) ○ ρ ＝ σ ○ (τ ○ ρ)
+    εSub-unique : {Γ : Con} {σ : Sub Γ ε}
+                → σ ＝ εSub
+
+    -- Type functor
+    Ty : Con → 𝓤 ̇
+    _[_] : {Γ Δ : Con} → Ty Γ → Sub Δ Γ → Ty Δ
+    -- Substitution laws for types
+    ty[id] : {Γ : Con} {A : Ty Γ}
+           → A [ idSub ] ＝ A
+    ty[○]  : {Γ Δ Θ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {τ : Sub Θ Δ}
+           → A [ σ ○ τ ] ＝ A [ σ ] [ τ ]
+
+    -- Term functor
+    Tm : (Γ : Con) → Ty Γ → 𝓥 ̇
+    _⁅_⁆ : {Γ Δ : Con} {A : Ty Γ} → Tm Γ A → (σ : Sub Δ Γ) → Tm Δ (A [ σ ])
+    -- Substitution laws for terms
+    tm[id] : {Γ : Con} {A : Ty Γ} {t : Tm Γ A}
+           → transport (Tm Γ) ty[id]
+             (t ⁅ idSub ⁆) ＝ t
+    tm[○] : {Γ Δ Θ : Con} {A : Ty Γ} {t : Tm Γ A} {σ : Sub Δ Γ} {τ : Sub Θ Δ}
+           → transport (Tm Θ) ty[○]
+             (t ⁅ σ ○ τ ⁆) ＝ t ⁅ σ ⁆ ⁅ τ ⁆
+    
+    -- Context extension
+    _₊_ : (Γ : Con) → Ty Γ → Con
+    ⟨_,_⟩ : {Γ Δ : Con} {A : Ty Γ}
+          → (σ : Sub Δ Γ) → Tm Δ (A [ σ ]) → Sub Δ (Γ ₊ A)
+    p : {Γ : Con} {A : Ty Γ} → Sub (Γ ₊ A) Γ
+    q : {Γ : Con} {A : Ty Γ} → Tm (Γ ₊ A) (A [ p ])
+    -- Laws for context extension
+    p,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
+         → p ○ ⟨ σ , t ⟩ ＝ σ
+    q,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
+         → transport (Tm Δ) (ty[○] ⁻¹ ∙ ap (A [_]) p,-β)
+          (q ⁅ ⟨ σ , t ⟩ ⁆) ＝ t
+    p,q-η : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
+          → ⟨ p , q ⟩ ＝ idSub {Γ ₊ A}
+    ,○-distrib : {Γ Δ Θ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])} {τ : Sub Θ Δ}
+               → ⟨ σ , t ⟩ ○ τ ＝ ⟨ σ ○ τ , transport (Tm Θ) (ty[○] ⁻¹)
+                                           (t ⁅ τ ⁆) ⟩
+
+open CwF public
+
+\end{code}

--- a/source/C-Spaces/CwFs/Base.lagda
+++ b/source/C-Spaces/CwFs/Base.lagda
@@ -7,20 +7,46 @@ modularity and clarity of the core definitions.
 
 \begin{code}
 
+{-# OPTIONS --safe --without-K #-}
+
 module C-Spaces.CwFs.Base where
 
 open import MLTT.Spartan
+open import UF.Base
 
-record CwF : (𝓤 ⊔ 𝓥)⁺ ̇ where
+record CwFStructure : (𝓤 ⊔ 𝓥)⁺ ̇ where
   field
     -- Category of contexts
     Con : 𝓤 ̇
     Sub : Con → Con → 𝓥 ̇
     idSub : {Γ : Con} → Sub Γ Γ
     _○_ : {Γ Δ Θ : Con} → Sub Δ Θ → Sub Γ Δ → Sub Γ Θ
+
     -- Terminal object, i.e., empty context
     ε : Con
     εSub : {Γ : Con} → Sub Γ ε
+
+    -- Type functor
+    Ty : Con → 𝓤 ̇
+    _[_] : {Γ Δ : Con} → Ty Γ → Sub Δ Γ → Ty Δ
+
+    -- Term functor
+    Tm : (Γ : Con) → Ty Γ → 𝓥 ̇
+    _⁅_⁆ : {Γ Δ : Con} {A : Ty Γ} → Tm Γ A → (σ : Sub Δ Γ) → Tm Δ (A [ σ ])
+    
+    -- Context extension
+    _₊_ : (Γ : Con) → Ty Γ → Con
+    ⟨_,_⟩ : {Γ Δ : Con} {A : Ty Γ}
+          → (σ : Sub Δ Γ) → Tm Δ (A [ σ ]) → Sub Δ (Γ ₊ A)
+    p : {Γ : Con} {A : Ty Γ} → Sub (Γ ₊ A) Γ
+    q : {Γ : Con} {A : Ty Γ} → Tm (Γ ₊ A) (A [ p ])
+
+
+record CwFLaws {𝓤 : Universe} {𝓥 : Universe}
+               (S : CwFStructure {𝓤} {𝓥})
+               : (𝓤 ⊔ 𝓥)⁺ ̇ where
+  open CwFStructure S
+  field
     -- Rules for substitution
     idl : {Γ Δ : Con} {σ : Sub Γ Δ}
         → idSub ○ σ ＝ σ
@@ -31,18 +57,12 @@ record CwF : (𝓤 ⊔ 𝓥)⁺ ̇ where
     εSub-unique : {Γ : Con} {σ : Sub Γ ε}
                 → σ ＝ εSub
 
-    -- Type functor
-    Ty : Con → 𝓤 ̇
-    _[_] : {Γ Δ : Con} → Ty Γ → Sub Δ Γ → Ty Δ
     -- Substitution laws for types
     ty[id] : {Γ : Con} {A : Ty Γ}
            → A [ idSub ] ＝ A
     ty[○]  : {Γ Δ Θ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {τ : Sub Θ Δ}
            → A [ σ ○ τ ] ＝ A [ σ ] [ τ ]
 
-    -- Term functor
-    Tm : (Γ : Con) → Ty Γ → 𝓥 ̇
-    _⁅_⁆ : {Γ Δ : Con} {A : Ty Γ} → Tm Γ A → (σ : Sub Δ Γ) → Tm Δ (A [ σ ])
     -- Substitution laws for terms
     tm[id] : {Γ : Con} {A : Ty Γ} {t : Tm Γ A}
            → transport (Tm Γ) ty[id]
@@ -50,25 +70,25 @@ record CwF : (𝓤 ⊔ 𝓥)⁺ ̇ where
     tm[○] : {Γ Δ Θ : Con} {A : Ty Γ} {t : Tm Γ A} {σ : Sub Δ Γ} {τ : Sub Θ Δ}
            → transport (Tm Θ) ty[○]
              (t ⁅ σ ○ τ ⁆) ＝ t ⁅ σ ⁆ ⁅ τ ⁆
-    
-    -- Context extension
-    _₊_ : (Γ : Con) → Ty Γ → Con
-    ⟨_,_⟩ : {Γ Δ : Con} {A : Ty Γ}
-          → (σ : Sub Δ Γ) → Tm Δ (A [ σ ]) → Sub Δ (Γ ₊ A)
-    p : {Γ : Con} {A : Ty Γ} → Sub (Γ ₊ A) Γ
-    q : {Γ : Con} {A : Ty Γ} → Tm (Γ ₊ A) (A [ p ])
+
     -- Laws for context extension
     p,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
          → p ○ ⟨ σ , t ⟩ ＝ σ
     q,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
-         → transport (Tm Δ) (ty[○] ⁻¹ ∙ ap (A [_]) p,-β)
+         → transport (Tm Δ) {(A [ p ]) [ ⟨ σ , t ⟩ ]} (ty[○] ⁻¹ ∙ ap (A [_]) p,-β)
           (q ⁅ ⟨ σ , t ⟩ ⁆) ＝ t
     p,q-η : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])}
           → ⟨ p , q ⟩ ＝ idSub {Γ ₊ A}
     ,○-distrib : {Γ Δ Θ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (A [ σ ])} {τ : Sub Θ Δ}
-               → ⟨ σ , t ⟩ ○ τ ＝ ⟨ σ ○ τ , transport (Tm Θ) (ty[○] ⁻¹)
+               → ⟨ σ , t ⟩ ○ τ ＝ ⟨ σ ○ τ , transport (Tm Θ) {(A [ σ ]) [ τ ]} {A [ σ ○ τ ]} (ty[○] ⁻¹)
                                            (t ⁅ τ ⁆) ⟩
 
-open CwF public
+record CwF : (𝓤 ⊔ 𝓥)⁺ ̇ where
+  field
+    structure : CwFStructure {𝓤} {𝓥}
+    laws : CwFLaws structure
+
+  open CwFStructure structure public
+  open CwFLaws laws public
 
 \end{code}

--- a/source/C-Spaces/CwFs/Types.lagda
+++ b/source/C-Spaces/CwFs/Types.lagda
@@ -6,6 +6,8 @@ terms are dependent functions.
 
 \begin{code}
 
+{-# OPTIONS --safe --without-K #-}
+
 open import MLTT.Spartan
 
 module C-Spaces.CwFs.Types {𝓤 : Universe} where
@@ -14,37 +16,42 @@ open import C-Spaces.CwFs.Base
 
 TypeCwF : CwF
 TypeCwF = record
-  { -- Category of contexts is given by types and functions
-    Con = 𝓤 ̇
-  ; Sub = λ Γ Δ → Γ → Δ
-  ; idSub = id
-  ; _○_ = _∘_
-  ; ε = 𝟙
-  ; εSub = unique-to-𝟙
-  ; idl = refl
-  ; idr = refl
-  ; ○-assoc = refl
-  ; εSub-unique = refl
+  { structure = record
+    { -- Category of contexts is given by types and functions
+      Con = 𝓤 ̇
+    ; Sub = λ Γ Δ → Γ → Δ
+    ; idSub = id
+    ; _○_ = _∘_
+    ; ε = 𝟙
+    ; εSub = unique-to-𝟙
 
-    -- Types are families over a context
-  ; Ty = λ (Γ : 𝓤 ̇) → (Γ → 𝓤 ̇)
-  ; _[_] = λ A σ x → A (σ x)
-  ; ty[id] = refl
-  ; ty[○] = refl
-  ; Tm = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → ((x : Γ) → A x)
-  ; _⁅_⁆ = λ t σ x → t (σ x)
-  ; tm[id] = refl
-  ; tm[○] = refl
+      -- Types are families over a context
+    ; Ty = λ (Γ : 𝓤 ̇) → (Γ → 𝓤 ̇)
+    ; _[_] = λ A σ x → A (σ x)
+    ; Tm = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → ((x : Γ) → A x)
+    ; _⁅_⁆ = λ t σ x → t (σ x)
 
-    -- Context extension is given by Sigma types
-  ; _₊_ = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → Σ x ꞉ Γ , A x
-  ; ⟨_,_⟩ = λ σ t δ → σ δ , t δ
-  ; p = pr₁
-  ; q = pr₂
-  ; p,-β = refl
-  ; q,-β = refl
-  ; p,q-η = refl
-  ; ,○-distrib = refl
+      -- Context extension is given by Sigma types
+    ; _₊_ = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → Σ x ꞉ Γ , A x
+    ; ⟨_,_⟩ = λ σ t δ → σ δ , t δ
+    ; p = pr₁
+    ; q = pr₂
+    }
+
+  ; laws = record
+    { idl = refl
+    ; idr = refl
+    ; ○-assoc = refl
+    ; εSub-unique = refl
+    ; ty[id] = refl
+    ; ty[○] = refl
+    ; tm[id] = refl
+    ; tm[○] = refl
+    ; p,-β = refl
+    ; q,-β = refl
+    ; p,q-η = refl
+    ; ,○-distrib = refl
+    }
   }
 
 \end{code}

--- a/source/C-Spaces/CwFs/Types.lagda
+++ b/source/C-Spaces/CwFs/Types.lagda
@@ -1,0 +1,50 @@
+Chuangjie Xu 2026
+
+The standard example of a CwF is given by types and families of types. In specific,
+contexts are types, substitutions are functions, types in context are families, and
+terms are dependent functions.
+
+\begin{code}
+
+open import MLTT.Spartan
+
+module C-Spaces.CwFs.Types {𝓤 : Universe} where
+
+open import C-Spaces.CwFs.Base
+
+TypeCwF : CwF
+TypeCwF = record
+  { -- Category of contexts is given by types and functions
+    Con = 𝓤 ̇
+  ; Sub = λ Γ Δ → Γ → Δ
+  ; idSub = id
+  ; _○_ = _∘_
+  ; ε = 𝟙
+  ; εSub = unique-to-𝟙
+  ; idl = refl
+  ; idr = refl
+  ; ○-assoc = refl
+  ; εSub-unique = refl
+
+    -- Types are families over a context
+  ; Ty = λ (Γ : 𝓤 ̇) → (Γ → 𝓤 ̇)
+  ; _[_] = λ A σ x → A (σ x)
+  ; ty[id] = refl
+  ; ty[○] = refl
+  ; Tm = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → ((x : Γ) → A x)
+  ; _⁅_⁆ = λ t σ x → t (σ x)
+  ; tm[id] = refl
+  ; tm[○] = refl
+
+    -- Context extension is given by Sigma types
+  ; _₊_ = λ (Γ : 𝓤 ̇) (A : Γ → 𝓤 ̇) → Σ x ꞉ Γ , A x
+  ; ⟨_,_⟩ = λ σ t δ → σ δ , t δ
+  ; p = pr₁
+  ; q = pr₂
+  ; p,-β = refl
+  ; q,-β = refl
+  ; p,q-η = refl
+  ; ,○-distrib = refl
+  }
+
+\end{code}

--- a/source/C-Spaces/Preliminaries/Booleans/Functions.lagda
+++ b/source/C-Spaces/Preliminaries/Booleans/Functions.lagda
@@ -1,5 +1,8 @@
 Chuangjie Xu 2015 (ported to TypeTopology in 2025)
 
+This module collects a few elementary boolean operations together with the
+basic facts about them needed later in the C-space development.
+
 \begin{code}
 
 {-# OPTIONS --safe --without-K #-}
@@ -8,8 +11,20 @@ module C-Spaces.Preliminaries.Booleans.Functions where
 
 open import MLTT.Spartan
 
+\end{code}
+
+Boolean if-then-else
+
+\begin{code}
+
 if : {A : Set} → 𝟚 → A → A → A
 if b a₀ a₁ = 𝟚-cases a₀ a₁ b
+
+\end{code}
+
+Boolean equality, returning `₁` exactly when the inputs agree
+
+\begin{code}
 
 eq : 𝟚 → 𝟚 → 𝟚
 eq b₀ b₁ = if b₀ (if b₁ ₁ ₀) b₁
@@ -19,6 +34,12 @@ Lemma[eq] ₀ ₀ refl = refl
 Lemma[eq] ₀ ₁ ()
 Lemma[eq] ₁ ₀ ()
 Lemma[eq] ₁ ₁ refl = refl
+
+\end{code}
+
+Boolean minimum, corresponding to conjunction
+
+\begin{code}
 
 min : 𝟚 → 𝟚 → 𝟚
 min b₀ b₁ = if b₀ ₀ b₁

--- a/source/C-Spaces/Preliminaries/Naturals/Order.lagda
+++ b/source/C-Spaces/Preliminaries/Naturals/Order.lagda
@@ -1,5 +1,10 @@
 Chuangjie Xu 2015 (ported to TypeTopology in 2025)
 
+This module develops the basic order theory of the natural numbers needed in
+the C-space formalization. It introduces the relations `≤` and `<`, proves a
+collection of elementary lemmas about them, and records a few auxiliary
+constructions such as maxima and least witnesses.
+
 \begin{code}
 
 {-# OPTIONS --safe --without-K --no-exact-split #-}
@@ -12,6 +17,11 @@ open import UF.Subsingletons
 open import Naturals.Addition
 open import Naturals.Properties
 
+\end{code}
+
+Orders on natural numbers
+
+\begin{code}
 
 infix 30 _≤_
 infix 30 _<_
@@ -169,6 +179,6 @@ re-pair : {P : ℕ → Set} → Σ-min P → Σ P
 re-pair (n , p , _) = (n , p)
 
 Σ-min-＝ : {P : ℕ → Set}{w₀ w₁ : Σ-min P} → w₀ ＝ w₁ → re-pair w₀ ＝ re-pair w₁
-Σ-min-＝ {P} {w} {.w} refl = refl
+Σ-min-＝ refl = refl
 
 \end{code}

--- a/source/C-Spaces/Syntax/HAOmega.lagda
+++ b/source/C-Spaces/Syntax/HAOmega.lagda
@@ -41,8 +41,9 @@ data HAω : Cxt → Set where
 
 Uniform-continuity principle
 
-As in the System-T-with-Fan file, `EQ` compares two booleans and `MIN`
-propagates failure while scanning initial segments of binary sequences.
+To formalize uniform continuity, we first define two auxiliary boolean
+operations. The term `EQ` compares two booleans, and `MIN` propagates failure
+while scanning initial segments of binary sequences.
 
 \begin{code}
 
@@ -52,10 +53,14 @@ EQ B₀ B₁ = IF · B₀ · (IF · B₁ · ⊤ · ⊥) · B₁
 MIN : {Γ : Cxt} → Tm Γ ② → Tm Γ ② → Tm Γ ②
 MIN B₀ B₁ = IF · B₀ · ⊥ · B₁
 
--- The context consists of:
---   F : (Ⓝ ⇨ ②) ⇨ Ⓝ   a function on binary sequences,
---   M : Ⓝ             a candidate modulus,
---   A , B : Ⓝ ⇨ ②     two binary sequences.
+\end{code}
+
+The formula expressing uniform continuity is written in a context containing a
+functional `F : (Ⓝ ⇨ ②) ⇨ Ⓝ`, a candidate modulus `M : Ⓝ`, and two binary
+sequences `A` and `B`.
+
+\begin{code}
+
 Γ : Cxt
 Γ = ε ₊ ((Ⓝ ⇨ ②) ⇨ Ⓝ) ₊ Ⓝ ₊ (Ⓝ ⇨ ②) ₊ (Ⓝ ⇨ ②)
 
@@ -69,27 +74,44 @@ A B : Tm Γ (Ⓝ ⇨ ②)
 A = VAR (succ zero)
 B = VAR zero
 
--- In the recursive step we work in the extended context
---   Γ , n : Ⓝ , b : ②
--- and recover the original sequences A and B by de Bruijn indexing.
+\end{code}
+
+To define the boolean term expressing that `A` and `B` agree on their first
+`M` bits, we use primitive recursion on `M`. Its step term is formed in the
+extended context consisting of `Γ` together with a natural number index and an
+accumulator boolean. The terms `A'` and `B'` are the weakened copies of `A`
+and `B` in this larger context.
+
+\begin{code}
+
 A' B' : Tm (Γ ₊ Ⓝ ₊ ②) (Ⓝ ⇨ ②)
 A' = VAR (succ (succ (succ zero)))
 B' = VAR (succ (succ zero))
 
--- The step checks equality at the current index and combines it with the
--- previously accumulated truth value.
+\end{code}
+
+The step term compares the values of `A` and `B` at the current index and
+combines that comparison with the accumulated truth value. The resulting term
+`A＝⟦M⟧B` is intended to express that `A` and `B` agree up to the bound `M`.
+
+\begin{code}
+
 step : Tm Γ (Ⓝ ⇨ ② ⇨ ②)
 step = LAM (LAM (MIN (EQ (A' · (VAR (succ zero)))
                          (B' · (VAR (succ zero))))
                      (VAR zero)))
 
--- Boolean predicate expressing that A and B agree on their first M bits.
 A＝⟦M⟧B : Tm Γ ②
 A＝⟦M⟧B = REC · ⊤ · step · M
 
--- The HAω formulation of uniform continuity:
--- every F : (Ⓝ ⇨ ②) ⇨ Ⓝ has some modulus M such that agreement of A and B on
--- the first M bits implies F A ＝ F B.
+\end{code}
+
+We can now write the HAω formulation of uniform continuity: every functional
+`F : (Ⓝ ⇨ ②) ⇨ Ⓝ` has some modulus `M` such that, whenever `A` and `B` agree on
+their first `M` bits, the values `F · A` and `F · B` are equal.
+
+\begin{code}
+
 Principle[UC] : HAω ε
 Principle[UC] =
    Ā (Ⓝ ⇨ ②) ⇨ Ⓝ     · Ē Ⓝ     · Ā Ⓝ ⇨ ②     · Ā Ⓝ ⇨ ②     ·  A＝⟦M⟧B == ⊤  →→  F · A == F · B

--- a/source/C-Spaces/Syntax/SystemTWithFan.lagda
+++ b/source/C-Spaces/Syntax/SystemTWithFan.lagda
@@ -62,9 +62,9 @@ data Fml : Cxt → Set where
 
 \end{code}
 
-The uniform-continuity principle in the object language
-
-To keep the main statement readable, we name the types that occur in it.
+To formulate uniform continuity in System T, we define some auxiliary functions:
+ - `EQ` compares two booleans and
+ - `MIN` propagates failure while scanning initial segments of binary sequences.
 
 \begin{code}
 
@@ -74,8 +74,13 @@ EQ B₀ B₁ = IF · B₀ · (IF · B₁ · ⊤ · ⊥) · B₁
 MIN : {Γ : Cxt} → Tm Γ ② → Tm Γ ② → Tm Γ ②
 MIN B₀ B₁ = IF · B₀ · ⊥ · B₁
 
--- The context consists of a function F : Cantor -> Nat and two binary
--- sequences A and B.
+\end{code}
+
+To state the uniform-continuity principle, we work in a context consisting of a
+functional `F : (Ⓝ ⇨ ②) ⇨ Ⓝ` together with two binary sequences `A` and `B`.
+
+\begin{code}
+
 Γ : Cxt
 Γ = ε ₊ ((Ⓝ ⇨ ②) ⇨ Ⓝ) ₊ (Ⓝ ⇨ ②) ₊ (Ⓝ ⇨ ②)
 
@@ -86,16 +91,32 @@ A B : Tm Γ (Ⓝ ⇨ ②)
 A = VAR (succ zero)
 B = VAR zero
 
--- In the body of the recursor we work in the extended context
---   Γ , n : Nat , b : ②
--- and refer back to the original sequences A and B.
+\end{code}
+
+To define the boolean term expressing that `A` and `B` agree on their first
+`FAN(F)` bits, we use primitive recursion on `FAN · F`. Its step term is formed
+in the extended context consisting of the original context `Γ` together with a
+natural number index and an accumulator boolean. The terms `A'` and `B'` are
+the weakened copies of `A` and `B` in this larger context.
+
+\begin{code}
+
 A' B' : Tm (Γ ₊ Ⓝ ₊ ②) (Ⓝ ⇨ ②)
 A' = VAR (succ (succ (succ zero)))
 B' = VAR (succ (succ zero))
 
--- Boolean predicate expressing that A and B agree on their first FAN(F) bits.
--- It is computed by primitive recursion on FAN · F, starting from ⊤ and
--- conjoining the equality test at each index.
+\end{code}
+
+The term `step` compares the values of `A` and `B` at the current index and
+combines the result with the accumulator. By primitive recursion on `FAN · F`,
+this yields a boolean expressing that `A` and `B` agree on their first
+`FAN(F)` bits.
+
+Accordingly, the notation `A＝⟦FAN•F⟧B` is meant to suggest that `A` and `B`
+are equal up to the bound computed by applying `FAN` to `F`.
+
+\begin{code}
+
 step : Tm Γ (Ⓝ ⇨ ② ⇨ ②)
 step = LAM (LAM (MIN (EQ (A' · (VAR (succ zero)))
                          (B' · (VAR (succ zero))))
@@ -103,8 +124,13 @@ step = LAM (LAM (MIN (EQ (A' · (VAR (succ zero)))
 A＝⟦FAN•F⟧B : Tm Γ ②
 A＝⟦FAN•F⟧B = REC · ⊤ · step · (FAN · F)
 
--- Uniform continuity principle: If A and B agree on their first FAN(F) bits,
--- then F takes the same value on A and B.
+\end{code}
+
+Uniform continuity principle: If A and B agree on their first FAN(F) bits,
+then F takes the same value on A and B.
+
+\begin{code}
+
 Principle[UC] : Fml Γ
 Principle[UC] = (A＝⟦FAN•F⟧B == ⊤) →→ ((F · A) == (F · B))
 

--- a/source/C-Spaces/UsingFunExt/CwF.lagda
+++ b/source/C-Spaces/UsingFunExt/CwF.lagda
@@ -1,0 +1,362 @@
+Chuangjie Xu 2014 (ported to TypeTopology in 2026)
+
+This file defines a category-with-families structure on C-spaces. A
+type over a context is given by a family together with a notion of
+admissible dependent probes satisfying the expected closure axioms. A
+term is a section whose composites with probes are admissible. From
+these data we define substitution, context comprehension, and verify
+the basic CwF equalities needed in the concrete model.
+
+\begin{code}
+
+{-# OPTIONS --safe --without-K #-}
+
+open import MLTT.Spartan
+open import UF.FunExt using (Fun-Ext; dfunext)
+
+module C-Spaces.UsingFunExt.CwF (fe : Fun-Ext) where
+
+open import UF.Base
+open import UF.Subsingletons
+open import UF.Subsingletons-FunExt
+
+open import C-Spaces.CwFs.Base
+open import C-Spaces.Preliminaries.Sequence
+open import C-Spaces.UniformContinuity
+open import C-Spaces.Coverage
+open import C-Spaces.UsingFunExt.Space
+open import C-Spaces.UsingFunExt.CartesianClosedness (dfunext fe)
+
+\end{code}
+
+Contexts are C-spaces, and substitutions are continuous maps.
+
+\begin{code}
+
+Con : Set₁
+Con = Space
+
+Sub : Con → Con → Set
+Sub = Map
+
+\end{code}
+
+A dependent version of the probe axioms.
+
+For a family `A` over a space `Γ`, the predicate `Q` specifies which
+dependent probes are admissible. The four clauses say that admissible
+dependent probes are closed under constants, precomposition by
+uniformly continuous maps, gluing from finite approximations, and
+change of witness for the underlying probe.
+
+The last clause would be unnecessary if the probe predicate itself were
+proposition-valued.
+
+\begin{code}
+
+dependent-probe-axioms : (Γ : Space) (A : U Γ → Set)
+                       → ((p : ₂ℕ → U Γ) → p ∈ Probe Γ → ((α : ₂ℕ) → A (p α)) → Set)
+                       → Set
+dependent-probe-axioms (Γ , P , c₀ , c₁ , c₂) A Q
+ =  ((γ : Γ) (a : A γ) → (λ α → a) ∈ Q (λ α → γ) (c₀ γ))
+  × ((t : ₂ℕ → ₂ℕ) (tC : t ∈ C) (p : ₂ℕ → Γ) (pP : p ∈ P) →
+     (q : (α : ₂ℕ) → A (p α)) → q ∈ Q p pP → q ∘ t ∈ Q (p ∘ t) (c₁ t tC p pP))
+  × ((p : ₂ℕ → Γ)
+     (q : (α : ₂ℕ) → A (p α))
+     (d : Σ \(n : ℕ) → (s : ₂Fin n) → Σ \(psP : p ∘ cons s ∈ P) → q ∘ cons s ∈ Q (p ∘ cons s) psP) →
+     q ∈ Q p (c₂ p (pr₁ d , λ s → pr₁ (pr₂ d s))))
+  × ((p : ₂ℕ → Γ) (pP pP' : p ∈ P) (q : (α : ₂ℕ) → A (p α)) → Q p pP q → Q p pP' q)
+
+dependent-probe-axioms-is-prop
+ : (Γ : Space) (A : U Γ → Set)
+ → (Q : (p : ₂ℕ → U Γ) → p ∈ Probe Γ → ((α : ₂ℕ) → A (p α)) → Set)
+ → (∀ p pΓ q → is-prop (q ∈ Q p pΓ))
+ → is-prop (dependent-probe-axioms Γ A Q)
+dependent-probe-axioms-is-prop (Γ , P , c₀ , c₁ , c₂) A Q pQ
+ = ×-is-prop c₀-prop (×-is-prop c₁-prop (×-is-prop c₂-prop c₃-prop))
+ where
+  c₀-prop
+   : is-prop ((γ : Γ) (a : A γ) → (λ α → a) ∈ Q (λ α → γ) (c₀ γ))
+  c₀-prop
+   = Π₂-is-prop fe (λ γ a → pQ (λ α → γ) (c₀ γ) (λ α → a))
+  c₁-prop
+   : is-prop ((t : ₂ℕ → ₂ℕ) (tC : t ∈ C) (p : ₂ℕ → Γ) (pP : p ∈ P) →
+              (q : (α : ₂ℕ) → A (p α)) → q ∈ Q p pP → q ∘ t ∈ Q (p ∘ t) (c₁ t tC p pP))
+  c₁-prop
+   = Π₆-is-prop fe (λ t tC p pP q qQ → pQ (p ∘ t) (c₁ t tC p pP) (q ∘ t))
+  c₂-prop
+   : is-prop ((p : ₂ℕ → Γ)
+              (q : (α : ₂ℕ) → A (p α))
+              (d : Σ \(n : ℕ) → (s : ₂Fin n) → Σ \(psP : p ∘ cons s ∈ P) → q ∘ cons s ∈ Q (p ∘ cons s) psP) →
+              q ∈ Q p (c₂ p (pr₁ d , λ s → pr₁ (pr₂ d s))))
+  c₂-prop
+   = Π₃-is-prop fe (λ p q d → pQ p (c₂ p (pr₁ d , λ s → pr₁ (pr₂ d s))) q)
+  c₃-prop
+   : is-prop ((p : ₂ℕ → Γ) (pP pP' : p ∈ P) (q : (α : ₂ℕ) → A (p α)) → Q p pP q → Q p pP' q)
+  c₃-prop
+   = Π₅-is-prop fe (λ p pP pP' q qQ → pQ p pP' q)
+
+\end{code}
+
+Types over a context are families equipped with proposition-valued
+dependent probes satisfying the axioms above. Terms are sections whose
+composites with probes are admissible.
+
+\begin{code}
+
+Ty : Con → Set₁
+Ty Γ = Σ \(A : U Γ → Set) →
+         Σ \(Q : (p : ₂ℕ → U Γ) → p ∈ Probe Γ → ((α : ₂ℕ) → A (p α)) → Set)
+           → (∀ p pΓ q → is-prop (q ∈ Q p pΓ)) ×
+             dependent-probe-axioms Γ A Q
+
+tyProbe : (Γ : Con) (A : Ty Γ)
+        → (p : ₂ℕ → U Γ) → p ∈ Probe Γ → ((α : ₂ℕ) → U A (p α)) → Set
+tyProbe _ (_ , Q , _) = Q
+
+tyProbe-is-prop : (Γ : Con) (A : Ty Γ)
+                → ∀ p pΓ q → is-prop (q ∈ tyProbe Γ A p pΓ)
+tyProbe-is-prop _ (_ , _ , pQ , _) = pQ
+
+Tm : (Γ : Con) → Ty Γ → Set
+Tm (Γ , P , _) (A , Q , _)
+ = Σ \(u : (γ : Γ) → A γ) → (p : ₂ℕ → Γ) (pP : p ∈ P) → u ∘ p ∈ Q p pP
+
+\end{code}
+
+Substitution is defined by reindexing both the underlying family and
+its dependent probe predicate along a substitution.
+
+\begin{code}
+
+⟪_,_⟫_[_]ʸ : (Γ Δ : Con) → Ty Γ → Sub Δ Γ → Ty Δ
+⟪ Γ , Δ ⟫ (A , Q , pQ , tc₀ , tc₁ , tc₂ , tc₃) [ σ , cσ ]ʸ
+ = Aσ , Q' , pQ' , c₀ , c₁ , c₂ , c₃
+ where
+  Aσ : U Δ → Set
+  Aσ δ = A (σ δ)
+  Q' : (p : ₂ℕ → U Δ) → p ∈ Probe Δ → ((α : ₂ℕ) → Aσ (p α)) → Set
+  Q' p pΔ q = q ∈ Q (σ ∘ p) (cσ p pΔ)
+  pQ' : ∀ p pΔ q → is-prop (q ∈ Q' p pΔ)
+  pQ' p pΔ q = pQ (σ ∘ p) (cσ p pΔ) q
+  c₀ : (δ : U Δ) (a : Aσ δ) → (λ α → a) ∈ Q' (λ α → δ) (cond₀ Δ δ)
+  c₀ δ a = goal
+   where
+    fact : (λ α → a) ∈ Q (λ α → σ δ) (cond₀ Γ (σ δ))
+    fact = tc₀ (σ δ) a
+    goal : (λ α → a) ∈ Q (λ α → σ δ) (cσ (λ α → δ) (cond₀ Δ δ))
+    goal = tc₃ (λ α → σ δ) _ _ (λ α → a) fact
+  c₁ : (t : ₂ℕ → ₂ℕ) (tC : t ∈ C) (p : ₂ℕ → U Δ) (pΔ : p ∈ Probe Δ) →
+       (q : (α : ₂ℕ) → Aσ (p α)) → q ∈ Q' p pΔ → q ∘ t ∈ Q' (p ∘ t) (cond₁ Δ t tC p pΔ)
+  c₁ t tC p pΔ q qQ' = goal
+   where
+    fact : q ∘ t ∈ Q (σ ∘ p ∘ t) (cond₁ Γ t tC (σ ∘ p) (cσ p pΔ))
+    fact = tc₁ t tC (σ ∘ p) (cσ p pΔ) q qQ'
+    goal : q ∘ t ∈ Q (σ ∘ p ∘ t) (cσ (p ∘ t) (cond₁ Δ t tC p pΔ))
+    goal = tc₃ (σ ∘ p ∘ t) _ _ (q ∘ t) fact
+  c₂ : (p : ₂ℕ → U Δ) (q : (α : ₂ℕ) → Aσ (p α)) →
+       (d : Σ \(n : ℕ) → (s : ₂Fin n) → Σ \(psΔ : p ∘ cons s ∈ Probe Δ)
+          → q ∘ cons s ∈ Q' (p ∘ cons s) psΔ) →
+       q ∈ Q' p (cond₂ Δ p (pr₁ d , λ s → pr₁ (pr₂ d s)))
+  c₂ p q (n , ξ) = goal
+   where
+    ξ' : (s : ₂Fin n)
+       → Σ \(σpsΓ : σ ∘ p ∘ cons s ∈ Probe Γ) → q ∘ cons s ∈ Q (σ ∘ p ∘ cons s) σpsΓ
+    ξ' s = cσ (p ∘ cons s) (pr₁ (ξ s)) , pr₂ (ξ s)
+    fact : q ∈ Q (σ ∘ p) (cond₂ Γ (σ ∘ p) (n , λ s → pr₁ (ξ' s)))
+    fact = tc₂ (σ ∘ p) q (n , ξ')
+    goal : q ∈ Q (σ ∘ p) (cσ p (cond₂ Δ p (n , λ s → pr₁ (ξ s))))
+    goal = tc₃ (σ ∘ p) _ _ q fact
+  c₃ : (p : ₂ℕ → U Δ) (pΔ pΔ' : p ∈ Probe Δ) (q : (α : ₂ℕ) → Aσ (p α)) →
+       Q' p pΔ q → Q' p pΔ' q
+  c₃ p _ _ = tc₃ (σ ∘ p) _ _
+
+⟪_,_,_⟫_[_]ᵐ : (Γ Δ : Con) (A : Ty Γ)
+             → Tm Γ A → (σ : Sub Δ Γ) → Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)
+⟪ Γ , Δ , (A , Q , _) ⟫ (u , cu) [ σ , cσ ]ᵐ = uσ , cuσ
+ where
+  uσ : (δ : U Δ) → A (σ δ)
+  uσ δ = u (σ δ)
+  cuσ : (p : ₂ℕ → U Δ) (pΔ : p ∈ Probe Δ) → uσ ∘ p ∈ Q (σ ∘ p) (cσ p pΔ)
+  cuσ p pΔ = cu (σ ∘ p) (cσ p pΔ)
+
+\end{code}
+
+Context comprehension is given by the sigma-space of a family, equipped
+with the evident probe structure.
+
+\begin{code}
+
+_₊_ : (Γ : Con) → Ty Γ → Con
+Γ ₊ (A , Q , pQ , tc₀ , tc₁ , tc₂ , tc₃) = (Σ A , R , c₀ , c₁ , c₂)
+ where
+  R : (₂ℕ → Σ A) → Set
+  R r = Σ \(rΓ : pr₁ ∘ r ∈ Probe Γ) → pr₂ ∘ r ∈ Q (pr₁ ∘ r) rΓ
+  c₀ : (w : Σ A) → (λ α → w) ∈ R
+  c₀ (γ , a) = cond₀ Γ γ , tc₀ γ a
+  c₁ : (t : ₂ℕ → ₂ℕ) (tC : t ∈ C) (r : ₂ℕ → Σ A) (rR : r ∈ R) → r ∘ t ∈ R
+  c₁ t tC r (rΓ , rQ) = cond₁ Γ t tC (pr₁ ∘ r) rΓ ,
+                        tc₁ t tC (pr₁ ∘ r) rΓ (pr₂ ∘ r) rQ
+  c₂ : (r : ₂ℕ → Σ A)
+     → (Σ \(n : ℕ) → ∀(s : ₂Fin n) → r ∘ cons s ∈ R) → r ∈ R
+  c₂ r (n , ξ) = cond₂ Γ (pr₁ ∘ r) (n , λ s → pr₁ (ξ s)) ,
+                 tc₂ (pr₁ ∘ r) (pr₂ ∘ r) (n , ξ)
+
+⟪_,_⟫p : (Γ : Con) (A : Ty Γ) → Sub (Γ ₊ A) Γ
+⟪ Γ , A ⟫p = pr₁ , (λ p pΓA → pr₁ pΓA)
+
+⟪_⟫_[p]ʸ : (Γ : Con) → (A : Ty Γ) → Ty (Γ ₊ A)
+⟪ Γ ⟫ A [p]ʸ = ⟪ Γ , Γ ₊ A ⟫ A [ ⟪ Γ , A ⟫p ]ʸ
+
+⟪_,_⟫q : (Γ : Con) (A : Ty Γ) → Tm (Γ ₊ A) (⟪ Γ ⟫ A [p]ʸ)
+⟪ Γ , A ⟫q = pr₂ , (λ p pΓA → pr₂ pΓA)
+
+⟪_,_,_⟫⟨_,_⟩ : (Γ Δ : Con) (A : Ty Γ)
+             → (σ : Sub Δ Γ) → Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)
+             → Sub Δ (Γ ₊ A)
+⟪ Γ , Δ , A ⟫⟨ (σ , cσ) , (u , cu) ⟩ = (σu , cσu)
+ where
+  σu : U Δ → Σ (U A)
+  σu δ = (σ δ , u δ)
+  cσu : ∀(p : ₂ℕ → U Δ) (pΔ : p ∈ Probe Δ) → σu ∘ p ∈ Probe (Γ ₊ A)
+  cσu p pΔ = (cσ p pΔ , cu p pΔ)
+
+\end{code}
+
+We can now assemble these operations into a CwF structure on spaces.
+
+\begin{code}
+
+SpaceCwFStructure : CwFStructure
+SpaceCwFStructure = record {
+    Con = Space
+  ; Sub = Map
+  ; idSub = λ {Γ} → idMap Γ
+  ; _○_ = λ {Γ Δ Θ} f g → ⟪ Γ , Δ , Θ ⟫ f ○ g
+  ; ε = 𝟙Space
+  ; εSub = λ {Γ} → continuous-unit Γ
+  ; Ty = Ty
+  ; _[_] = λ {Γ Δ} A σ → ⟪ Γ , Δ ⟫ A [ σ ]ʸ
+  ; Tm = Tm
+  ; _⁅_⁆ = λ {Γ Δ A} t σ → ⟪ Γ , Δ , A ⟫ t [ σ ]ᵐ
+  ; _₊_ = _₊_
+  ; ⟨_,_⟩ = λ {Γ Δ A} σ u → ⟪ Γ , Δ , A ⟫⟨ σ , u ⟩
+  ; p = λ {Γ A} → ⟪ Γ , A ⟫p
+  ; q = λ {Γ A} → ⟪ Γ , A ⟫q
+  }
+
+\end{code}
+
+We next verify the basic equalities satisfied by this structure.
+
+For the term equalities below we work with raw equalities, without the
+explicit transports that appear in `CwFLaws`. This is enough for the
+present concrete development because the family `Tm Γ A` only depends
+definitionally on the family part and the probe predicate part of
+`A : Ty Γ`; it ignores the proof components. For example,
+`⟪ Γ , Γ , A ⟫ t [ idMap Γ ]ᵐ ＝ t` type checks because reindexing along
+`idMap` leaves those data judgmentally unchanged, even though the full
+equality `⟪ Γ , Γ ⟫ A [ idMap Γ ]ʸ ＝ A` still needs proof irrelevance for
+the proof fields.
+
+Accordingly, this file does not yet package the results below into an
+element of `CwFLaws SpaceCwFStructure`. The record `CwFLaws` phrases
+some laws, such as `tm[id]`, `tm[○]`, `q,-β`, and `,○-distrib`, with
+transports along the corresponding type equalities. To build that
+record one would still need bridge lemmas showing that these transports
+act trivially on the concrete term family used here.
+
+\begin{code}
+
+-- Left unit law for substitutions.
+-- id ∘ σ ＝ σ
+idl : {Γ Δ : Con} {σ : Sub Γ Δ}
+    → ⟪ Γ , Δ , Δ ⟫ idMap Δ ○ σ ＝ σ
+idl = refl
+
+-- Right unit law for substitutions.
+-- σ ∘ id = σ
+idr : {Γ Δ : Con} {σ : Sub Γ Δ}
+    → ⟪ Γ , Γ , Δ ⟫ σ ○ idMap Γ ＝ σ
+idr = refl
+
+-- Associativity of substitution composition.
+-- (σ ∘ τ) ∘ ρ = σ ∘ (τ ∘ ρ)
+○-assoc : {Γ Δ Θ Ξ : Con} {σ : Sub Θ Ξ} {τ : Sub Δ Θ} {ρ : Sub Γ Δ}
+        → ⟪ Γ , Δ , Ξ ⟫ (⟪ Δ , Θ , Ξ ⟫ σ ○ τ) ○ ρ ＝
+          ⟪ Γ , Θ , Ξ ⟫ σ ○ (⟪ Γ , Δ , Θ ⟫ τ ○ ρ)
+○-assoc = refl
+
+-- There is a unique substitution into the terminal context.
+εSub-unique : {Γ : Con} {σ : Sub Γ 𝟙Space}
+            → σ ＝ continuous-unit Γ
+εSub-unique = refl
+
+-- Type substitution by the identity map is extensionality equal to the original type.
+-- A [ id ] = A
+ty[id] : (Γ : Con) (A : Ty Γ)
+       → ⟪ Γ , Γ ⟫ A [ idMap Γ ]ʸ ＝ A
+ty[id] Γ A =
+  to-Σ-＝
+    (refl ,
+     to-Σ-＝
+       (refl ,
+        to-×-＝ refl
+          (dependent-probe-axioms-is-prop Γ _ _ (tyProbe-is-prop Γ A) _ _)))
+
+-- Type substitution is compatible with composition.
+-- A [ σ ∘ τ ] = A [ σ ] [ τ ]
+ty[○] : (Γ Δ Θ : Con) (A : Ty Γ) (σ : Sub Δ Γ) (τ : Sub Θ Δ)
+      → ⟪ Γ , Θ ⟫ A [ ⟪ Θ , Δ , Γ ⟫ σ ○ τ ]ʸ ＝
+        ⟪ Δ , Θ ⟫ ⟪ Γ , Δ ⟫ A [ σ ]ʸ [ τ ]ʸ
+ty[○] Γ Δ Θ A σ τ =
+  to-Σ-＝
+    (refl ,
+     to-Σ-＝
+       (refl ,
+        to-×-＝ refl
+          (dependent-probe-axioms-is-prop Θ _ _ (tyProbe-is-prop Θ Aστ) _ _)))
+ where
+  Aστ : Ty Θ
+  Aστ = ⟪ Γ , Θ ⟫ A [ ⟪ Θ , Δ , Γ ⟫ σ ○ τ ]ʸ
+
+-- Term substitution by the identity map is judgmentally trivial in this concrete model.
+-- t [ id ] = t
+tm[id] : (Γ : Con) (A : Ty Γ) (t : Tm Γ A)
+       → ⟪ Γ , Γ , A ⟫ t [ idMap Γ ]ᵐ ＝ t
+tm[id] Γ A t = refl
+
+-- Term substitution is compatible with composition.
+-- t [ σ ∘ τ ] = t [ σ ] [ τ ]
+tm[○] : {Γ Δ Θ : Con} {A : Ty Γ} {t : Tm Γ A} {σ : Sub Δ Γ} {τ : Sub Θ Δ}
+      → ⟪ Γ , Θ , A ⟫ t [ ⟪ Θ , Δ , Γ ⟫ σ ○ τ ]ᵐ ＝
+        ⟪ Δ , Θ , ⟪ Γ , Δ ⟫ A [ σ ]ʸ ⟫ ⟪ Γ , Δ , A ⟫ t [ σ ]ᵐ [ τ ]ᵐ
+tm[○] = refl
+
+-- The first projection of a comprehension pair is the original substitution.
+-- p ∘ ⟨ σ , t ⟩ ＝ σ
+p,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)}
+     → ⟪ Δ , Γ ₊ A , Γ ⟫ ⟪ Γ , A ⟫p ○ ⟪ Γ , Δ , A ⟫⟨ σ , t ⟩ ＝ σ
+p,-β = refl
+
+-- The second projection of a comprehension pair recovers the given term.
+-- q [ ⟨ σ , t ⟩ ] = t
+q,-β : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)}
+     → ⟪ Γ ₊ A , Δ , ⟪ Γ ⟫ A [p]ʸ ⟫ ⟪ Γ , A ⟫q [ ⟪ Γ , Δ , A ⟫⟨ σ , t ⟩ ]ᵐ ＝ t
+q,-β = refl
+
+-- Pairing the projections yields the identity substitution on the comprehension context.
+-- ⟨ p , q ⟩ ＝ id
+p,q-η : {Γ Δ : Con} {A : Ty Γ} {σ : Sub Δ Γ} {t : Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)}
+      → ⟪ Γ , Γ ₊ A , A ⟫⟨ ⟪ Γ , A ⟫p , ⟪ Γ , A ⟫q ⟩ ＝ idMap (Γ ₊ A)
+p,q-η = refl
+
+-- Pairing is stable under postcomposition.
+-- ⟨ σ , t ⟩ ∘ τ = ⟨ σ ∘ τ , t [ τ ] ⟩
+,○-distrib : {Γ Δ Θ : Con} {A : Ty Γ}
+           → {σ : Sub Δ Γ} {t : Tm Δ (⟪ Γ , Δ ⟫ A [ σ ]ʸ)} {τ : Sub Θ Δ}
+           → ⟪ Θ , Δ , Γ ₊ A ⟫ ⟪ Γ , Δ , A ⟫⟨ σ , t ⟩ ○ τ ＝
+             ⟪ Γ , Θ , A ⟫⟨ ⟪ Θ , Δ , Γ ⟫ σ ○ τ , ⟪ Δ , Θ , ⟪ Γ , Δ ⟫ A [ σ ]ʸ ⟫ t [ τ ]ᵐ ⟩
+,○-distrib = refl
+
+\end{code}

--- a/source/C-Spaces/UsingFunExt/Space.lagda
+++ b/source/C-Spaces/UsingFunExt/Space.lagda
@@ -26,7 +26,7 @@ probe-axioms : (X : Set) → ((₂ℕ → X) → Set) → Set
 probe-axioms X P =
     (∀(x : X) → (λ α → x) ∈ P)
   × (∀(t : ₂ℕ → ₂ℕ) → t ∈ C → ∀(p : ₂ℕ → X) → p ∈ P → p ∘ t ∈ P)
-  × (∀(p : ₂ℕ → X) → (Σ \(n : ℕ) → ∀(s : ₂Fin n) → (p ∘ (cons s)) ∈ P) → p ∈ P)
+  × (∀(p : ₂ℕ → X) → (Σ \(n : ℕ) → ∀(s : ₂Fin n) → p ∘ cons s ∈ P) → p ∈ P)
 
 TopologyOn : Set → Set₁
 TopologyOn X = Σ \(P : (₂ℕ → X) → Set) → probe-axioms X P
@@ -34,7 +34,6 @@ TopologyOn X = Σ \(P : (₂ℕ → X) → Set) → probe-axioms X P
 Space : Set₁
 Space = Σ \(X : Set) → TopologyOn X
 
-U : Space → Set
 U = pr₁
 
 Probe : (X : Space) → (₂ℕ → U X) → Set
@@ -72,6 +71,9 @@ Mapto Y = Σ \(X : Space) → Map X Y
 
 id-is-continuous : ∀{X : Space} → continuous X X id
 id-is-continuous p pinP = pinP
+
+idMap : (X : Space) → Map X X
+idMap X = id , id-is-continuous {X}
 
 ∘-preserves-continuity : (X Y Z : Space) →
     ∀(f : U X → U Y) → continuous X Y f →

--- a/source/C-Spaces/UsingFunExt/UCinHAOmega.lagda
+++ b/source/C-Spaces/UsingFunExt/UCinHAOmega.lagda
@@ -34,7 +34,7 @@ open import C-Spaces.UsingFunExt.TdefinableFunctionsAreUC fe
 
 \end{code}
 
-Realizability semantic
+Realizability semantics
 
 The type `∣ φ ∣` is the type of realizers of `φ`. Equality is realized by a
 natural-number placeholder, while conjunction, implication, and quantifiers are
@@ -49,10 +49,17 @@ interpreted by the corresponding type formers.
 ∣ Ā σ · φ ∣ = σ ⇨ ∣ φ ∣
 ∣ Ē σ · φ ∣ = σ ⊠ ∣ φ ∣
 
+\end{code}
+
+A pair `(ρ , r)` realizes a formula `φ` when `ρ` interprets the free variables
+of `φ` and `r` supplies the realizer data required by the logical shape of `φ`.
+The type `φ is-realizable` is the corresponding existential statement saying
+that some environment-realizer pair realizes `φ`.
+
+\begin{code}
+
 infix 50 _is-realized-by_
 
--- A pair `(ρ , r)` realizes `φ` when `ρ` interprets the free variables of `φ`
--- and `r` provides the realizer data required by the shape of `φ`.
 _is-realized-by_ : {Γ : Cxt} → (φ : HAω Γ) → U ⟦ Γ ⟧ᶜ × U ⟦ ∣ φ ∣ ⟧ʸ → Set
 (M == N)  is-realized-by (ρ , _)     = pr₁ ⟦ M ⟧ᵐ ρ ＝ pr₁ ⟦ N ⟧ᵐ ρ
 (φ ∧∧ ψ)  is-realized-by (ρ , x , y) = φ is-realized-by (ρ , x) × ψ is-realized-by (ρ , y)
@@ -65,25 +72,28 @@ _is-realizable {Γ} φ = Σ \(w : U ⟦ Γ ⟧ᶜ × U ⟦ ∣ φ ∣ ⟧ʸ) →
 
 \end{code}
 
-These are the meta-level counterparts of the object-language boolean terms
-used to express agreement on an initial segment.
+In the case of the formula `Principle[UC]`, realizability amounts to producing
+for each functional `f : (ℕSpace ⇒ 𝟚Space) ⇒ ℕSpace` a modulus together with
+enough auxiliary data to satisfy the realizability interpretation of the
+quantifier prefix.
+
+The final theorem is obtained by supplying a realizer for the quantifier prefix
+of `Principle[UC]`. The modulus component is extracted by the fan functional,
+and the remaining higher-type component is filled by a constant dummy witness,
+which is sufficient because only the modulus is used in the equality
+conclusion. The proof then shows that realization of the premise
+`A＝⟦M⟧B == ⊤` yields agreement of the two input sequences on the required
+initial segment, so that the fan theorem can be applied.
 
 \begin{code}
 
-
-
--- The realizer for `Principle[UC]` packages:
---   1. a modulus extracted by the fan functional, and
---   2. a trivial witness for the higher-type component introduced by the
---      realizability interpretation of the quantifier prefix.
 Theorem : Principle[UC] is-realizable
 Theorem = (⋆ , e) , prf
  where
   e : U (((ℕSpace ⇒ 𝟚Space) ⇒ ℕSpace) ⇒ (ℕSpace ⊗ ((ℕSpace ⇒ 𝟚Space) ⇒ (ℕSpace ⇒ 𝟚Space) ⇒ ℕSpace ⇒ ℕSpace)))
   e = g , cts-g
    where
-    -- This witness is constant and computationally irrelevant for the equality
-    -- conclusion.
+    -- This witness is constant and computationally irrelevant for the equality conclusion.
     c : Map (ℕSpace ⇒ 𝟚Space) ((ℕSpace ⇒ 𝟚Space) ⇒ ℕSpace ⇒ ℕSpace)
     c = continuous-constant (ℕSpace ⇒ 𝟚Space) ((ℕSpace ⇒ 𝟚Space) ⇒ ℕSpace ⇒ ℕSpace)
                             (continuous-constant (ℕSpace ⇒ 𝟚Space) (ℕSpace ⇒ ℕSpace)

--- a/source/C-Spaces/UsingFunExt/UCinT.lagda
+++ b/source/C-Spaces/UsingFunExt/UCinT.lagda
@@ -36,7 +36,11 @@ open import C-Spaces.UsingFunExt.TdefinableFunctionsAreUC fe
 
 \end{code}
 
-Interpretation of the syntax of System T with Fan into C-spaces:
+Interpretation of the syntax
+
+We interpret terms of the extended System T in the category of C-spaces. Each
+term in context is sent to a continuous map from the semantic context to the
+semantic type.
 
 \begin{code}
 
@@ -55,8 +59,15 @@ Interpretation of the syntax of System T with Fan into C-spaces:
 ⟦ _·_ {Γ} {σ} {τ} M N ⟧ᵐ  = continuous-app ⟦ Γ ⟧ᶜ ⟦ σ ⟧ʸ ⟦ τ ⟧ʸ ⟦ M ⟧ᵐ ⟦ N ⟧ᵐ
 ⟦ FAN {Γ} ⟧ᵐ              = continuous-constant ⟦ Γ ⟧ᶜ ⟦ ((Ⓝ ⇨ ②) ⇨ Ⓝ) ⇨ Ⓝ ⟧ʸ fan
 
--- Formula semantics: a formula in context Γ is interpreted as a predicate on
--- semantic environments ρ : U ⟦ Γ ⟧ᶜ.
+\end{code}
+
+Formula semantics
+
+A formula in context `Γ` is interpreted as a predicate on semantic
+environments `ρ : U ⟦ Γ ⟧ᶜ`.
+
+\begin{code}
+
 ⟦_⟧ᶠ : {Γ : Cxt} → Fml Γ → U ⟦ Γ ⟧ᶜ → Set
 ⟦ t == u ⟧ᶠ ρ = pr₁ ⟦ t ⟧ᵐ ρ ＝ pr₁ ⟦ u ⟧ᵐ ρ
 ⟦ φ ∧∧ ψ ⟧ᶠ ρ = (⟦ φ ⟧ᶠ ρ) × (⟦ ψ ⟧ᶠ ρ)
@@ -64,7 +75,9 @@ Interpretation of the syntax of System T with Fan into C-spaces:
 
 \end{code}
 
-We say a formula is validated by the model if
+Validation
+
+A formula is validated by the model if it holds for every semantic environment.
 
 \begin{code}
 
@@ -73,18 +86,19 @@ _is-validated : {Γ : Cxt} → Fml Γ → Set
 
 \end{code}
 
-The uniform-continuity principle is validated by the model:
+Validation of Uniform Continuity
+
+The formula `Principle[UC]` says that if two binary sequences agree on their
+first `FAN(F)` bits, then the functional `F` takes the same value on them.
 
 Given an environment `ρ`, the assumption `EN` says that the interpreted term
-`A＝⟦FAN•F⟧B` evaluates to `⊤`. Unfolding the recursor shows that the
-interpreted sequences agree on the first `fan f` bits; `fan-behaviour` then
-gives equality of the values of `f` on those sequences.
+`A＝⟦FAN•F⟧B` evaluates to `⊤`. Unfolding the recursor defining this term shows
+that the interpreted sequences agree on the first `fan f` bits. The theorem
+`fan-behaviour` can then be applied to conclude that `f α ＝ f β`.
 
 \begin{code}
 
 Theorem : Principle[UC] is-validated
-       -- ∀ ρ, if A and B agree on their first FAN(F) bits at ρ, then
-       -- the interpreted function F takes the same value on A and B.
 Theorem ρ EN = fan-behaviour f α β en
  where
   -- The function and the two sequences named by the distinguished variables in

--- a/source/C-Spaces/UsingFunExt/index.lagda
+++ b/source/C-Spaces/UsingFunExt/index.lagda
@@ -33,6 +33,7 @@ import C-Spaces.UsingFunExt.Coproduct
 import C-Spaces.UsingFunExt.LocalCartesianClosedness
 import C-Spaces.UsingFunExt.DiscreteSpace
 import C-Spaces.UsingFunExt.IndiscreteSpace
+import C-Spaces.UsingFunExt.CwF
 
 \end{code}
 

--- a/source/C-Spaces/UsingNotNotFunExt/DiscreteSpace.lagda
+++ b/source/C-Spaces/UsingNotNotFunExt/DiscreteSpace.lagda
@@ -366,7 +366,7 @@ Lemma[Map-discrete] X Y d h (f , cf) (g , cg) ex = ¬¬-kleisli claim ¬¬e₀
       claim₁ = Φg₁ p pX (φf p pX) (Φf₀ p pX)
     ¬¬eφ : ¬¬ (φf ＝ φg)
     ¬¬eφ = fe² epx
-        -----
+          -----
 
     claim-E : φf ＝ φg → ¬¬ (CF ＝ CG)
     claim-E eφ = ¬¬to-Σ-＝ (eφ , eΦ)

--- a/source/C-Spaces/UsingNotNotFunExt/UCinT.lagda
+++ b/source/C-Spaces/UsingNotNotFunExt/UCinT.lagda
@@ -1,7 +1,9 @@
 Chuangjie Xu 2013 (updated in February 2015, ported to TypeTopology in 2025)
 
-We extend System T with a Fan functional, use it to formulate the
-uniform-continuity principle, and validate the principle via C-spaces.
+We have extended System T with a Fan functional and used it to formulate the
+uniform-continuity principle. In this module we interpret the theory in the
+C-space model to validate the distinguished formula for the uniform-continuity
+principle.
 
 \begin{code}
 
@@ -30,8 +32,7 @@ open import C-Spaces.UsingNotNotFunExt.Fan dnfe
 
 Interpretation of the syntax of System T with Fan into C-spaces:
 
-Types are interpreted as C-spaces, contexts as iterated products, and terms as
-continuous maps between the corresponding interpretations.
+Types are interpreted as C-spaces and contexts as iterated products.
 
 \begin{code}
 
@@ -45,7 +46,12 @@ continuous maps between the corresponding interpretations.
 ⟦ ε ⟧ᶜ = 𝟙Space
 ⟦ Γ ₊ A ⟧ᶜ = ⟦ Γ ⟧ᶜ ⊗ ⟦ A ⟧ʸ
 
--- The semantic projection corresponding to a de Bruijn variable.
+\end{code}
+
+The semantic projection corresponding to a de Bruijn variable.
+
+\begin{code}
+
 continuous-prj : (Γ : Cxt)(i : Fin (length Γ)) → Map ⟦ Γ ⟧ᶜ ⟦ Γ [ i ] ⟧ʸ
 continuous-prj  ε      ()
 continuous-prj (Γ ₊ σ)  zero    = pr₂ , (λ _ → pr₂)
@@ -59,6 +65,12 @@ continuous-prj (Γ ₊ σ) (succ i) = prjᵢ₊₁ , cprjᵢ₊₁
   cprjᵢ = pr₂ (continuous-prj Γ i)
   cprjᵢ₊₁ : continuous ⟦ Γ ₊ σ ⟧ᶜ ⟦ (Γ ₊ σ) [ succ i ] ⟧ʸ prjᵢ₊₁
   cprjᵢ₊₁ p pΓσ = cprjᵢ (pr₁ ∘ p) (pr₁ pΓσ)
+
+\end{code}
+
+Terms are interpreted as continuous maps between the corresponding interpretations.
+
+\begin{code}
 
 ⟦_⟧ᵐ : {Γ : Cxt}{σ : Ty} → Tm Γ σ → Map ⟦ Γ ⟧ᶜ ⟦ σ ⟧ʸ
 ⟦ VAR {Γ} i ⟧ᵐ            = continuous-prj Γ i
@@ -75,8 +87,13 @@ continuous-prj (Γ ₊ σ) (succ i) = prjᵢ₊₁ , cprjᵢ₊₁
 ⟦ _·_ {Γ} {σ} {τ} M N ⟧ᵐ  = continuous-app ⟦ Γ ⟧ᶜ ⟦ σ ⟧ʸ ⟦ τ ⟧ʸ ⟦ M ⟧ᵐ ⟦ N ⟧ᵐ
 ⟦ FAN {Γ} ⟧ᵐ              = continuous-constant ⟦ Γ ⟧ᶜ ⟦ ((Ⓝ ⇨ ②) ⇨ Ⓝ) ⇨ Ⓝ ⟧ʸ fan
 
--- Formula semantics: a formula in context Γ is interpreted as a predicate on
--- semantic environments ρ : U ⟦ Γ ⟧ᶜ.
+\end{code}
+
+Formula semantics: a formula in context Γ is interpreted as a predicate on
+semantic environments ρ : U ⟦ Γ ⟧ᶜ.
+
+\begin{code}
+
 ⟦_⟧ᶠ : {Γ : Cxt} → Fml Γ → U ⟦ Γ ⟧ᶜ → Set
 ⟦ t == u ⟧ᶠ ρ = pr₁ ⟦ t ⟧ᵐ ρ ＝ pr₁ ⟦ u ⟧ᵐ ρ
 ⟦ φ ∧∧ ψ ⟧ᶠ ρ = (⟦ φ ⟧ᶠ ρ) × (⟦ ψ ⟧ᶠ ρ)
@@ -84,7 +101,7 @@ continuous-prj (Γ ₊ σ) (succ i) = prjᵢ₊₁ , cprjᵢ₊₁
 
 \end{code}
 
-We say a formula is validated by the model if
+A formula is validated by the model if it holds for every semantic environment.
 
 \begin{code}
 
@@ -93,12 +110,14 @@ _is-validated : {Γ : Cxt} → Fml Γ → Set
 
 \end{code}
 
-The uniform-continuity principle is validated by the model:
+The uniform-continuity principle, formulated as the formula `Principle[UC]`, says that
+if two binary sequences agree on their first `FAN(F)` bits, then the functional `F`
+takes the same value on them.
 
 Given an environment `ρ`, the assumption `EN` says that the interpreted term
-`A＝⟦FAN•F⟧B` evaluates to `⊤`. Unfolding the recursor shows that the
-interpreted sequences agree on the first `fan f` bits; `fan-behaviour` then
-gives equality of the values of `f` on those sequences.
+`A＝⟦FAN•F⟧B` evaluates to `⊤`. Unfolding the recursor defining this term shows
+that the interpreted sequences agree on the first `fan f` bits. The theorem
+`fan-behaviour` can then be applied to conclude that `f α ＝ f β`.
 
 \begin{code}
 

--- a/source/C-Spaces/index.lagda
+++ b/source/C-Spaces/index.lagda
@@ -88,6 +88,19 @@ import C-Spaces.UsingFunExt.ValidatingUCviaLCCC
 
 \end{code}
 
+C-spaces form a category with families (CwF).
+
+\begin{code}
+
+-- § 6.3  Categories with families
+import C-Spaces.CwFs.Base
+import C-Spaces.CwFs.Types
+
+-- § 6.4  A continuous model of dependent types
+import C-Spaces.UsingFunExt.CwF
+
+\end{code}
+
 The above development is closest to the mathematical presentation in the thesis,
 but it relies on the full function extensionality axiom, which is not available
 in Spartan MLTT. This does not affect the mathematical correctness of the


### PR DESCRIPTION
This PR does two things. First, it refactors the existing Agda development of C-spaces, for example by turning inline comments into proper literal/block comments. Second, it ports the construction of the category with families of C-spaces.

The CwF records and the type/set example are located in the `CwFs` module, while the CwF of C-spaces is developed in the `UsingFunExt` module. In particular, verifying some of the CwF laws requires function extensionality.