### PR TITLE
Internal dialogue-tree correctness in PaperIndex

### DIFF
--- a/source/EffectfulForcing/Internal/PaperIndex.lagda
+++ b/source/EffectfulForcing/Internal/PaperIndex.lagda
@@ -363,8 +363,8 @@ Correctness of `dialogue-treeᵀ`.
 \begin{code}
 
 Theorem-37 : (t : T₀ ((ι ⇒ ι) ⇒ ι)) (α : ℕ → ℕ)
-           → ⟦ t ⟧₀ α ＝ dialogue (dialogue-tree t) α
-Theorem-37 = dialogue-tree-correct
+           → ⟦ t ⟧₀ α ＝ ⟦ dialogueᵀ · (dialogue-treeᵀ t) ⟧₀ α
+Theorem-37 = ⌜dialogue-tree⌝-correct
 
 \end{code}
 


### PR DESCRIPTION
Theorem 37 is about the correctness of the internal dialogue-tree function.